### PR TITLE
Mission 057: DSL Data Model — Node + StepProxy (v0.4.46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.4.46] — 2026-04-07
+
+### Added
+- **Python DSL data model**: `Node` dataclass (universal DAG node for brick, for_each, branch) and `StepProxy` (`step.brick_name(**kwargs)` → `Node`) in `bricks.core.dsl`
+- **Public DSL exports**: `Node` and `step` available from top-level `from bricks import Node, step`; also exported from `bricks.core`
+
+---
+
 ## [0.4.45] — 2026-04-07
 
 ### Added

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bricks-ai"
-version = "0.4.45"
+version = "0.4.46"
 description = "Deterministic execution engine: typed Python building blocks composed into auditable YAML blueprints."
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -3,6 +3,6 @@
 from bricks.api import Bricks
 from bricks.core.dsl import Node, step
 
-__version__ = "0.4.45"
+__version__ = "0.4.46"
 
 __all__ = ["Bricks", "Node", "__version__", "step"]

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -1,7 +1,8 @@
 """Bricks - Deterministic execution engine for typed Python building blocks."""
 
 from bricks.api import Bricks
+from bricks.core.dsl import Node, step
 
 __version__ = "0.4.45"
 
-__all__ = ["Bricks", "__version__"]
+__all__ = ["Bricks", "Node", "__version__", "step"]

--- a/packages/core/src/bricks/core/__init__.py
+++ b/packages/core/src/bricks/core/__init__.py
@@ -14,6 +14,7 @@ from bricks.core.config import (
 )
 from bricks.core.context import ExecutionContext
 from bricks.core.discovery import BrickDiscovery
+from bricks.core.dsl import Node, StepProxy, step
 from bricks.core.engine import BlueprintEngine
 from bricks.core.exceptions import (
     BlueprintValidationError,
@@ -91,11 +92,13 @@ __all__ = [
     "DuplicateBrickError",
     "ExecutionContext",
     "ExecutionResult",
+    "Node",
     "OrchestratorError",
     "ReferenceResolver",
     "RegistryConfig",
     "SelectorConfig",
     "StepDefinition",
+    "StepProxy",
     "StepResult",
     "StoreConfig",
     "TieredBrickSelector",
@@ -113,4 +116,5 @@ __all__ = [
     "parse_description_keys",
     "registry_schema",
     "signature_params",
+    "step",
 ]

--- a/packages/core/src/bricks/core/dsl.py
+++ b/packages/core/src/bricks/core/dsl.py
@@ -1,0 +1,133 @@
+"""Bricks Python DSL — foundational data model.
+
+Provides the two core building blocks for the Python-first DSL:
+
+- :class:`Node` — a universal DAG node representing a brick invocation,
+  a ``for_each`` loop, or a ``branch``.
+- :class:`StepProxy` — enables the ``step.brick_name(param=value)`` syntax
+  that captures brick invocations as :class:`Node` objects without executing
+  them.
+
+Nothing executes in this module. It is a pure data model.
+
+Example::
+
+    from bricks import step
+
+    clean_node = step.clean_text(text="hello world")
+    filtered = step.filter_dict_list(items=clean_node, key="status", value="active")
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Node:
+    """A single node in the Bricks execution DAG.
+
+    Nodes are created by :class:`StepProxy` calls (``step.brick_name(**kwargs)``)
+    or by the control-flow primitives ``for_each()`` and ``branch()`` (Mission 058).
+
+    Attributes:
+        id: Auto-generated 8-char hex unique identifier.
+        type: Node type — ``"brick"``, ``"for_each"``, or ``"branch"``.
+        brick_name: Brick identifier (set only when ``type="brick"``).
+        params: Keyword arguments passed to the brick. Values may be other
+            :class:`Node` objects — dependency edges are resolved later by
+            :class:`~bricks.dsl.dag_builder.DAGBuilder`.
+        items: Input items for ``for_each`` nodes.
+        do: Callable body for ``for_each`` nodes.
+        on_error: Error policy for ``for_each`` — ``"fail"`` (default, stop on
+            first error) or ``"collect"`` (continue, gather all errors).
+        condition: Condition for ``branch`` nodes (brick name string in v1).
+        if_true: Callable for the truthy branch.
+        if_false: Callable for the falsy branch.
+        depends_on: IDs of nodes this node depends on. Populated by
+            :class:`~bricks.dsl.dag_builder.DAGBuilder` (Mission 059).
+    """
+
+    id: str = field(default_factory=lambda: uuid.uuid4().hex[:8])
+    type: str = ""
+    brick_name: str = ""
+    params: dict[str, Any] = field(default_factory=dict)
+
+    # for_each fields
+    items: Node | list[Any] | None = None
+    do: Callable[..., Any] | None = None
+    on_error: str = "fail"
+
+    # branch fields
+    condition: str | Callable[..., Any] | None = None
+    if_true: Callable[..., Any] | None = None
+    if_false: Callable[..., Any] | None = None
+
+    # DAG wiring — populated by DAGBuilder (Mission 059)
+    depends_on: list[str] = field(default_factory=list)
+
+    def __repr__(self) -> str:
+        """Return a concise string representation.
+
+        Returns:
+            Representation showing brick name (for brick nodes) or type,
+            plus the node id.
+        """
+        if self.type == "brick":
+            return f"Node(brick={self.brick_name!r}, id={self.id!r})"
+        return f"Node(type={self.type!r}, id={self.id!r})"
+
+
+class StepProxy:
+    """Proxy that captures ``step.brick_name(param=value)`` as :class:`Node` objects.
+
+    All attribute access on a :class:`StepProxy` returns a keyword-only callable.
+    Calling that callable creates and returns a :class:`Node` with
+    ``type="brick"``, the accessed attribute name as ``brick_name``, and the
+    keyword arguments as ``params``.
+
+    Positional arguments are rejected — brick invocations must be explicit
+    (keyword-only) to keep DSL code readable and unambiguous.
+
+    Example::
+
+        from bricks import step
+
+        node = step.filter_dict_list(items=data, key="status", value="active")
+        assert node.brick_name == "filter_dict_list"
+        assert node.params == {"items": data, "key": "status", "value": "active"}
+    """
+
+    def __getattr__(self, brick_name: str) -> Callable[..., Node]:
+        """Return a keyword-only callable that creates a brick Node.
+
+        Args:
+            brick_name: The brick identifier to capture.
+
+        Returns:
+            A callable that accepts only keyword arguments and returns a
+            :class:`Node` with ``type="brick"``.
+        """
+
+        def invoke_step(**kwargs: Any) -> Node:
+            """Create a brick Node from keyword arguments.
+
+            Args:
+                **kwargs: Parameters to pass to the brick.
+
+            Returns:
+                A :class:`Node` representing this brick invocation.
+            """
+            return Node(type="brick", brick_name=brick_name, params=kwargs)
+
+        return invoke_step
+
+
+#: Module-level :class:`StepProxy` singleton. Import and use directly::
+#:
+#:     from bricks import step
+#:     node = step.my_brick(param="value")
+step: StepProxy = StepProxy()

--- a/packages/core/tests/core/test_dsl.py
+++ b/packages/core/tests/core/test_dsl.py
@@ -1,0 +1,152 @@
+"""Tests for bricks.core.dsl — Node and StepProxy data model."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from bricks.core.dsl import Node, StepProxy, step
+
+
+class TestStepProxy:
+    """Tests for StepProxy and the module-level step singleton."""
+
+    def test_step_proxy_creates_brick_node(self) -> None:
+        """step.clean(text='hi') returns Node with correct type, brick_name, params."""
+        node = step.clean(text="hi")
+        assert node.type == "brick"
+        assert node.brick_name == "clean"
+        assert node.params == {"text": "hi"}
+
+    def test_step_proxy_different_bricks(self) -> None:
+        """step.filter and step.sort create nodes with distinct brick_names."""
+        n1 = step.filter(items=[], key="status", value="active")
+        n2 = step.sort(items=[], field="name")
+        assert n1.brick_name == "filter"
+        assert n2.brick_name == "sort"
+        assert n1.brick_name != n2.brick_name
+
+    def test_step_proxy_no_positional_args(self) -> None:
+        """step.clean('hello') raises TypeError — keyword-only."""
+        with pytest.raises(TypeError):
+            step.clean("hello")  # type: ignore[call-arg]
+
+    def test_step_proxy_returns_callable(self) -> None:
+        """Accessing step.X returns a callable before being called."""
+        fn = step.my_brick
+        assert callable(fn)
+
+    def test_step_singleton_is_step_proxy(self) -> None:
+        """The module-level step is a StepProxy instance."""
+        assert isinstance(step, StepProxy)
+
+
+class TestNode:
+    """Tests for the Node dataclass."""
+
+    def test_node_auto_generates_unique_id(self) -> None:
+        """Two independently created nodes have different ids."""
+        n1 = Node()
+        n2 = Node()
+        assert n1.id != n2.id
+
+    def test_node_id_is_8_char_hex(self) -> None:
+        """Node id is exactly 8 lowercase hex characters."""
+        node = Node()
+        assert re.fullmatch(r"[0-9a-f]{8}", node.id)
+
+    def test_node_defaults(self) -> None:
+        """Fresh Node() has expected default field values."""
+        node = Node()
+        assert node.type == ""
+        assert node.brick_name == ""
+        assert node.params == {}
+        assert node.depends_on == []
+        assert node.items is None
+        assert node.do is None
+        assert node.condition is None
+        assert node.if_true is None
+        assert node.if_false is None
+
+    def test_node_on_error_default_is_fail(self) -> None:
+        """Node.on_error defaults to 'fail'."""
+        node = Node()
+        assert node.on_error == "fail"
+
+    def test_node_params_can_reference_other_nodes(self) -> None:
+        """step.process(data=step.clean(text='x')) creates nested Node references."""
+        inner = step.clean(text="x")
+        outer = step.process(data=inner)
+        assert isinstance(outer.params["data"], Node)
+        assert outer.params["data"].brick_name == "clean"
+
+    def test_node_repr_brick(self) -> None:
+        """repr for a brick node shows brick_name and id."""
+        node = Node(type="brick", brick_name="my_brick")
+        r = repr(node)
+        assert "brick='my_brick'" in r
+        assert node.id in r
+
+    def test_node_repr_non_brick(self) -> None:
+        """repr for a non-brick node shows type and id."""
+        node = Node(type="for_each")
+        r = repr(node)
+        assert "type='for_each'" in r
+        assert node.id in r
+
+    def test_node_for_each_fields(self) -> None:
+        """Node stores for_each-specific fields correctly."""
+
+        def do_fn(n: Node) -> Node:
+            """Dummy for_each body."""
+            return step.clean(text=n)
+
+        items_node = step.load(path="data.csv")
+        node = Node(type="for_each", items=items_node, do=do_fn, on_error="collect")
+        assert node.items is items_node
+        assert node.do is do_fn
+        assert node.on_error == "collect"
+
+    def test_node_branch_fields(self) -> None:
+        """Node stores branch-specific fields correctly."""
+
+        def true_fn() -> Node:
+            """Dummy true branch."""
+            return step.approve()
+
+        def false_fn() -> Node:
+            """Dummy false branch."""
+            return step.reject()
+
+        node = Node(type="branch", condition="is_valid", if_true=true_fn, if_false=false_fn)
+        assert node.condition == "is_valid"
+        assert node.if_true is true_fn
+        assert node.if_false is false_fn
+
+    def test_node_depends_on_is_mutable_list(self) -> None:
+        """depends_on starts empty and can be appended to without aliasing."""
+        n1 = Node()
+        n2 = Node()
+        n1.depends_on.append("abc")
+        assert n2.depends_on == []  # no shared state
+
+
+class TestImports:
+    """Tests that public exports work as documented."""
+
+    def test_import_from_bricks(self) -> None:
+        """from bricks import step, Node works."""
+        from bricks import Node as BricksNode
+        from bricks import step as bricks_step
+
+        assert bricks_step is not None
+        assert BricksNode is Node
+
+    def test_import_from_bricks_core_dsl(self) -> None:
+        """from bricks.core.dsl import Node, StepProxy, step works."""
+        from bricks.core.dsl import Node as BricksNode
+        from bricks.core.dsl import StepProxy as BricksStepProxy
+        from bricks.core.dsl import step as bricks_step
+
+        assert isinstance(bricks_step, BricksStepProxy)
+        assert BricksNode is Node


### PR DESCRIPTION
## Summary
- Adds `Node` dataclass and `StepProxy` class in `bricks.core.dsl`
- Exports `Node`, `step` from top-level `bricks` package
- Exports `Node`, `StepProxy`, `step` from `bricks.core`
- 17 tests, all passing

## Test plan
- [x] `pytest packages/core/tests/core/test_dsl.py` — 17 passed
- [x] `pytest -q` — 893 passed, 18 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)