### PR TITLE
Mission 058: DSL Primitives — for_each, branch, ExecutionTracer (v0.4.47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.4.47] — 2026-04-07
+
+### Added
+- **DSL primitives**: `for_each(items, do, on_error)` and `branch(condition, if_true, if_false)` control-flow functions in `bricks.core.dsl`
+- **ExecutionTracer**: module-level `_tracer` singleton that records all Nodes created when active; all primitives (`step.*`, `for_each`, `branch`) auto-record to it
+- **Public exports**: `for_each` and `branch` now exported from `bricks` and `bricks.core`; `ExecutionTracer` from `bricks.core`
+
+---
+
 ## [0.4.46] — 2026-04-07
 
 ### Added

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bricks-ai"
-version = "0.4.46"
+version = "0.4.47"
 description = "Deterministic execution engine: typed Python building blocks composed into auditable YAML blueprints."
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -1,8 +1,8 @@
 """Bricks - Deterministic execution engine for typed Python building blocks."""
 
 from bricks.api import Bricks
-from bricks.core.dsl import Node, step
+from bricks.core.dsl import Node, branch, for_each, step
 
 __version__ = "0.4.46"
 
-__all__ = ["Bricks", "Node", "__version__", "step"]
+__all__ = ["Bricks", "Node", "__version__", "branch", "for_each", "step"]

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -3,6 +3,6 @@
 from bricks.api import Bricks
 from bricks.core.dsl import Node, branch, for_each, step
 
-__version__ = "0.4.46"
+__version__ = "0.4.47"
 
 __all__ = ["Bricks", "Node", "__version__", "branch", "for_each", "step"]

--- a/packages/core/src/bricks/core/__init__.py
+++ b/packages/core/src/bricks/core/__init__.py
@@ -14,7 +14,7 @@ from bricks.core.config import (
 )
 from bricks.core.context import ExecutionContext
 from bricks.core.discovery import BrickDiscovery
-from bricks.core.dsl import Node, StepProxy, step
+from bricks.core.dsl import ExecutionTracer, Node, StepProxy, branch, for_each, step
 from bricks.core.engine import BlueprintEngine
 from bricks.core.exceptions import (
     BlueprintValidationError,
@@ -92,6 +92,7 @@ __all__ = [
     "DuplicateBrickError",
     "ExecutionContext",
     "ExecutionResult",
+    "ExecutionTracer",
     "Node",
     "OrchestratorError",
     "ReferenceResolver",
@@ -108,9 +109,11 @@ __all__ = [
     "YamlLoadError",
     "blueprint_schema",
     "blueprint_to_yaml",
+    "branch",
     "brick",
     "brick_schema",
     "catalog_schema",
+    "for_each",
     "output_key_table",
     "output_keys",
     "parse_description_keys",

--- a/packages/core/src/bricks/core/dsl.py
+++ b/packages/core/src/bricks/core/dsl.py
@@ -1,21 +1,26 @@
-"""Bricks Python DSL — foundational data model.
+"""Bricks Python DSL — foundational data model and control-flow primitives.
 
-Provides the two core building blocks for the Python-first DSL:
+Provides the core building blocks for the Python-first DSL:
 
 - :class:`Node` — a universal DAG node representing a brick invocation,
   a ``for_each`` loop, or a ``branch``.
 - :class:`StepProxy` — enables the ``step.brick_name(param=value)`` syntax
   that captures brick invocations as :class:`Node` objects without executing
   them.
+- :func:`for_each` — maps a step over a list of items.
+- :func:`branch` — conditional routing based on a brick's boolean output.
+- :class:`ExecutionTracer` — records all Node objects created during a trace
+  phase (used by the ``@flow`` decorator in Mission 060).
 
 Nothing executes in this module. It is a pure data model.
 
 Example::
 
-    from bricks import step
+    from bricks import step, for_each, branch
 
     clean_node = step.clean_text(text="hello world")
     filtered = step.filter_dict_list(items=clean_node, key="status", value="active")
+    loop = for_each(items=filtered, do=lambda item: step.process(data=item))
 """
 
 from __future__ import annotations
@@ -31,7 +36,7 @@ class Node:
     """A single node in the Bricks execution DAG.
 
     Nodes are created by :class:`StepProxy` calls (``step.brick_name(**kwargs)``)
-    or by the control-flow primitives ``for_each()`` and ``branch()`` (Mission 058).
+    or by the control-flow primitives :func:`for_each` and :func:`branch`.
 
     Attributes:
         id: Auto-generated 8-char hex unique identifier.
@@ -81,13 +86,75 @@ class Node:
         return f"Node(type={self.type!r}, id={self.id!r})"
 
 
+class ExecutionTracer:
+    """Records all Node objects created during a trace phase.
+
+    Used by the ``@flow`` decorator (Mission 060) to capture the DAG structure
+    without executing any bricks. The tracer is inactive by default; call
+    :meth:`start` before a trace and :meth:`stop` after.
+
+    Example::
+
+        from bricks.core.dsl import _tracer
+        _tracer.start()
+        node = step.clean(text="hi")
+        _tracer.stop()
+        assert len(_tracer.get_nodes()) == 1
+    """
+
+    def __init__(self) -> None:
+        """Initialise with an empty node list and inactive state."""
+        self.nodes: list[Node] = []
+        self._active: bool = False
+
+    def start(self) -> None:
+        """Begin recording nodes, clearing any previously recorded nodes."""
+        self.nodes = []
+        self._active = True
+
+    def stop(self) -> None:
+        """Stop recording nodes."""
+        self._active = False
+
+    def record(self, node: Node) -> Node:
+        """Record a node if tracing is active.
+
+        Args:
+            node: The node to potentially record.
+
+        Returns:
+            The node unchanged (for convenient chaining).
+        """
+        if self._active:
+            self.nodes.append(node)
+        return node
+
+    @property
+    def is_active(self) -> bool:
+        """Return True if the tracer is currently recording."""
+        return self._active
+
+    def get_nodes(self) -> list[Node]:
+        """Return a copy of all recorded nodes.
+
+        Returns:
+            A new list containing all nodes recorded since the last :meth:`start`.
+        """
+        return list(self.nodes)
+
+
+#: Module-level :class:`ExecutionTracer` singleton used by all primitives.
+_tracer: ExecutionTracer = ExecutionTracer()
+
+
 class StepProxy:
     """Proxy that captures ``step.brick_name(param=value)`` as :class:`Node` objects.
 
     All attribute access on a :class:`StepProxy` returns a keyword-only callable.
     Calling that callable creates and returns a :class:`Node` with
     ``type="brick"``, the accessed attribute name as ``brick_name``, and the
-    keyword arguments as ``params``.
+    keyword arguments as ``params``. The node is also auto-recorded to the
+    module-level :data:`_tracer` if it is active.
 
     Positional arguments are rejected — brick invocations must be explicit
     (keyword-only) to keep DSL code readable and unambiguous.
@@ -121,9 +188,63 @@ class StepProxy:
             Returns:
                 A :class:`Node` representing this brick invocation.
             """
-            return Node(type="brick", brick_name=brick_name, params=kwargs)
+            node = Node(type="brick", brick_name=brick_name, params=kwargs)
+            _tracer.record(node)
+            return node
 
         return invoke_step
+
+
+def for_each(
+    items: Node | list[Any],
+    do: Callable[[Any], Node],
+    on_error: str = "fail",
+) -> Node:
+    """Map a step over a list of items.
+
+    Args:
+        items: A :class:`Node` whose output is a list, or a literal list.
+        do: A callable that takes one item and returns a :class:`Node`.
+        on_error: ``"fail"`` (stop on first error, default) or ``"collect"``
+            (continue processing, gather all errors).
+
+    Returns:
+        A :class:`Node` with ``type="for_each"``.
+
+    Raises:
+        ValueError: If ``on_error`` is not ``"fail"`` or ``"collect"``.
+    """
+    if on_error not in ("fail", "collect"):
+        raise ValueError(f"on_error must be 'fail' or 'collect', got {on_error!r}")
+    node = Node(type="for_each", items=items, do=do, on_error=on_error)
+    _tracer.record(node)
+    return node
+
+
+def branch(
+    condition: str,
+    if_true: Callable[[], Node],
+    if_false: Callable[[], Node],
+) -> Node:
+    """Conditional routing based on a brick's boolean output.
+
+    Args:
+        condition: Brick name that returns a boolean. In v1, only brick name
+            strings are accepted — no lambdas or arbitrary callables.
+        if_true: Called when the condition brick returns ``True``.
+        if_false: Called when the condition brick returns ``False``.
+
+    Returns:
+        A :class:`Node` with ``type="branch"``.
+
+    Raises:
+        TypeError: If ``condition`` is not a string (v1 restriction).
+    """
+    if not isinstance(condition, str):
+        raise TypeError(f"In v1, condition must be a brick name string, got {type(condition).__name__}")
+    node = Node(type="branch", condition=condition, if_true=if_true, if_false=if_false)
+    _tracer.record(node)
+    return node
 
 
 #: Module-level :class:`StepProxy` singleton. Import and use directly::

--- a/packages/core/tests/core/test_dsl_primitives.py
+++ b/packages/core/tests/core/test_dsl_primitives.py
@@ -1,0 +1,232 @@
+"""Tests for bricks.core.dsl — for_each, branch, ExecutionTracer primitives."""
+
+from __future__ import annotations
+
+import pytest
+from bricks.core.dsl import ExecutionTracer, Node, _tracer, branch, for_each, step
+
+
+class TestForEach:
+    """Tests for the for_each() primitive."""
+
+    def test_for_each_creates_node(self) -> None:
+        """for_each returns a Node with type='for_each'."""
+
+        def do_fn(item: object) -> Node:
+            """Dummy body."""
+            return step.clean(text=item)
+
+        node = for_each(items=[1, 2, 3], do=do_fn)
+        assert node.type == "for_each"
+
+    def test_for_each_with_node_items(self) -> None:
+        """items can be a Node (output of a previous step)."""
+
+        def do_fn(item: object) -> Node:
+            """Dummy body."""
+            return step.process(data=item)
+
+        items_node = step.load(path="data.csv")
+        node = for_each(items=items_node, do=do_fn)
+        assert node.items is items_node
+
+    def test_for_each_on_error_default_is_fail(self) -> None:
+        """Default on_error for for_each is 'fail'."""
+
+        def do_fn(item: object) -> Node:
+            """Dummy body."""
+            return step.noop(x=item)
+
+        node = for_each(items=[], do=do_fn)
+        assert node.on_error == "fail"
+
+    def test_for_each_on_error_collect(self) -> None:
+        """on_error='collect' is accepted."""
+
+        def do_fn(item: object) -> Node:
+            """Dummy body."""
+            return step.noop(x=item)
+
+        node = for_each(items=[], do=do_fn, on_error="collect")
+        assert node.on_error == "collect"
+
+    def test_for_each_on_error_invalid_raises(self) -> None:
+        """on_error='skip' raises ValueError."""
+
+        def do_fn(item: object) -> Node:
+            """Dummy body."""
+            return step.noop(x=item)
+
+        with pytest.raises(ValueError, match="on_error must be"):
+            for_each(items=[], do=do_fn, on_error="skip")
+
+
+class TestBranch:
+    """Tests for the branch() primitive."""
+
+    def test_branch_creates_node(self) -> None:
+        """branch returns a Node with type='branch' and string condition."""
+
+        def true_fn() -> Node:
+            """Dummy true branch."""
+            return step.approve()
+
+        def false_fn() -> Node:
+            """Dummy false branch."""
+            return step.reject()
+
+        node = branch("is_valid", if_true=true_fn, if_false=false_fn)
+        assert node.type == "branch"
+        assert node.condition == "is_valid"
+
+    def test_branch_condition_must_be_string(self) -> None:
+        """Passing a lambda as condition raises TypeError."""
+
+        def true_fn() -> Node:
+            """Dummy true branch."""
+            return step.approve()
+
+        def false_fn() -> Node:
+            """Dummy false branch."""
+            return step.reject()
+
+        condition_fn = lambda x: x  # noqa: E731
+        with pytest.raises(TypeError, match="condition must be a brick name string"):
+            branch(condition_fn, if_true=true_fn, if_false=false_fn)  # type: ignore[arg-type]
+
+    def test_branch_condition_must_be_string_not_int(self) -> None:
+        """Passing an int as condition raises TypeError."""
+
+        def true_fn() -> Node:
+            """Dummy true branch."""
+            return step.approve()
+
+        def false_fn() -> Node:
+            """Dummy false branch."""
+            return step.reject()
+
+        with pytest.raises(TypeError, match="condition must be a brick name string"):
+            branch(42, if_true=true_fn, if_false=false_fn)  # type: ignore[arg-type]
+
+
+class TestExecutionTracer:
+    """Tests for the ExecutionTracer class."""
+
+    def setup_method(self) -> None:
+        """Reset module-level tracer before each test."""
+        _tracer.stop()
+        _tracer.nodes.clear()
+
+    def test_tracer_records_when_active(self) -> None:
+        """Active tracer captures nodes."""
+        tracer = ExecutionTracer()
+        tracer.start()
+        n1 = Node(type="brick", brick_name="a")
+        n2 = Node(type="brick", brick_name="b")
+        tracer.record(n1)
+        tracer.record(n2)
+        tracer.stop()
+        assert len(tracer.get_nodes()) == 2
+
+    def test_tracer_ignores_when_inactive(self) -> None:
+        """Inactive tracer does not capture nodes."""
+        tracer = ExecutionTracer()
+        n = Node(type="brick", brick_name="a")
+        tracer.record(n)
+        assert tracer.get_nodes() == []
+
+    def test_tracer_start_clears_previous(self) -> None:
+        """Calling start() resets the node list."""
+        tracer = ExecutionTracer()
+        tracer.start()
+        tracer.record(Node(type="brick", brick_name="old"))
+        tracer.start()  # second start clears
+        tracer.record(Node(type="brick", brick_name="new"))
+        tracer.stop()
+        nodes = tracer.get_nodes()
+        assert len(nodes) == 1
+        assert nodes[0].brick_name == "new"
+
+    def test_tracer_stop_stops_recording(self) -> None:
+        """Nodes created after stop() are not captured."""
+        tracer = ExecutionTracer()
+        tracer.start()
+        tracer.record(Node(type="brick", brick_name="a"))
+        tracer.stop()
+        tracer.record(Node(type="brick", brick_name="b"))
+        assert len(tracer.get_nodes()) == 1
+
+    def test_tracer_get_nodes_returns_copy(self) -> None:
+        """Mutating the returned list does not affect the tracer."""
+        tracer = ExecutionTracer()
+        tracer.start()
+        tracer.record(Node(type="brick", brick_name="a"))
+        tracer.stop()
+        result = tracer.get_nodes()
+        result.clear()
+        assert len(tracer.get_nodes()) == 1
+
+    def test_step_proxy_records_to_tracer(self) -> None:
+        """step.X() calls are captured by the active module-level tracer."""
+        _tracer.start()
+        step.clean(text="hi")
+        step.sort(items=[])
+        _tracer.stop()
+        nodes = _tracer.get_nodes()
+        assert len(nodes) == 2
+        assert nodes[0].brick_name == "clean"
+        assert nodes[1].brick_name == "sort"
+
+    def test_for_each_records_to_tracer(self) -> None:
+        """for_each() calls are captured by the active module-level tracer."""
+
+        def do_fn(item: object) -> Node:
+            """Dummy body."""
+            return step.process(data=item)
+
+        _tracer.start()
+        for_each(items=[1, 2], do=do_fn)
+        _tracer.stop()
+        nodes = _tracer.get_nodes()
+        assert any(n.type == "for_each" for n in nodes)
+
+    def test_branch_records_to_tracer(self) -> None:
+        """branch() calls are captured by the active module-level tracer."""
+
+        def true_fn() -> Node:
+            """Dummy true branch."""
+            return step.approve()
+
+        def false_fn() -> Node:
+            """Dummy false branch."""
+            return step.reject()
+
+        _tracer.start()
+        branch("is_valid", if_true=true_fn, if_false=false_fn)
+        _tracer.stop()
+        nodes = _tracer.get_nodes()
+        assert any(n.type == "branch" for n in nodes)
+
+    def test_nested_for_each_with_branch(self) -> None:
+        """Complex: for_each containing branch creates correct node hierarchy."""
+
+        def do_fn(item: object) -> Node:
+            """Inner body with branch."""
+
+            def true_fn() -> Node:
+                """True branch."""
+                return step.process_a(data=item)
+
+            def false_fn() -> Node:
+                """False branch."""
+                return step.process_b(data=item)
+
+            return branch("check_condition", if_true=true_fn, if_false=false_fn)
+
+        items_node = step.load(path="data.csv")
+        node = for_each(items=items_node, do=do_fn)
+        assert node.type == "for_each"
+        assert node.items is items_node
+        inner = node.do(42)  # type: ignore[misc]
+        assert inner.type == "branch"
+        assert inner.condition == "check_condition"


### PR DESCRIPTION
## Summary
- Adds `for_each()` and `branch()` control-flow primitives to `bricks.core.dsl`
- Adds `ExecutionTracer` class + module-level `_tracer` singleton
- All primitives auto-record to `_tracer` when active (prepares for `@flow` decorator in Mission 060)
- 17 new tests in `test_dsl_primitives.py`

**Note:** This PR includes Mission 057 commits (Node + StepProxy) as base — PR #1 (`dev` → `main`) covers that work.

## Test plan
- [x] `pytest tests/core/test_dsl_primitives.py` — 17 passed
- [x] `pytest -q` — 910 passed, 18 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)