### PR TITLE
Mission 059: DAGBuilder — Node graph to BlueprintDefinition (v0.4.48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.4.48] — 2026-04-07
+
+### Added
+- **DAG class**: `bricks.core.dag.DAG` — directed acyclic graph of DSL nodes with topological sort and `to_blueprint()` conversion
+- **DAGBuilder class**: `bricks.core.dag_builder.DAGBuilder` — resolves Node-in-params and for_each items dependencies into edges
+- **`DAG.to_blueprint()`**: converts a DAG to `BlueprintDefinition`; Node refs → `${step.result}`, for_each → `__for_each__`, branch → `__branch__`
+- **Public exports**: `DAG` and `DAGBuilder` now exported from `bricks` and `bricks.core`
+
+---
+
 ## [0.4.47] — 2026-04-07
 
 ### Added

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bricks-ai"
-version = "0.4.47"
+version = "0.4.48"
 description = "Deterministic execution engine: typed Python building blocks composed into auditable YAML blueprints."
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -5,6 +5,6 @@ from bricks.core.dag import DAG
 from bricks.core.dag_builder import DAGBuilder
 from bricks.core.dsl import Node, branch, for_each, step
 
-__version__ = "0.4.47"
+__version__ = "0.4.48"
 
 __all__ = ["DAG", "Bricks", "DAGBuilder", "Node", "__version__", "branch", "for_each", "step"]

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -1,8 +1,10 @@
 """Bricks - Deterministic execution engine for typed Python building blocks."""
 
 from bricks.api import Bricks
+from bricks.core.dag import DAG
+from bricks.core.dag_builder import DAGBuilder
 from bricks.core.dsl import Node, branch, for_each, step
 
 __version__ = "0.4.47"
 
-__all__ = ["Bricks", "Node", "__version__", "branch", "for_each", "step"]
+__all__ = ["DAG", "Bricks", "DAGBuilder", "Node", "__version__", "branch", "for_each", "step"]

--- a/packages/core/src/bricks/core/__init__.py
+++ b/packages/core/src/bricks/core/__init__.py
@@ -13,6 +13,8 @@ from bricks.core.config import (
     StoreConfig,
 )
 from bricks.core.context import ExecutionContext
+from bricks.core.dag import DAG
+from bricks.core.dag_builder import DAGBuilder
 from bricks.core.discovery import BrickDiscovery
 from bricks.core.dsl import ExecutionTracer, Node, StepProxy, branch, for_each, step
 from bricks.core.engine import BlueprintEngine
@@ -66,6 +68,7 @@ sequence_schema = blueprint_schema
 sequence_to_yaml = blueprint_to_yaml
 
 __all__ = [
+    "DAG",
     "AiConfig",
     "AllBricksSelector",
     "BaseBrick",
@@ -88,6 +91,7 @@ __all__ = [
     "CatalogConfig",
     "ConfigError",
     "ConfigLoader",
+    "DAGBuilder",
     "DuplicateBlueprintError",
     "DuplicateBrickError",
     "ExecutionContext",

--- a/packages/core/src/bricks/core/dag.py
+++ b/packages/core/src/bricks/core/dag.py
@@ -1,0 +1,180 @@
+"""Bricks DAG — directed acyclic graph of DSL nodes.
+
+Provides :class:`DAG` which stores a graph of :class:`~bricks.core.dsl.Node`
+objects and can convert the graph into a :class:`~bricks.core.models.BlueprintDefinition`
+that the existing engine can execute.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bricks.core.dsl import Node
+
+if TYPE_CHECKING:
+    from bricks.core.models import BlueprintDefinition
+
+
+@dataclass
+class DAG:
+    """Directed acyclic graph of Bricks DSL nodes.
+
+    Attributes:
+        nodes: Mapping from node id to :class:`~bricks.core.dsl.Node`.
+        edges: Mapping from node id to list of dependency node ids.
+        root_id: Id of the final/return node.
+    """
+
+    nodes: dict[str, Node] = field(default_factory=dict)
+    edges: dict[str, list[str]] = field(default_factory=dict)
+    root_id: str = ""
+
+    def topological_sort(self) -> list[str]:
+        """Return node ids in execution order (dependencies before dependents).
+
+        Uses Kahn's algorithm. Nodes at the same depth are sorted
+        deterministically by id.
+
+        Returns:
+            Ordered list of node ids.
+
+        Raises:
+            ValueError: If the graph contains a cycle.
+        """
+        in_degree: dict[str, int] = dict.fromkeys(self.nodes, 0)
+        for nid, deps in self.edges.items():
+            in_degree[nid] = len(deps)
+
+        # Build reverse adjacency: dep_id → [nodes that depend on it]
+        reverse: dict[str, list[str]] = {nid: [] for nid in self.nodes}
+        for nid, deps in self.edges.items():
+            for dep in deps:
+                reverse[dep].append(nid)
+
+        queue = sorted(nid for nid, deg in in_degree.items() if deg == 0)
+        result: list[str] = []
+
+        while queue:
+            nid = queue.pop(0)
+            result.append(nid)
+            for dependent in sorted(reverse[nid]):
+                in_degree[dependent] -= 1
+                if in_degree[dependent] == 0:
+                    queue.append(dependent)
+            queue.sort()
+
+        if len(result) != len(self.nodes):
+            raise ValueError("DAG contains a cycle")
+
+        return result
+
+    def get_node(self, node_id: str) -> Node:
+        """Get a node by id.
+
+        Args:
+            node_id: The node's unique identifier.
+
+        Returns:
+            The :class:`~bricks.core.dsl.Node` with that id.
+
+        Raises:
+            KeyError: If no node with that id exists.
+        """
+        return self.nodes[node_id]
+
+    def get_dependencies(self, node_id: str) -> list[Node]:
+        """Get all direct dependencies of a node.
+
+        Args:
+            node_id: The node's unique identifier.
+
+        Returns:
+            List of :class:`~bricks.core.dsl.Node` objects this node depends on.
+        """
+        return [self.nodes[dep_id] for dep_id in self.edges.get(node_id, [])]
+
+    def to_blueprint(self, name: str = "dsl_pipeline", description: str = "") -> BlueprintDefinition:
+        """Convert this DAG to a BlueprintDefinition for the existing engine.
+
+        Maps each :class:`~bricks.core.dsl.Node` to a
+        :class:`~bricks.core.models.StepDefinition`. Node references in
+        ``params`` become ``${step_name.result}`` reference strings.
+        ``for_each`` nodes map to the ``__for_each__`` built-in brick;
+        ``branch`` nodes map to ``__branch__``.
+
+        Args:
+            name: Blueprint name. Defaults to ``"dsl_pipeline"``.
+            description: Blueprint description. Auto-generated when empty.
+
+        Returns:
+            A :class:`~bricks.core.models.BlueprintDefinition` ready for the
+            existing :class:`~bricks.core.engine.BlueprintEngine`.
+        """
+        from bricks.core.models import BlueprintDefinition, StepDefinition  # noqa: PLC0415
+
+        ordered = self.topological_sort()
+        steps: list[StepDefinition] = []
+        node_to_step_name: dict[str, str] = {}
+
+        for i, node_id in enumerate(ordered):
+            node = self.nodes[node_id]
+            step_name = f"step_{i + 1}_{node.brick_name or node.type}"
+            node_to_step_name[node.id] = step_name
+            step = self._node_to_step(node, step_name, node_to_step_name)
+            steps.append(step)
+
+        return BlueprintDefinition(
+            name=name,
+            description=description or f"DSL-generated pipeline with {len(steps)} steps",
+            steps=steps,
+        )
+
+    def _node_to_step(
+        self,
+        node: Node,
+        step_name: str,
+        node_to_step_name: dict[str, str],
+    ) -> Any:
+        """Convert a single Node to a StepDefinition.
+
+        Args:
+            node: The node to convert.
+            step_name: Assigned name for this step.
+            node_to_step_name: Mapping already-processed node ids to step names.
+
+        Returns:
+            A :class:`~bricks.core.models.StepDefinition`.
+        """
+        from bricks.core.models import StepDefinition  # noqa: PLC0415
+
+        if node.type == "brick":
+            resolved: dict[str, Any] = {}
+            for key, value in node.params.items():
+                if isinstance(value, Node) and value.id in node_to_step_name:
+                    resolved[key] = f"${{{node_to_step_name[value.id]}.result}}"
+                else:
+                    resolved[key] = value
+            return StepDefinition(name=step_name, brick=node.brick_name, params=resolved)
+
+        if node.type == "for_each":
+            items_ref: str = ""
+            if isinstance(node.items, Node) and node.items.id in node_to_step_name:
+                items_ref = f"${{{node_to_step_name[node.items.id]}.result}}"
+            do_name = node.do.__name__ if callable(node.do) and hasattr(node.do, "__name__") else str(node.do)
+            return StepDefinition(
+                name=step_name,
+                brick="__for_each__",
+                params={"items": items_ref, "do_brick": do_name, "on_error": node.on_error},
+            )
+
+        # branch
+        return StepDefinition(
+            name=step_name,
+            brick="__branch__",
+            params={
+                "condition_brick": node.condition,
+                "if_true_brick": "",
+                "if_false_brick": "",
+            },
+        )

--- a/packages/core/src/bricks/core/dag_builder.py
+++ b/packages/core/src/bricks/core/dag_builder.py
@@ -1,0 +1,89 @@
+"""DAGBuilder — converts a flat list of traced Nodes into a DAG."""
+
+from __future__ import annotations
+
+from bricks.core.dag import DAG
+from bricks.core.dsl import Node
+
+
+class DAGBuilder:
+    """Builds a :class:`~bricks.core.dag.DAG` from traced :class:`~bricks.core.dsl.Node` objects.
+
+    Resolves dependency edges by inspecting:
+
+    - ``params`` values that are themselves :class:`~bricks.core.dsl.Node` objects
+      (brick→brick data flow).
+    - ``items`` field of ``for_each`` nodes when it is a
+      :class:`~bricks.core.dsl.Node`.
+
+    Example::
+
+        from bricks.core.dsl import _tracer, step
+        from bricks.core.dag_builder import DAGBuilder
+
+        _tracer.start()
+        a = step.load(path="data.csv")
+        b = step.clean(data=a)
+        _tracer.stop()
+
+        dag = DAGBuilder().build(_tracer.get_nodes())
+    """
+
+    def build(self, nodes: list[Node], root: Node | None = None) -> DAG:
+        """Convert a flat list of traced nodes into a DAG.
+
+        Registers every node, resolves dependency edges, and sets the root.
+
+        Args:
+            nodes: Flat list of :class:`~bricks.core.dsl.Node` objects, typically
+                from :meth:`~bricks.core.dsl.ExecutionTracer.get_nodes`.
+            root: The final/return node. Defaults to the last node in *nodes*.
+
+        Returns:
+            A :class:`~bricks.core.dag.DAG` with all nodes registered and
+            ``edges`` / ``depends_on`` populated.
+        """
+        dag = DAG()
+        node_map: dict[str, Node] = {}
+
+        for node in nodes:
+            node_map[node.id] = node
+            dag.nodes[node.id] = node
+            dag.edges[node.id] = []
+
+        for node in nodes:
+            deps = self._find_dependencies(node, node_map)
+            dag.edges[node.id] = deps
+            node.depends_on = deps
+
+        if root is not None:
+            dag.root_id = root.id
+        elif nodes:
+            dag.root_id = nodes[-1].id
+
+        return dag
+
+    def _find_dependencies(self, node: Node, node_map: dict[str, Node]) -> list[str]:
+        """Return ids of all nodes that *node* directly depends on.
+
+        Args:
+            node: The node to inspect.
+            node_map: All registered nodes keyed by id.
+
+        Returns:
+            List of dependency node ids (may be empty).
+        """
+        deps: list[str] = []
+
+        if node.type == "brick":
+            for value in node.params.values():
+                if isinstance(value, Node) and value.id in node_map:
+                    deps.append(value.id)
+
+        elif node.type == "for_each" and isinstance(node.items, Node) and node.items.id in node_map:
+            deps.append(node.items.id)
+
+        # branch — sub-nodes produced by if_true/if_false are already in the
+        # traced list; no extra wiring needed at this stage.
+
+        return deps

--- a/packages/core/tests/core/test_dag.py
+++ b/packages/core/tests/core/test_dag.py
@@ -1,0 +1,255 @@
+"""Tests for bricks.core.dag and bricks.core.dag_builder."""
+
+from __future__ import annotations
+
+import pytest
+from bricks.core.dag import DAG
+from bricks.core.dag_builder import DAGBuilder
+from bricks.core.dsl import Node, _tracer, branch, for_each, step
+
+
+def _build(nodes: list[Node], root: Node | None = None) -> DAG:
+    """Shortcut: build a DAG from a list of nodes."""
+    return DAGBuilder().build(nodes, root=root)
+
+
+def _traced(*callables: object) -> list[Node]:
+    """Run callables with tracer active and return recorded nodes."""
+    _tracer.start()
+    for fn in callables:
+        if callable(fn):
+            fn()  # type: ignore[operator]
+    _tracer.stop()
+    return _tracer.get_nodes()
+
+
+class TestDAGBuilder:
+    """Tests for DAGBuilder.build()."""
+
+    def setup_method(self) -> None:
+        """Reset tracer before each test."""
+        _tracer.stop()
+        _tracer.nodes.clear()
+
+    def test_dag_builder_simple_chain(self) -> None:
+        """a → b(data=a) → c(data=b) produces edges b→a and c→b."""
+        _tracer.start()
+        a = step.load(path="data.csv")
+        b = step.clean(data=a)
+        c = step.save(data=b)
+        _tracer.stop()
+        nodes = _tracer.get_nodes()
+
+        dag = _build(nodes)
+        assert len(dag.nodes) == 3
+        assert a.id in dag.edges[b.id]
+        assert b.id in dag.edges[c.id]
+        assert dag.edges[a.id] == []
+
+    def test_dag_builder_no_deps(self) -> None:
+        """Independent nodes have no edges."""
+        _tracer.start()
+        a = step.brick_a()
+        b = step.brick_b()
+        _tracer.stop()
+        nodes = _tracer.get_nodes()
+
+        dag = _build(nodes)
+        assert dag.edges[a.id] == []
+        assert dag.edges[b.id] == []
+
+    def test_dag_builder_for_each_depends_on_items(self) -> None:
+        """for_each node depends on its items node."""
+
+        def do_fn(item: object) -> Node:
+            """Dummy body."""
+            return step.process(data=item)
+
+        _tracer.start()
+        data = step.load(path="input.csv")
+        fe = for_each(items=data, do=do_fn)
+        _tracer.stop()
+        nodes = _tracer.get_nodes()
+
+        dag = _build(nodes)
+        assert data.id in dag.edges[fe.id]
+
+    def test_dag_builder_root_is_last_node(self) -> None:
+        """root_id defaults to the last node in the list."""
+        _tracer.start()
+        step.a()
+        b = step.b()
+        _tracer.stop()
+        nodes = _tracer.get_nodes()
+
+        dag = _build(nodes)
+        assert dag.root_id == b.id
+
+    def test_dag_builder_explicit_root(self) -> None:
+        """Passing root= overrides the default."""
+        _tracer.start()
+        a = step.a()
+        step.b()
+        _tracer.stop()
+        nodes = _tracer.get_nodes()
+
+        dag = _build(nodes, root=a)
+        assert dag.root_id == a.id
+
+
+class TestTopologicalSort:
+    """Tests for DAG.topological_sort()."""
+
+    def test_topological_sort_simple_chain(self) -> None:
+        """a → b → c sorts to [a, b, c]."""
+        a = Node(type="brick", brick_name="a")
+        b = Node(type="brick", brick_name="b")
+        c = Node(type="brick", brick_name="c")
+        dag = DAG(
+            nodes={a.id: a, b.id: b, c.id: c},
+            edges={a.id: [], b.id: [a.id], c.id: [b.id]},
+        )
+        order = dag.topological_sort()
+        assert order.index(a.id) < order.index(b.id) < order.index(c.id)
+
+    def test_topological_sort_independent_nodes(self) -> None:
+        """Independent nodes all appear in result (deterministic order)."""
+        a = Node(type="brick", brick_name="a")
+        b = Node(type="brick", brick_name="b")
+        dag = DAG(
+            nodes={a.id: a, b.id: b},
+            edges={a.id: [], b.id: []},
+        )
+        order = dag.topological_sort()
+        assert set(order) == {a.id, b.id}
+        assert len(order) == 2
+
+    def test_topological_sort_diamond(self) -> None:
+        """Diamond a→b, a→c, b→d, c→d: a first, d last."""
+        a = Node(type="brick", brick_name="a")
+        b = Node(type="brick", brick_name="b")
+        c = Node(type="brick", brick_name="c")
+        d = Node(type="brick", brick_name="d")
+        dag = DAG(
+            nodes={a.id: a, b.id: b, c.id: c, d.id: d},
+            edges={a.id: [], b.id: [a.id], c.id: [a.id], d.id: [b.id, c.id]},
+        )
+        order = dag.topological_sort()
+        assert order[0] == a.id
+        assert order[-1] == d.id
+
+    def test_topological_sort_cycle_raises(self) -> None:
+        """A cycle raises ValueError."""
+        a = Node(type="brick", brick_name="a")
+        b = Node(type="brick", brick_name="b")
+        dag = DAG(
+            nodes={a.id: a, b.id: b},
+            edges={a.id: [b.id], b.id: [a.id]},
+        )
+        with pytest.raises(ValueError, match="cycle"):
+            dag.topological_sort()
+
+
+class TestToBlueprint:
+    """Tests for DAG.to_blueprint()."""
+
+    def setup_method(self) -> None:
+        """Reset tracer before each test."""
+        _tracer.stop()
+        _tracer.nodes.clear()
+
+    def test_to_blueprint_simple_chain(self) -> None:
+        """3-step chain produces a BlueprintDefinition with 3 steps."""
+        _tracer.start()
+        a = step.load(path="data.csv")
+        b = step.clean(data=a)
+        step.save(data=b)
+        _tracer.stop()
+        dag = _build(_tracer.get_nodes())
+
+        bp = dag.to_blueprint(name="my_pipe")
+        assert bp.name == "my_pipe"
+        assert len(bp.steps) == 3
+
+    def test_to_blueprint_params_resolve_to_refs(self) -> None:
+        """Node references in params become ${step_name.result} strings."""
+        _tracer.start()
+        a = step.load(path="data.csv")
+        step.clean(data=a)
+        _tracer.stop()
+        dag = _build(_tracer.get_nodes())
+
+        bp = dag.to_blueprint()
+        clean_step = next(s for s in bp.steps if s.brick == "clean")
+        assert "${" in clean_step.params["data"]
+        assert ".result}" in clean_step.params["data"]
+
+    def test_to_blueprint_for_each_becomes_builtin(self) -> None:
+        """for_each node maps to __for_each__ brick."""
+
+        def do_fn(item: object) -> Node:
+            """Dummy body."""
+            return step.process(data=item)
+
+        _tracer.start()
+        data = step.load(path="x.csv")
+        for_each(items=data, do=do_fn)
+        _tracer.stop()
+        dag = _build(_tracer.get_nodes())
+
+        bp = dag.to_blueprint()
+        fe_step = next(s for s in bp.steps if s.brick == "__for_each__")
+        assert fe_step is not None
+
+    def test_to_blueprint_branch_becomes_builtin(self) -> None:
+        """branch node maps to __branch__ brick."""
+
+        def true_fn() -> Node:
+            """True branch."""
+            return step.approve()
+
+        def false_fn() -> Node:
+            """False branch."""
+            return step.reject()
+
+        _tracer.start()
+        branch("is_valid", if_true=true_fn, if_false=false_fn)
+        _tracer.stop()
+        dag = _build(_tracer.get_nodes())
+
+        bp = dag.to_blueprint()
+        br_step = next(s for s in bp.steps if s.brick == "__branch__")
+        assert br_step.params["condition_brick"] == "is_valid"
+
+    def test_to_blueprint_name_and_description(self) -> None:
+        """Custom name and description flow through to BlueprintDefinition."""
+        _tracer.start()
+        step.noop()
+        _tracer.stop()
+        dag = _build(_tracer.get_nodes())
+
+        bp = dag.to_blueprint(name="custom", description="my desc")
+        assert bp.name == "custom"
+        assert bp.description == "my desc"
+
+
+class TestDAGAccessors:
+    """Tests for DAG.get_node() and DAG.get_dependencies()."""
+
+    def test_dag_get_node(self) -> None:
+        """get_node returns the correct node."""
+        n = Node(type="brick", brick_name="my_brick")
+        dag = DAG(nodes={n.id: n}, edges={n.id: []})
+        assert dag.get_node(n.id) is n
+
+    def test_dag_get_dependencies(self) -> None:
+        """get_dependencies returns the correct dependency nodes."""
+        a = Node(type="brick", brick_name="a")
+        b = Node(type="brick", brick_name="b")
+        dag = DAG(
+            nodes={a.id: a, b.id: b},
+            edges={a.id: [], b.id: [a.id]},
+        )
+        deps = dag.get_dependencies(b.id)
+        assert len(deps) == 1
+        assert deps[0] is a


### PR DESCRIPTION
## Summary
- Adds `DAG` class with topological sort and `to_blueprint()` conversion
- Adds `DAGBuilder` that resolves Node-in-params and for_each items into dependency edges
- `DAG.to_blueprint()` maps brick nodes → `StepDefinition`, for_each → `__for_each__`, branch → `__branch__`
- 16 tests in `test_dag.py`

## Test plan
- [x] `pytest tests/core/test_dag.py` — 16 passed
- [x] `pytest -q` — 926 passed, 18 skipped
- [x] `mypy --strict` — clean (54 files)
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)