### PR TITLE
Mission 060: @flow decorator and FlowDefinition (v0.4.49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.4.49] — 2026-04-07
+
+### Added
+- **`@flow` decorator**: traces a Python function once at decoration time and returns a `FlowDefinition`
+- **`FlowDefinition`**: holds the traced DAG; exposes `.to_dag()`, `.to_blueprint()`, `.to_yaml()`, `.execute()`
+- **Public exports**: `flow` and `FlowDefinition` exported from `bricks` and `bricks.core`
+
+---
+
 ## [0.4.48] — 2026-04-07
 
 ### Added

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bricks-ai"
-version = "0.4.48"
+version = "0.4.49"
 description = "Deterministic execution engine: typed Python building blocks composed into auditable YAML blueprints."
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -5,6 +5,6 @@ from bricks.core.dag import DAG
 from bricks.core.dag_builder import DAGBuilder
 from bricks.core.dsl import Node, branch, flow, for_each, step
 
-__version__ = "0.4.48"
+__version__ = "0.4.49"
 
 __all__ = ["DAG", "Bricks", "DAGBuilder", "Node", "__version__", "branch", "flow", "for_each", "step"]

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -3,8 +3,8 @@
 from bricks.api import Bricks
 from bricks.core.dag import DAG
 from bricks.core.dag_builder import DAGBuilder
-from bricks.core.dsl import Node, branch, for_each, step
+from bricks.core.dsl import Node, branch, flow, for_each, step
 
 __version__ = "0.4.48"
 
-__all__ = ["DAG", "Bricks", "DAGBuilder", "Node", "__version__", "branch", "for_each", "step"]
+__all__ = ["DAG", "Bricks", "DAGBuilder", "Node", "__version__", "branch", "flow", "for_each", "step"]

--- a/packages/core/src/bricks/core/__init__.py
+++ b/packages/core/src/bricks/core/__init__.py
@@ -16,7 +16,7 @@ from bricks.core.context import ExecutionContext
 from bricks.core.dag import DAG
 from bricks.core.dag_builder import DAGBuilder
 from bricks.core.discovery import BrickDiscovery
-from bricks.core.dsl import ExecutionTracer, Node, StepProxy, branch, for_each, step
+from bricks.core.dsl import ExecutionTracer, FlowDefinition, Node, StepProxy, branch, flow, for_each, step
 from bricks.core.engine import BlueprintEngine
 from bricks.core.exceptions import (
     BlueprintValidationError,
@@ -97,6 +97,7 @@ __all__ = [
     "ExecutionContext",
     "ExecutionResult",
     "ExecutionTracer",
+    "FlowDefinition",
     "Node",
     "OrchestratorError",
     "ReferenceResolver",
@@ -117,6 +118,7 @@ __all__ = [
     "brick",
     "brick_schema",
     "catalog_schema",
+    "flow",
     "for_each",
     "output_key_table",
     "output_keys",

--- a/packages/core/src/bricks/core/dsl.py
+++ b/packages/core/src/bricks/core/dsl.py
@@ -10,25 +10,39 @@ Provides the core building blocks for the Python-first DSL:
 - :func:`for_each` — maps a step over a list of items.
 - :func:`branch` — conditional routing based on a brick's boolean output.
 - :class:`ExecutionTracer` — records all Node objects created during a trace
-  phase (used by the ``@flow`` decorator in Mission 060).
+  phase (used by the ``@flow`` decorator).
+- :class:`FlowDefinition` — result of the ``@flow`` decorator; holds a DAG and
+  exposes ``.to_blueprint()``, ``.to_yaml()``, ``.to_dag()``, and
+  ``.execute()`` methods.
+- :func:`flow` — decorator that traces a function once at decoration time and
+  returns a :class:`FlowDefinition`.
 
-Nothing executes in this module. It is a pure data model.
+Nothing executes in this module beyond the trace phase inside :func:`flow`.
 
 Example::
 
-    from bricks import step, for_each, branch
+    from bricks import flow, step, for_each
 
-    clean_node = step.clean_text(text="hello world")
-    filtered = step.filter_dict_list(items=clean_node, key="status", value="active")
-    loop = for_each(items=filtered, do=lambda item: step.process(data=item))
+    @flow
+    def my_pipeline(data):
+        \"\"\"Clean and save data.\"\"\"
+        cleaned = step.clean(text=data)
+        return step.save(data=cleaned)
+
+    bp = my_pipeline.to_blueprint()
 """
 
 from __future__ import annotations
 
+import inspect
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bricks.core.dag import DAG
+    from bricks.core.models import BlueprintDefinition, ExecutionResult
 
 
 @dataclass
@@ -252,3 +266,127 @@ def branch(
 #:     from bricks import step
 #:     node = step.my_brick(param="value")
 step: StepProxy = StepProxy()
+
+
+class FlowDefinition:
+    """A traced flow — the result of decorating a function with :func:`flow`.
+
+    Holds the DAG produced by tracing the decorated function and exposes
+    conversion and execution methods.
+
+    Attributes:
+        name: Function name used as the blueprint name.
+        description: Function docstring used as the blueprint description.
+        dag: The resolved :class:`~bricks.core.dag.DAG`.
+    """
+
+    def __init__(self, name: str, description: str, dag: DAG) -> None:
+        """Initialise with a name, description, and pre-built DAG.
+
+        Args:
+            name: Blueprint / flow name.
+            description: Human-readable description.
+            dag: The resolved DAG from the trace phase.
+        """
+        self.name = name
+        self.description = description
+        self.dag = dag
+
+    def to_dag(self) -> DAG:
+        """Return the raw DAG.
+
+        Returns:
+            The :class:`~bricks.core.dag.DAG` built from the traced nodes.
+        """
+        return self.dag
+
+    def to_blueprint(self) -> BlueprintDefinition:
+        """Convert to a :class:`~bricks.core.models.BlueprintDefinition`.
+
+        Returns:
+            A blueprint ready for the existing
+            :class:`~bricks.core.engine.BlueprintEngine`.
+        """
+        return self.dag.to_blueprint(name=self.name, description=self.description)
+
+    def to_yaml(self) -> str:
+        """Serialize to a YAML string.
+
+        Returns:
+            YAML representation of the blueprint.
+        """
+        from bricks.core.utils import blueprint_to_yaml  # noqa: PLC0415
+
+        return blueprint_to_yaml(self.to_blueprint())
+
+    def execute(
+        self,
+        inputs: dict[str, Any] | None = None,
+        engine: Any = None,
+    ) -> ExecutionResult:
+        """Execute the flow through :class:`~bricks.core.engine.BlueprintEngine`.
+
+        Args:
+            inputs: Runtime input values for ``${inputs.X}`` references.
+            engine: A :class:`~bricks.core.engine.BlueprintEngine` instance.
+                When ``None``, a default engine with an empty registry is
+                created (suitable for flows that only use built-in bricks).
+
+        Returns:
+            :class:`~bricks.core.models.ExecutionResult` from the engine.
+        """
+        from bricks.core.engine import BlueprintEngine  # noqa: PLC0415
+        from bricks.core.registry import BrickRegistry  # noqa: PLC0415
+
+        bp = self.to_blueprint()
+        resolved_engine: BlueprintEngine = engine if engine is not None else BlueprintEngine(BrickRegistry())
+        return resolved_engine.run(bp, inputs or {})
+
+
+def flow(func: Callable[..., Any]) -> FlowDefinition:
+    """Decorator that traces a function once and returns a :class:`FlowDefinition`.
+
+    The decorated function is called **once at decoration time** with ``None``
+    substituted for all parameters. The body should only call ``step.*``,
+    :func:`for_each`, and :func:`branch` — all of which return
+    :class:`Node` objects.  Actual values are irrelevant during tracing;
+    only the graph structure is captured.
+
+    Args:
+        func: The pipeline function to trace. Its parameters become mock
+            ``None`` values during the trace phase.
+
+    Returns:
+        A :class:`FlowDefinition` with the traced DAG.
+
+    Example::
+
+        from bricks import flow, step
+
+        @flow
+        def clean_pipeline(text):
+            \"\"\"Clean raw text.\"\"\"
+            return step.clean(text=text)
+
+        bp = clean_pipeline.to_blueprint()
+    """
+    from bricks.core.dag_builder import DAGBuilder  # noqa: PLC0415
+
+    sig = inspect.signature(func)
+    mock_args = dict.fromkeys(sig.parameters)
+
+    _tracer.start()
+    try:
+        return_value = func(**mock_args)
+    finally:
+        _tracer.stop()
+
+    traced_nodes = _tracer.get_nodes()
+    root = return_value if isinstance(return_value, Node) else None
+    dag = DAGBuilder().build(traced_nodes, root=root)
+
+    return FlowDefinition(
+        name=func.__name__,
+        description=func.__doc__ or "",
+        dag=dag,
+    )

--- a/packages/core/tests/core/test_flow.py
+++ b/packages/core/tests/core/test_flow.py
@@ -1,0 +1,215 @@
+"""Tests for the @flow decorator and FlowDefinition."""
+
+from __future__ import annotations
+
+import yaml
+from bricks.core.dag import DAG
+from bricks.core.dsl import FlowDefinition, Node, _tracer, branch, flow, for_each, step
+from bricks.core.models import BlueprintDefinition
+
+
+class TestFlowDecorator:
+    """Tests for the @flow decorator itself."""
+
+    def setup_method(self) -> None:
+        """Reset tracer before each test."""
+        _tracer.stop()
+        _tracer.nodes.clear()
+
+    def test_flow_decorator_returns_flow_definition(self) -> None:
+        """@flow returns a FlowDefinition, not a callable."""
+
+        @flow
+        def my_pipe() -> Node:
+            """Simple pipe."""
+            return step.noop()
+
+        assert isinstance(my_pipe, FlowDefinition)
+
+    def test_flow_definition_has_name(self) -> None:
+        """FlowDefinition.name matches the decorated function's name."""
+
+        @flow
+        def my_pipeline() -> Node:
+            """My pipeline."""
+            return step.noop()
+
+        assert my_pipeline.name == "my_pipeline"
+
+    def test_flow_definition_has_docstring(self) -> None:
+        """FlowDefinition.description matches the function docstring."""
+
+        @flow
+        def documented_flow() -> Node:
+            """This is the description."""
+            return step.noop()
+
+        assert documented_flow.description == "This is the description."
+
+    def test_flow_to_dag_returns_dag(self) -> None:
+        """to_dag() returns a DAG object."""
+
+        @flow
+        def pipe() -> Node:
+            """Pipe."""
+            return step.clean(text="x")
+
+        dag = pipe.to_dag()
+        assert isinstance(dag, DAG)
+        assert len(dag.nodes) == 1
+
+    def test_flow_to_blueprint_returns_blueprint_definition(self) -> None:
+        """to_blueprint() returns a BlueprintDefinition."""
+
+        @flow
+        def pipe() -> Node:
+            """Pipe."""
+            return step.clean(text="x")
+
+        bp = pipe.to_blueprint()
+        assert isinstance(bp, BlueprintDefinition)
+
+    def test_flow_to_yaml_returns_string(self) -> None:
+        """to_yaml() returns a non-empty string."""
+
+        @flow
+        def pipe() -> Node:
+            """Pipe."""
+            return step.clean(text="x")
+
+        result = pipe.to_yaml()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_flow_to_yaml_is_valid_yaml(self) -> None:
+        """to_yaml() output is parseable YAML."""
+
+        @flow
+        def pipe() -> Node:
+            """Pipe."""
+            return step.clean(text="x")
+
+        result = pipe.to_yaml()
+        parsed = yaml.safe_load(result)
+        assert isinstance(parsed, dict)
+
+
+class TestFlowTracing:
+    """Tests that @flow traces the correct node structure."""
+
+    def setup_method(self) -> None:
+        """Reset tracer before each test."""
+        _tracer.stop()
+        _tracer.nodes.clear()
+
+    def test_flow_simple_chain(self) -> None:
+        """@flow with a 3-step chain traces 3 nodes."""
+
+        @flow
+        def pipe(data: object) -> Node:
+            """Chain."""
+            a = step.load(path=data)
+            b = step.clean(text=a)
+            return step.save(result=b)
+
+        assert len(pipe.dag.nodes) == 3
+
+    def test_flow_with_for_each(self) -> None:
+        """@flow with for_each traces the for_each node."""
+
+        def do_fn(item: object) -> Node:
+            """Inner."""
+            return step.process(data=item)
+
+        @flow
+        def pipe(items: object) -> Node:
+            """For-each flow."""
+            loaded = step.load(path=items)
+            return for_each(items=loaded, do=do_fn)
+
+        types = {n.type for n in pipe.dag.nodes.values()}
+        assert "for_each" in types
+
+    def test_flow_with_branch(self) -> None:
+        """@flow with branch traces the branch node."""
+
+        def true_fn() -> Node:
+            """True branch."""
+            return step.approve()
+
+        def false_fn() -> Node:
+            """False branch."""
+            return step.reject()
+
+        @flow
+        def pipe() -> Node:
+            """Branch flow."""
+            return branch("is_valid", if_true=true_fn, if_false=false_fn)
+
+        types = {n.type for n in pipe.dag.nodes.values()}
+        assert "branch" in types
+
+    def test_flow_complex_pipeline(self) -> None:
+        """@flow with 5+ steps traces them all."""
+
+        def do_fn(item: object) -> Node:
+            """Inner."""
+            return step.transform(x=item)
+
+        @flow
+        def complex_pipe(data: object) -> Node:
+            """Complex pipeline."""
+            raw = step.load(path=data)
+            validated = step.validate(data=raw)
+            processed = for_each(items=validated, do=do_fn)
+            aggregated = step.aggregate(results=processed)
+            return step.format_output(data=aggregated)
+
+        assert len(complex_pipe.dag.nodes) >= 5
+
+    def test_flow_blueprint_has_correct_step_count(self) -> None:
+        """Blueprint step count matches traced node count."""
+
+        @flow
+        def pipe() -> Node:
+            """Two steps."""
+            a = step.load()
+            return step.save(data=a)
+
+        bp = pipe.to_blueprint()
+        assert len(bp.steps) == len(pipe.dag.nodes)
+
+    def test_flow_blueprint_step_references(self) -> None:
+        """Node references in params become ${...} in blueprint steps."""
+
+        @flow
+        def pipe() -> Node:
+            """Chain with ref."""
+            a = step.load(path="x")
+            return step.clean(data=a)
+
+        bp = pipe.to_blueprint()
+        clean_step = next(s for s in bp.steps if s.brick == "clean")
+        assert "${" in str(clean_step.params.get("data", ""))
+
+    def test_flow_no_return_value(self) -> None:
+        """Function that doesn't return a Node still creates a FlowDefinition."""
+
+        @flow
+        def pipe() -> None:
+            """No return."""
+            step.load()
+            step.save()
+
+        assert isinstance(pipe, FlowDefinition)
+        assert len(pipe.dag.nodes) == 2
+
+    def test_flow_empty_function(self) -> None:
+        """Function with no step calls creates FlowDefinition with empty DAG."""
+
+        @flow
+        def empty_pipe() -> None:
+            """Empty."""
+
+        assert isinstance(empty_pipe, FlowDefinition)
+        assert len(empty_pipe.dag.nodes) == 0


### PR DESCRIPTION
## Summary
- Adds `@flow` decorator that traces a Python function once at decoration time
- Adds `FlowDefinition` with `.to_dag()`, `.to_blueprint()`, `.to_yaml()`, `.execute()`
- 15 tests in `test_flow.py`

## Test plan
- [x] `pytest tests/core/test_flow.py` — 15 passed
- [x] `pytest -q` — 941 passed, 18 skipped
- [x] `mypy --strict` — clean (54 files)
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)