### PR TITLE
Mission 066: FastAPI benchmark web API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.5.1] — 2026-04-07
+
+### Added
+- **Benchmark web API** — FastAPI server at `python -m bricks_benchmark.web` on port 8742
+- `GET /api/datasets` — 3 built-in datasets (CRM, support tickets, orders+customers)
+- `GET /api/bricks` — all stdlib bricks with name, description, category
+- `GET /api/presets` — preset YAML scenarios loaded from `web/presets/`
+- `POST /api/run` — runs BricksEngine + RawLLMEngine, returns savings ratio + percent
+- `web/ticket_generator.py` — deterministic 100-record support ticket dataset generator
+- `web/datasets.py` — DatasetLoader supporting flat and multi-table JSON datasets
+- `web/schemas.py` — Pydantic v2 schemas: BenchmarkRequest, EngineResultResponse, BenchmarkResponse
+- Benchmark package dependencies: `fastapi>=0.100`, `uvicorn>=0.20`, `PyYAML>=6.0`
+
 ## [0.5.0] — 2026-04-07
 
 ### Added

--- a/packages/benchmark/pyproject.toml
+++ b/packages/benchmark/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "bricks-ai-stdlib>=0.4.23",
     "tiktoken>=0.5",
     "matplotlib>=3.7",
+    "fastapi>=0.100",
+    "uvicorn>=0.20",
+    "PyYAML>=6.0",
 ]
 
 [project.urls]

--- a/packages/benchmark/src/bricks_benchmark/tests/test_web_datasets.py
+++ b/packages/benchmark/src/bricks_benchmark/tests/test_web_datasets.py
@@ -1,0 +1,102 @@
+"""Tests for bricks_benchmark.web.datasets."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bricks_benchmark.web.datasets import DatasetLoader, _summarise_data
+
+
+class TestSummariseData:
+    """Tests for the _summarise_data helper."""
+
+    def test_list_data_count_and_preview(self) -> None:
+        """List data: row_count = len, preview = first 3."""
+        data = [{"a": i} for i in range(10)]
+        count, preview = _summarise_data(data)
+        assert count == 10
+        assert preview == [{"a": 0}, {"a": 1}, {"a": 2}]
+
+    def test_list_data_shorter_than_three(self) -> None:
+        """List data shorter than 3 rows: preview = all rows."""
+        data = [{"x": 1}, {"x": 2}]
+        count, preview = _summarise_data(data)
+        assert count == 2
+        assert preview == [{"x": 1}, {"x": 2}]
+
+    def test_dict_data_totals_and_preview(self) -> None:
+        """Dict data: total = sum of all list lengths, preview = first 3 of first list."""
+        data = {"orders": [{"id": i} for i in range(5)], "customers": [{"id": i} for i in range(3)]}
+        count, preview = _summarise_data(data)
+        assert count == 8
+        assert len(preview) == 3
+
+    def test_empty_list(self) -> None:
+        """Empty list: count = 0, preview = []."""
+        count, preview = _summarise_data([])
+        assert count == 0
+        assert preview == []
+
+
+class TestDatasetLoader:
+    """Tests for DatasetLoader reading real dataset files."""
+
+    @pytest.fixture
+    def loader(self) -> DatasetLoader:
+        """Create a DatasetLoader instance."""
+        return DatasetLoader()
+
+    def test_loads_three_datasets(self, loader: DatasetLoader) -> None:
+        """DatasetLoader loads exactly 3 built-in datasets."""
+        datasets = loader.list_datasets()
+        assert len(datasets) == 3
+
+    def test_dataset_ids_present(self, loader: DatasetLoader) -> None:
+        """All expected dataset IDs are present."""
+        ids = {ds["id"] for ds in loader.list_datasets()}
+        assert "crm-customers" in ids
+        assert "support-tickets" in ids
+        assert "orders-customers" in ids
+
+    def test_preview_has_at_most_three_rows(self, loader: DatasetLoader) -> None:
+        """Each dataset preview contains at most 3 rows."""
+        for ds in loader.list_datasets():
+            assert len(ds["preview"]) <= 3
+
+    def test_full_data_is_valid_json(self, loader: DatasetLoader) -> None:
+        """Each dataset's full_data field is valid JSON."""
+        for ds in loader.list_datasets():
+            parsed = json.loads(ds["full_data"])
+            assert parsed is not None
+
+    def test_crm_dataset_has_expected_fields(self, loader: DatasetLoader) -> None:
+        """CRM dataset has the expected field list."""
+        ds = loader.get_dataset("crm-customers")
+        assert ds is not None
+        assert "id" in ds["fields"]
+        assert "status" in ds["fields"]
+        assert "monthly_revenue" in ds["fields"]
+
+    def test_crm_dataset_row_count(self, loader: DatasetLoader) -> None:
+        """CRM dataset has 25 records."""
+        ds = loader.get_dataset("crm-customers")
+        assert ds is not None
+        assert len(ds["data"]) == 25
+
+    def test_ticket_dataset_row_count(self, loader: DatasetLoader) -> None:
+        """Support tickets dataset has 100 records."""
+        ds = loader.get_dataset("support-tickets")
+        assert ds is not None
+        assert len(ds["data"]) == 100
+
+    def test_get_dataset_unknown_id_returns_none(self, loader: DatasetLoader) -> None:
+        """get_dataset returns None for an unknown dataset ID."""
+        assert loader.get_dataset("nonexistent-id") is None
+
+    def test_dataset_has_all_required_keys(self, loader: DatasetLoader) -> None:
+        """Each dataset dict has all required keys for the API response."""
+        required = {"id", "name", "description", "row_count", "fields", "preview", "full_data"}
+        for ds in loader.list_datasets():
+            assert required.issubset(ds.keys())

--- a/packages/benchmark/src/bricks_benchmark/tests/test_web_schemas.py
+++ b/packages/benchmark/src/bricks_benchmark/tests/test_web_schemas.py
@@ -1,0 +1,132 @@
+"""Tests for bricks_benchmark.web.schemas."""
+
+from __future__ import annotations
+
+import pytest
+
+from bricks_benchmark.web.schemas import BenchmarkRequest, BenchmarkResponse, EngineResultResponse
+
+
+class TestBenchmarkRequest:
+    """Tests for BenchmarkRequest schema."""
+
+    def test_required_fields(self) -> None:
+        """BenchmarkRequest accepts task_text and raw_data as required fields."""
+        req = BenchmarkRequest(task_text="Count active users", raw_data='{"users": []}')
+        assert req.task_text == "Count active users"
+        assert req.raw_data == '{"users": []}'
+
+    def test_defaults(self) -> None:
+        """BenchmarkRequest optional fields default correctly."""
+        req = BenchmarkRequest(task_text="t", raw_data="d")
+        assert req.expected_outputs is None
+        assert req.required_bricks is None
+        assert req.model == "claudecode"
+
+    def test_custom_model(self) -> None:
+        """BenchmarkRequest accepts a custom model string."""
+        req = BenchmarkRequest(task_text="t", raw_data="d", model="gpt-4o-mini")
+        assert req.model == "gpt-4o-mini"
+
+    def test_with_expected_outputs(self) -> None:
+        """BenchmarkRequest stores expected_outputs dict."""
+        req = BenchmarkRequest(
+            task_text="t",
+            raw_data="d",
+            expected_outputs={"count": 5, "total": 3.14},
+        )
+        assert req.expected_outputs == {"count": 5, "total": 3.14}
+
+    def test_with_required_bricks(self) -> None:
+        """BenchmarkRequest stores required_bricks list."""
+        req = BenchmarkRequest(
+            task_text="t",
+            raw_data="d",
+            required_bricks=["filter_dict_list", "count_dict_list"],
+        )
+        assert req.required_bricks == ["filter_dict_list", "count_dict_list"]
+
+
+class TestEngineResultResponse:
+    """Tests for EngineResultResponse schema."""
+
+    def _make(self, correct: bool | None = None) -> EngineResultResponse:
+        """Build a minimal EngineResultResponse for testing."""
+        return EngineResultResponse(
+            engine_name="TestEngine",
+            outputs={"count": 5},
+            correct=correct,
+            tokens_in=100,
+            tokens_out=50,
+            duration_seconds=1.5,
+            model="test-model",
+            raw_response="yaml: content",
+            error="",
+        )
+
+    def test_correct_is_none_when_no_expected(self) -> None:
+        """correct is None when expected_outputs were not provided."""
+        result = self._make(correct=None)
+        assert result.correct is None
+
+    def test_correct_true(self) -> None:
+        """correct stores True when engine output matches expected."""
+        result = self._make(correct=True)
+        assert result.correct is True
+
+    def test_correct_false(self) -> None:
+        """correct stores False when engine output does not match expected."""
+        result = self._make(correct=False)
+        assert result.correct is False
+
+    def test_all_fields_stored(self) -> None:
+        """EngineResultResponse stores all provided fields."""
+        result = self._make()
+        assert result.engine_name == "TestEngine"
+        assert result.outputs == {"count": 5}
+        assert result.tokens_in == 100
+        assert result.tokens_out == 50
+        assert result.duration_seconds == 1.5
+        assert result.model == "test-model"
+        assert result.raw_response == "yaml: content"
+        assert result.error == ""
+
+
+class TestBenchmarkResponse:
+    """Tests for BenchmarkResponse schema and savings math."""
+
+    def _make_engine_result(self, tokens_in: int, tokens_out: int) -> EngineResultResponse:
+        """Build a minimal EngineResultResponse with given token counts."""
+        return EngineResultResponse(
+            engine_name="Engine",
+            outputs={},
+            correct=None,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            duration_seconds=1.0,
+            model="m",
+            raw_response="",
+            error="",
+        )
+
+    def test_savings_ratio_computed(self) -> None:
+        """BenchmarkResponse stores savings_ratio and savings_percent."""
+        resp = BenchmarkResponse(
+            bricks_result=self._make_engine_result(100, 50),
+            llm_result=self._make_engine_result(400, 200),
+            savings_ratio=4.0,
+            savings_percent=75.0,
+        )
+        assert resp.savings_ratio == pytest.approx(4.0)
+        assert resp.savings_percent == pytest.approx(75.0)
+
+    def test_savings_zero_percent_when_equal(self) -> None:
+        """0% savings when both engines use the same tokens."""
+        resp = BenchmarkResponse(
+            bricks_result=self._make_engine_result(100, 50),
+            llm_result=self._make_engine_result(100, 50),
+            savings_ratio=1.0,
+            savings_percent=0.0,
+        )
+        assert resp.savings_ratio == pytest.approx(1.0)
+        assert resp.savings_percent == pytest.approx(0.0)

--- a/packages/benchmark/src/bricks_benchmark/web/__init__.py
+++ b/packages/benchmark/src/bricks_benchmark/web/__init__.py
@@ -1,0 +1,5 @@
+"""Bricks Benchmark web module — FastAPI backend for the interactive benchmark GUI."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/packages/benchmark/src/bricks_benchmark/web/__main__.py
+++ b/packages/benchmark/src/bricks_benchmark/web/__main__.py
@@ -1,0 +1,14 @@
+"""Entry point for the Bricks Benchmark web server.
+
+Run with:
+    python -m bricks_benchmark.web
+"""
+
+from __future__ import annotations
+
+import uvicorn
+
+from bricks_benchmark.web.app import app
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8742)  # noqa: S104

--- a/packages/benchmark/src/bricks_benchmark/web/app.py
+++ b/packages/benchmark/src/bricks_benchmark/web/app.py
@@ -1,0 +1,28 @@
+"""FastAPI application for the Bricks Benchmark web server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from bricks_benchmark.web.routes import router
+
+_STATIC_DIR = Path(__file__).parent / "static"
+_INDEX_HTML = _STATIC_DIR / "index.html"
+
+app = FastAPI(title="Bricks Benchmark", version="0.1.0")
+app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
+app.include_router(router)
+
+
+@app.get("/")
+async def index() -> FileResponse:
+    """Serve the benchmark GUI frontend.
+
+    Returns:
+        FileResponse for the ``index.html`` single-page app.
+    """
+    return FileResponse(str(_INDEX_HTML))

--- a/packages/benchmark/src/bricks_benchmark/web/datasets.py
+++ b/packages/benchmark/src/bricks_benchmark/web/datasets.py
@@ -1,0 +1,85 @@
+"""Dataset loader for the Bricks Benchmark web API.
+
+Loads built-in datasets from the ``web/datasets/`` directory and serves them
+via the ``/api/datasets`` endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+_DATASETS_DIR = Path(__file__).parent / "datasets"
+
+
+def _summarise_data(data: Any) -> tuple[int, list[Any]]:
+    """Return (row_count, preview) for list or multi-table dict data.
+
+    Args:
+        data: Either a list of records or a dict of table-name → list.
+
+    Returns:
+        Tuple of total row count and first 3 rows of the primary table.
+    """
+    if isinstance(data, list):
+        return len(data), data[:3]
+    if isinstance(data, dict):
+        first_list = next((v for v in data.values() if isinstance(v, list)), [])
+        total = sum(len(v) for v in data.values() if isinstance(v, list))
+        return total, first_list[:3]
+    return 0, []
+
+
+class DatasetLoader:
+    """Loads and serves built-in benchmark datasets from JSON files.
+
+    Each dataset file contains an ``id``, ``name``, ``description``, ``fields``,
+    and ``data`` (list of records).
+    """
+
+    def __init__(self) -> None:
+        """Load all dataset JSON files from the datasets directory."""
+        self._datasets: dict[str, dict[str, Any]] = {}
+        for path in sorted(_DATASETS_DIR.glob("*.json")):
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            self._datasets[raw["id"]] = raw
+
+    def list_datasets(self) -> list[dict[str, Any]]:
+        """Return all datasets with preview (first 3 rows) and full data JSON string.
+
+        Supports both list data (``data: [...]``) and multi-table data
+        (``data: {"table": [...], ...}``).
+
+        Returns:
+            List of dataset dicts, each with:
+            ``id``, ``name``, ``description``, ``row_count``, ``fields``,
+            ``preview`` (first 3 rows of primary table), ``full_data`` (full JSON string).
+        """
+        result: list[dict[str, Any]] = []
+        for ds in self._datasets.values():
+            data = ds["data"]
+            row_count, preview = _summarise_data(data)
+            result.append(
+                {
+                    "id": ds["id"],
+                    "name": ds["name"],
+                    "description": ds["description"],
+                    "row_count": row_count,
+                    "fields": ds["fields"],
+                    "preview": preview,
+                    "full_data": json.dumps(data),
+                }
+            )
+        return result
+
+    def get_dataset(self, dataset_id: str) -> dict[str, Any] | None:
+        """Return a single dataset by ID, or None if not found.
+
+        Args:
+            dataset_id: The dataset identifier (e.g. ``'crm-customers'``).
+
+        Returns:
+            Dataset dict with full data, or ``None`` if the ID is unknown.
+        """
+        return self._datasets.get(dataset_id)

--- a/packages/benchmark/src/bricks_benchmark/web/datasets/crm_customers.json
+++ b/packages/benchmark/src/bricks_benchmark/web/datasets/crm_customers.json
@@ -1,0 +1,241 @@
+{
+  "id": "crm-customers",
+  "name": "CRM Customers",
+  "description": "25 customer records with mixed statuses, revenues, and email validity",
+  "fields": [
+    "id",
+    "name",
+    "email",
+    "status",
+    "plan",
+    "monthly_revenue",
+    "signup_date"
+  ],
+  "data": [
+    {
+      "id": 1,
+      "name": "Quinn Taylor",
+      "email": "quinn.taylor0@example.com",
+      "status": "active",
+      "plan": "basic",
+      "monthly_revenue": 50.0,
+      "signup_date": "2020-07-15"
+    },
+    {
+      "id": 2,
+      "name": "Vince Taylor",
+      "email": "vince.taylor1@example.com",
+      "status": "inactive",
+      "plan": "pro",
+      "monthly_revenue": 110.5,
+      "signup_date": "2021-02-18"
+    },
+    {
+      "id": 3,
+      "name": "Alice Taylor",
+      "email": "alice.taylor2@example.com",
+      "status": "suspended",
+      "plan": "enterprise",
+      "monthly_revenue": 501.0,
+      "signup_date": "2022-09-21"
+    },
+    {
+      "id": 4,
+      "name": "Frank Wilson",
+      "email": "frank.wilson3@example.com",
+      "status": "active",
+      "plan": "pro",
+      "monthly_revenue": 116.5,
+      "signup_date": "2023-04-24"
+    },
+    {
+      "id": 5,
+      "name": "Kim Wilson",
+      "email": "kim.wilson4@example.com",
+      "status": "inactive",
+      "plan": "enterprise",
+      "monthly_revenue": 507.0,
+      "signup_date": "2024-11-27"
+    },
+    {
+      "id": 6,
+      "name": "Paul Wilson",
+      "email": "paul.wilson5@example.com",
+      "status": "suspended",
+      "plan": "pro",
+      "monthly_revenue": 122.5,
+      "signup_date": "2020-06-02"
+    },
+    {
+      "id": 7,
+      "name": "Uma Davis",
+      "email": "uma.davis6@example.com",
+      "status": "active",
+      "plan": "enterprise",
+      "monthly_revenue": 513.0,
+      "signup_date": "2021-01-05"
+    },
+    {
+      "id": 8,
+      "name": "Zoe Davis",
+      "email": "zoe.davis7@example.com",
+      "status": "inactive",
+      "plan": "pro",
+      "monthly_revenue": 103.5,
+      "signup_date": "2022-08-08"
+    },
+    {
+      "id": 9,
+      "name": "Eve Davis",
+      "email": "eve.davis8@example.com",
+      "status": "suspended",
+      "plan": "enterprise",
+      "monthly_revenue": 519.0,
+      "signup_date": "2023-03-11"
+    },
+    {
+      "id": 10,
+      "name": "Jack Miller",
+      "email": "jack.miller9@example.com",
+      "status": "active",
+      "plan": "basic",
+      "monthly_revenue": 39.5,
+      "signup_date": "2024-10-14"
+    },
+    {
+      "id": 11,
+      "name": "Olivia Miller",
+      "email": "olivia.miller10@example.com",
+      "status": "inactive",
+      "plan": "enterprise",
+      "monthly_revenue": 500.0,
+      "signup_date": "2020-05-17"
+    },
+    {
+      "id": 12,
+      "name": "Tina Miller",
+      "email": "tina.miller11@example.com",
+      "status": "suspended",
+      "plan": "basic",
+      "monthly_revenue": 45.5,
+      "signup_date": "2021-12-20"
+    },
+    {
+      "id": 13,
+      "name": "Yara Moore",
+      "email": "yara.moore12@example.com",
+      "status": "active",
+      "plan": "enterprise",
+      "monthly_revenue": 506.0,
+      "signup_date": "2022-07-23"
+    },
+    {
+      "id": 14,
+      "name": "Dave Moore",
+      "email": "dave.moore13@example.com",
+      "status": "inactive",
+      "plan": "basic",
+      "monthly_revenue": 51.5,
+      "signup_date": "2023-02-26"
+    },
+    {
+      "id": 15,
+      "name": "Iris Moore",
+      "email": "iris.moore14@example.com",
+      "status": "suspended",
+      "plan": "enterprise",
+      "monthly_revenue": 512.0,
+      "signup_date": "2024-09-01"
+    },
+    {
+      "id": 16,
+      "name": "Ned Clark",
+      "email": "ned.clark15@example.com",
+      "status": "active",
+      "plan": "basic",
+      "monthly_revenue": 32.5,
+      "signup_date": "2020-04-04"
+    },
+    {
+      "id": 17,
+      "name": "Sam Clark",
+      "email": "sam.clark16@example.com",
+      "status": "inactive",
+      "plan": "pro",
+      "monthly_revenue": 118.0,
+      "signup_date": "2021-11-07"
+    },
+    {
+      "id": 18,
+      "name": "Xander Clark",
+      "email": "xander.clark17@example.com",
+      "status": "suspended",
+      "plan": "basic",
+      "monthly_revenue": 38.5,
+      "signup_date": "2022-06-10"
+    },
+    {
+      "id": 19,
+      "name": "Carol Smith",
+      "email": "carol.smith18@example.com",
+      "status": "active",
+      "plan": "pro",
+      "monthly_revenue": 99.0,
+      "signup_date": "2023-01-13"
+    },
+    {
+      "id": 20,
+      "name": "Hank Smith",
+      "email": "hank.smith19@example.com",
+      "status": "inactive",
+      "plan": "basic",
+      "monthly_revenue": 44.5,
+      "signup_date": "2024-08-16"
+    },
+    {
+      "id": 21,
+      "name": "Mia Smith",
+      "email": "mia.smith20@example.com",
+      "status": "suspended",
+      "plan": "pro",
+      "monthly_revenue": 105.0,
+      "signup_date": "2020-03-19"
+    },
+    {
+      "id": 22,
+      "name": "Rose Jones",
+      "email": "rose.jones21@example.com",
+      "status": "active",
+      "plan": "basic",
+      "monthly_revenue": 50.5,
+      "signup_date": "2021-10-22"
+    },
+    {
+      "id": 23,
+      "name": "Wendy Jones",
+      "email": "wendy.jones22@example.com",
+      "status": "inactive",
+      "plan": "pro",
+      "monthly_revenue": 111.0,
+      "signup_date": "2022-05-25"
+    },
+    {
+      "id": 24,
+      "name": "Bob Jones",
+      "email": "bob.jones23@example.com",
+      "status": "suspended",
+      "plan": "enterprise",
+      "monthly_revenue": 501.5,
+      "signup_date": "2023-12-28"
+    },
+    {
+      "id": 25,
+      "name": "Grace Lee",
+      "email": "grace.lee24@example.com",
+      "status": "active",
+      "plan": "pro",
+      "monthly_revenue": 117.0,
+      "signup_date": "2024-07-03"
+    }
+  ]
+}

--- a/packages/benchmark/src/bricks_benchmark/web/datasets/orders_customers.json
+++ b/packages/benchmark/src/bricks_benchmark/web/datasets/orders_customers.json
@@ -1,0 +1,545 @@
+{
+  "id": "orders-customers",
+  "name": "Orders and Customers",
+  "description": "50 orders linked to 30 customers with plan types and order statuses",
+  "fields": [
+    "orders: order_id, customer_id, amount, status, order_date",
+    "customers: id, name, email, plan"
+  ],
+  "data": {
+    "orders": [
+      {
+        "order_id": 1,
+        "customer_id": 13,
+        "amount": 226.4,
+        "status": "completed",
+        "order_date": "2024-07-15"
+      },
+      {
+        "order_id": 2,
+        "customer_id": 6,
+        "amount": 475.5,
+        "status": "refunded",
+        "order_date": "2025-12-12"
+      },
+      {
+        "order_id": 3,
+        "customer_id": 29,
+        "amount": 254.6,
+        "status": "pending",
+        "order_date": "2024-05-09"
+      },
+      {
+        "order_id": 4,
+        "customer_id": 22,
+        "amount": 33.7,
+        "status": "completed",
+        "order_date": "2025-10-06"
+      },
+      {
+        "order_id": 5,
+        "customer_id": 15,
+        "amount": 282.8,
+        "status": "refunded",
+        "order_date": "2024-03-03"
+      },
+      {
+        "order_id": 6,
+        "customer_id": 8,
+        "amount": 61.9,
+        "status": "pending",
+        "order_date": "2025-08-28"
+      },
+      {
+        "order_id": 7,
+        "customer_id": 1,
+        "amount": 311.0,
+        "status": "completed",
+        "order_date": "2024-01-25"
+      },
+      {
+        "order_id": 8,
+        "customer_id": 24,
+        "amount": 90.1,
+        "status": "refunded",
+        "order_date": "2025-06-22"
+      },
+      {
+        "order_id": 9,
+        "customer_id": 17,
+        "amount": 339.2,
+        "status": "pending",
+        "order_date": "2024-11-19"
+      },
+      {
+        "order_id": 10,
+        "customer_id": 10,
+        "amount": 118.3,
+        "status": "completed",
+        "order_date": "2025-04-16"
+      },
+      {
+        "order_id": 11,
+        "customer_id": 3,
+        "amount": 367.4,
+        "status": "refunded",
+        "order_date": "2024-09-13"
+      },
+      {
+        "order_id": 12,
+        "customer_id": 26,
+        "amount": 146.5,
+        "status": "pending",
+        "order_date": "2025-02-10"
+      },
+      {
+        "order_id": 13,
+        "customer_id": 19,
+        "amount": 395.6,
+        "status": "completed",
+        "order_date": "2024-07-07"
+      },
+      {
+        "order_id": 14,
+        "customer_id": 12,
+        "amount": 174.7,
+        "status": "refunded",
+        "order_date": "2025-12-04"
+      },
+      {
+        "order_id": 15,
+        "customer_id": 5,
+        "amount": 423.8,
+        "status": "pending",
+        "order_date": "2024-05-01"
+      },
+      {
+        "order_id": 16,
+        "customer_id": 28,
+        "amount": 202.9,
+        "status": "completed",
+        "order_date": "2025-10-26"
+      },
+      {
+        "order_id": 17,
+        "customer_id": 21,
+        "amount": 452.0,
+        "status": "refunded",
+        "order_date": "2024-03-23"
+      },
+      {
+        "order_id": 18,
+        "customer_id": 14,
+        "amount": 231.1,
+        "status": "pending",
+        "order_date": "2025-08-20"
+      },
+      {
+        "order_id": 19,
+        "customer_id": 7,
+        "amount": 480.2,
+        "status": "completed",
+        "order_date": "2024-01-17"
+      },
+      {
+        "order_id": 20,
+        "customer_id": 20,
+        "amount": 259.3,
+        "status": "pending",
+        "order_date": "2025-02-22"
+      },
+      {
+        "order_id": 21,
+        "customer_id": 13,
+        "amount": 38.4,
+        "status": "completed",
+        "order_date": "2024-07-19"
+      },
+      {
+        "order_id": 22,
+        "customer_id": 6,
+        "amount": 287.5,
+        "status": "refunded",
+        "order_date": "2025-12-16"
+      },
+      {
+        "order_id": 23,
+        "customer_id": 29,
+        "amount": 66.6,
+        "status": "pending",
+        "order_date": "2024-05-13"
+      },
+      {
+        "order_id": 24,
+        "customer_id": 22,
+        "amount": 315.7,
+        "status": "completed",
+        "order_date": "2025-10-10"
+      },
+      {
+        "order_id": 25,
+        "customer_id": 15,
+        "amount": 94.8,
+        "status": "refunded",
+        "order_date": "2024-03-07"
+      },
+      {
+        "order_id": 26,
+        "customer_id": 8,
+        "amount": 343.9,
+        "status": "pending",
+        "order_date": "2025-08-04"
+      },
+      {
+        "order_id": 27,
+        "customer_id": 1,
+        "amount": 123.0,
+        "status": "completed",
+        "order_date": "2024-01-01"
+      },
+      {
+        "order_id": 28,
+        "customer_id": 24,
+        "amount": 372.1,
+        "status": "refunded",
+        "order_date": "2025-06-26"
+      },
+      {
+        "order_id": 29,
+        "customer_id": 17,
+        "amount": 151.2,
+        "status": "pending",
+        "order_date": "2024-11-23"
+      },
+      {
+        "order_id": 30,
+        "customer_id": 10,
+        "amount": 400.3,
+        "status": "completed",
+        "order_date": "2025-04-20"
+      },
+      {
+        "order_id": 31,
+        "customer_id": 3,
+        "amount": 179.4,
+        "status": "refunded",
+        "order_date": "2024-09-17"
+      },
+      {
+        "order_id": 32,
+        "customer_id": 26,
+        "amount": 428.5,
+        "status": "pending",
+        "order_date": "2025-02-14"
+      },
+      {
+        "order_id": 33,
+        "customer_id": 19,
+        "amount": 207.6,
+        "status": "completed",
+        "order_date": "2024-07-11"
+      },
+      {
+        "order_id": 34,
+        "customer_id": 12,
+        "amount": 456.7,
+        "status": "refunded",
+        "order_date": "2025-12-08"
+      },
+      {
+        "order_id": 35,
+        "customer_id": 5,
+        "amount": 235.8,
+        "status": "pending",
+        "order_date": "2024-05-05"
+      },
+      {
+        "order_id": 36,
+        "customer_id": 28,
+        "amount": 484.9,
+        "status": "completed",
+        "order_date": "2025-10-02"
+      },
+      {
+        "order_id": 37,
+        "customer_id": 21,
+        "amount": 264.0,
+        "status": "refunded",
+        "order_date": "2024-03-27"
+      },
+      {
+        "order_id": 38,
+        "customer_id": 4,
+        "amount": 43.1,
+        "status": "completed",
+        "order_date": "2025-04-04"
+      },
+      {
+        "order_id": 39,
+        "customer_id": 27,
+        "amount": 292.2,
+        "status": "refunded",
+        "order_date": "2024-09-01"
+      },
+      {
+        "order_id": 40,
+        "customer_id": 20,
+        "amount": 71.3,
+        "status": "pending",
+        "order_date": "2025-02-26"
+      },
+      {
+        "order_id": 41,
+        "customer_id": 13,
+        "amount": 320.4,
+        "status": "completed",
+        "order_date": "2024-07-23"
+      },
+      {
+        "order_id": 42,
+        "customer_id": 6,
+        "amount": 99.5,
+        "status": "refunded",
+        "order_date": "2025-12-20"
+      },
+      {
+        "order_id": 43,
+        "customer_id": 29,
+        "amount": 348.6,
+        "status": "pending",
+        "order_date": "2024-05-17"
+      },
+      {
+        "order_id": 44,
+        "customer_id": 22,
+        "amount": 127.7,
+        "status": "completed",
+        "order_date": "2025-10-14"
+      },
+      {
+        "order_id": 45,
+        "customer_id": 15,
+        "amount": 376.8,
+        "status": "refunded",
+        "order_date": "2024-03-11"
+      },
+      {
+        "order_id": 46,
+        "customer_id": 8,
+        "amount": 155.9,
+        "status": "pending",
+        "order_date": "2025-08-08"
+      },
+      {
+        "order_id": 47,
+        "customer_id": 1,
+        "amount": 405.0,
+        "status": "completed",
+        "order_date": "2024-01-05"
+      },
+      {
+        "order_id": 48,
+        "customer_id": 24,
+        "amount": 184.1,
+        "status": "refunded",
+        "order_date": "2025-06-02"
+      },
+      {
+        "order_id": 49,
+        "customer_id": 17,
+        "amount": 433.2,
+        "status": "pending",
+        "order_date": "2024-11-27"
+      },
+      {
+        "order_id": 50,
+        "customer_id": 10,
+        "amount": 212.3,
+        "status": "completed",
+        "order_date": "2025-04-24"
+      }
+    ],
+    "customers": [
+      {
+        "id": 1,
+        "name": "Mia Taylor",
+        "email": "mia.taylor0@orders.io",
+        "plan": "basic"
+      },
+      {
+        "id": 2,
+        "name": "Xander Miller",
+        "email": "xander.miller1@orders.io",
+        "plan": "enterprise"
+      },
+      {
+        "id": 3,
+        "name": "Eve Jones",
+        "email": "eve.jones2@orders.io",
+        "plan": "pro"
+      },
+      {
+        "id": 4,
+        "name": "Paul Wilson",
+        "email": "paul.wilson3@orders.io",
+        "plan": "basic"
+      },
+      {
+        "id": 5,
+        "name": "Aaron Moore",
+        "email": "aaron.moore4@orders.io",
+        "plan": "enterprise"
+      },
+      {
+        "id": 6,
+        "name": "Hank Lee",
+        "email": "hank.lee5@orders.io",
+        "plan": "pro"
+      },
+      {
+        "id": 7,
+        "name": "Sam Davis",
+        "email": "sam.davis6@orders.io",
+        "plan": "basic"
+      },
+      {
+        "id": 8,
+        "name": "Diana Clark",
+        "email": "diana.clark7@orders.io",
+        "plan": "enterprise"
+      },
+      {
+        "id": 9,
+        "name": "Kim Brown",
+        "email": "kim.brown8@orders.io",
+        "plan": "pro"
+      },
+      {
+        "id": 10,
+        "name": "Vince Miller",
+        "email": "vince.miller9@orders.io",
+        "plan": "basic"
+      },
+      {
+        "id": 11,
+        "name": "Carol Smith",
+        "email": "carol.smith10@orders.io",
+        "plan": "enterprise"
+      },
+      {
+        "id": 12,
+        "name": "Ned Taylor",
+        "email": "ned.taylor11@orders.io",
+        "plan": "pro"
+      },
+      {
+        "id": 13,
+        "name": "Yara Moore",
+        "email": "yara.moore12@orders.io",
+        "plan": "basic"
+      },
+      {
+        "id": 14,
+        "name": "Frank Jones",
+        "email": "frank.jones13@orders.io",
+        "plan": "enterprise"
+      },
+      {
+        "id": 15,
+        "name": "Quinn Wilson",
+        "email": "quinn.wilson14@orders.io",
+        "plan": "pro"
+      },
+      {
+        "id": 16,
+        "name": "Bella Clark",
+        "email": "bella.clark15@orders.io",
+        "plan": "basic"
+      },
+      {
+        "id": 17,
+        "name": "Iris Lee",
+        "email": "iris.lee16@orders.io",
+        "plan": "enterprise"
+      },
+      {
+        "id": 18,
+        "name": "Tina Davis",
+        "email": "tina.davis17@orders.io",
+        "plan": "pro"
+      },
+      {
+        "id": 19,
+        "name": "Alice Smith",
+        "email": "alice.smith18@orders.io",
+        "plan": "basic"
+      },
+      {
+        "id": 20,
+        "name": "Leo Brown",
+        "email": "leo.brown19@orders.io",
+        "plan": "enterprise"
+      },
+      {
+        "id": 21,
+        "name": "Wendy Miller",
+        "email": "wendy.miller20@orders.io",
+        "plan": "pro"
+      },
+      {
+        "id": 22,
+        "name": "Dave Jones",
+        "email": "dave.jones21@orders.io",
+        "plan": "basic"
+      },
+      {
+        "id": 23,
+        "name": "Olivia Taylor",
+        "email": "olivia.taylor22@orders.io",
+        "plan": "enterprise"
+      },
+      {
+        "id": 24,
+        "name": "Zoe Moore",
+        "email": "zoe.moore23@orders.io",
+        "plan": "pro"
+      },
+      {
+        "id": 25,
+        "name": "Aaron Moore",
+        "email": "aaron.moore24@orders.io",
+        "plan": "enterprise"
+      },
+      {
+        "id": 26,
+        "name": "Hank Lee",
+        "email": "hank.lee25@orders.io",
+        "plan": "pro"
+      },
+      {
+        "id": 27,
+        "name": "Sam Davis",
+        "email": "sam.davis26@orders.io",
+        "plan": "basic"
+      },
+      {
+        "id": 28,
+        "name": "Diana Clark",
+        "email": "diana.clark27@orders.io",
+        "plan": "enterprise"
+      },
+      {
+        "id": 29,
+        "name": "Kim Brown",
+        "email": "kim.brown28@orders.io",
+        "plan": "pro"
+      },
+      {
+        "id": 30,
+        "name": "Vince Miller",
+        "email": "vince.miller29@orders.io",
+        "plan": "basic"
+      }
+    ]
+  }
+}

--- a/packages/benchmark/src/bricks_benchmark/web/datasets/support_tickets.json
+++ b/packages/benchmark/src/bricks_benchmark/web/datasets/support_tickets.json
@@ -1,0 +1,916 @@
+{
+  "id": "support-tickets",
+  "name": "Support Tickets",
+  "description": "100 support ticket records with priority, category, and status fields",
+  "fields": [
+    "id",
+    "subject",
+    "email",
+    "priority",
+    "category",
+    "status",
+    "created_date"
+  ],
+  "data": [
+    {
+      "id": 1,
+      "subject": "Feature not working",
+      "email": "user42@corp.net",
+      "priority": "low",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2024-07-15"
+    },
+    {
+      "id": 2,
+      "subject": "Integration broken",
+      "email": "user79@yahoo.com",
+      "priority": "medium",
+      "category": "technical",
+      "status": "pending",
+      "created_date": "2025-08-24"
+    },
+    {
+      "id": 3,
+      "subject": "API rate limit exceeded",
+      "email": "user116@example.com",
+      "priority": "high",
+      "category": "general",
+      "status": "closed",
+      "created_date": "2024-09-05"
+    },
+    {
+      "id": 4,
+      "subject": "Payment failed",
+      "email": "user153@yahoo.com",
+      "priority": "low",
+      "category": "general",
+      "status": "open",
+      "created_date": "2025-10-14"
+    },
+    {
+      "id": 5,
+      "subject": "Cannot login to account",
+      "email": "user190@example.com",
+      "priority": "medium",
+      "category": "general",
+      "status": "open",
+      "created_date": "2024-11-23"
+    },
+    {
+      "id": 6,
+      "subject": "Password reset not received",
+      "email": "user227@gmail.com",
+      "priority": "high",
+      "category": "general",
+      "status": "pending",
+      "created_date": "2025-12-04"
+    },
+    {
+      "id": 7,
+      "subject": "Account suspended",
+      "email": "user264@example.com",
+      "priority": "low",
+      "category": "billing",
+      "status": "closed",
+      "created_date": "2024-01-13"
+    },
+    {
+      "id": 8,
+      "subject": "Invoice discrepancy",
+      "email": "user301@gmail.com",
+      "priority": "medium",
+      "category": "billing",
+      "status": "closed",
+      "created_date": "2025-02-22"
+    },
+    {
+      "id": 9,
+      "subject": "Billing cycle question",
+      "email": "user338@company.io",
+      "priority": "high",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2024-03-03"
+    },
+    {
+      "id": 10,
+      "subject": "Data export issue",
+      "email": "user375@gmail.com",
+      "priority": "low",
+      "category": "billing",
+      "status": "pending",
+      "created_date": "2025-04-12"
+    },
+    {
+      "id": 11,
+      "subject": "Feature not working",
+      "email": "user412@company.io",
+      "priority": "medium",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2024-05-21"
+    },
+    {
+      "id": 12,
+      "subject": "Integration broken",
+      "email": "user449@corp.net",
+      "priority": "high",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2025-06-02"
+    },
+    {
+      "id": 13,
+      "subject": "API rate limit exceeded",
+      "email": "user486@company.io",
+      "priority": "low",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2024-07-11"
+    },
+    {
+      "id": 14,
+      "subject": "Payment failed",
+      "email": "user23@corp.net",
+      "priority": "medium",
+      "category": "technical",
+      "status": "pending",
+      "created_date": "2025-08-20"
+    },
+    {
+      "id": 15,
+      "subject": "Cannot login to account",
+      "email": "user60@yahoo.com",
+      "priority": "high",
+      "category": "general",
+      "status": "pending",
+      "created_date": "2024-09-01"
+    },
+    {
+      "id": 16,
+      "subject": "Password reset not received",
+      "email": "user97@corp.net",
+      "priority": "low",
+      "category": "general",
+      "status": "closed",
+      "created_date": "2025-10-10"
+    },
+    {
+      "id": 17,
+      "subject": "Account suspended",
+      "email": "user134@yahoo.com",
+      "priority": "medium",
+      "category": "general",
+      "status": "open",
+      "created_date": "2024-11-19"
+    },
+    {
+      "id": 18,
+      "subject": "Invoice discrepancy",
+      "email": "user171@example.com",
+      "priority": "high",
+      "category": "general",
+      "status": "pending",
+      "created_date": "2025-12-28"
+    },
+    {
+      "id": 19,
+      "subject": "Billing cycle question",
+      "email": "user208@yahoo.com",
+      "priority": "low",
+      "category": "billing",
+      "status": "pending",
+      "created_date": "2024-01-09"
+    },
+    {
+      "id": 20,
+      "subject": "Data export issue",
+      "email": "user245@example.com",
+      "priority": "medium",
+      "category": "billing",
+      "status": "closed",
+      "created_date": "2025-02-18"
+    },
+    {
+      "id": 21,
+      "subject": "Feature not working",
+      "email": "user282@gmail.com",
+      "priority": "high",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2024-03-27"
+    },
+    {
+      "id": 22,
+      "subject": "Integration broken",
+      "email": "user319@example.com",
+      "priority": "low",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2025-04-08"
+    },
+    {
+      "id": 23,
+      "subject": "API rate limit exceeded",
+      "email": "user356@gmail.com",
+      "priority": "medium",
+      "category": "technical",
+      "status": "pending",
+      "created_date": "2024-05-17"
+    },
+    {
+      "id": 24,
+      "subject": "Payment failed",
+      "email": "user393@company.io",
+      "priority": "high",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2025-06-26"
+    },
+    {
+      "id": 25,
+      "subject": "Cannot login to account",
+      "email": "user430@gmail.com",
+      "priority": "low",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2024-07-07"
+    },
+    {
+      "id": 26,
+      "subject": "Password reset not received",
+      "email": "user467@company.io",
+      "priority": "medium",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2025-08-16"
+    },
+    {
+      "id": 27,
+      "subject": "Account suspended",
+      "email": "user4@yahoo.com",
+      "priority": "medium",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2024-05-05"
+    },
+    {
+      "id": 28,
+      "subject": "Invoice discrepancy",
+      "email": "user41@example.com",
+      "priority": "high",
+      "category": "technical",
+      "status": "pending",
+      "created_date": "2025-06-14"
+    },
+    {
+      "id": 29,
+      "subject": "Billing cycle question",
+      "email": "user78@yahoo.com",
+      "priority": "low",
+      "category": "technical",
+      "status": "pending",
+      "created_date": "2024-07-23"
+    },
+    {
+      "id": 30,
+      "subject": "Data export issue",
+      "email": "user115@example.com",
+      "priority": "medium",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2025-08-04"
+    },
+    {
+      "id": 31,
+      "subject": "Feature not working",
+      "email": "user152@gmail.com",
+      "priority": "high",
+      "category": "general",
+      "status": "open",
+      "created_date": "2024-09-13"
+    },
+    {
+      "id": 32,
+      "subject": "Integration broken",
+      "email": "user189@example.com",
+      "priority": "low",
+      "category": "general",
+      "status": "open",
+      "created_date": "2025-10-22"
+    },
+    {
+      "id": 33,
+      "subject": "API rate limit exceeded",
+      "email": "user226@gmail.com",
+      "priority": "medium",
+      "category": "general",
+      "status": "pending",
+      "created_date": "2024-11-03"
+    },
+    {
+      "id": 34,
+      "subject": "Payment failed",
+      "email": "user263@company.io",
+      "priority": "high",
+      "category": "general",
+      "status": "closed",
+      "created_date": "2025-12-12"
+    },
+    {
+      "id": 35,
+      "subject": "Cannot login to account",
+      "email": "user300@gmail.com",
+      "priority": "low",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2024-01-21"
+    },
+    {
+      "id": 36,
+      "subject": "Password reset not received",
+      "email": "user337@company.io",
+      "priority": "medium",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2025-02-02"
+    },
+    {
+      "id": 37,
+      "subject": "Account suspended",
+      "email": "user374@corp.net",
+      "priority": "high",
+      "category": "billing",
+      "status": "pending",
+      "created_date": "2024-03-11"
+    },
+    {
+      "id": 38,
+      "subject": "Invoice discrepancy",
+      "email": "user411@company.io",
+      "priority": "low",
+      "category": "billing",
+      "status": "closed",
+      "created_date": "2025-04-20"
+    },
+    {
+      "id": 39,
+      "subject": "Billing cycle question",
+      "email": "user448@corp.net",
+      "priority": "medium",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2024-05-01"
+    },
+    {
+      "id": 40,
+      "subject": "Data export issue",
+      "email": "user485@yahoo.com",
+      "priority": "high",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2025-06-10"
+    },
+    {
+      "id": 41,
+      "subject": "Feature not working",
+      "email": "user22@corp.net",
+      "priority": "low",
+      "category": "technical",
+      "status": "pending",
+      "created_date": "2024-07-19"
+    },
+    {
+      "id": 42,
+      "subject": "Integration broken",
+      "email": "user59@yahoo.com",
+      "priority": "medium",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2025-08-28"
+    },
+    {
+      "id": 43,
+      "subject": "API rate limit exceeded",
+      "email": "user96@example.com",
+      "priority": "high",
+      "category": "general",
+      "status": "closed",
+      "created_date": "2024-09-09"
+    },
+    {
+      "id": 44,
+      "subject": "Payment failed",
+      "email": "user133@yahoo.com",
+      "priority": "low",
+      "category": "general",
+      "status": "open",
+      "created_date": "2025-10-18"
+    },
+    {
+      "id": 45,
+      "subject": "Cannot login to account",
+      "email": "user170@example.com",
+      "priority": "medium",
+      "category": "general",
+      "status": "pending",
+      "created_date": "2024-11-27"
+    },
+    {
+      "id": 46,
+      "subject": "Password reset not received",
+      "email": "user207@gmail.com",
+      "priority": "high",
+      "category": "general",
+      "status": "pending",
+      "created_date": "2025-12-08"
+    },
+    {
+      "id": 47,
+      "subject": "Account suspended",
+      "email": "user244@example.com",
+      "priority": "low",
+      "category": "billing",
+      "status": "closed",
+      "created_date": "2024-01-17"
+    },
+    {
+      "id": 48,
+      "subject": "Invoice discrepancy",
+      "email": "user281@gmail.com",
+      "priority": "medium",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2025-02-26"
+    },
+    {
+      "id": 49,
+      "subject": "Billing cycle question",
+      "email": "user318@company.io",
+      "priority": "high",
+      "category": "billing",
+      "status": "pending",
+      "created_date": "2024-03-07"
+    },
+    {
+      "id": 50,
+      "subject": "Data export issue",
+      "email": "user355@gmail.com",
+      "priority": "low",
+      "category": "billing",
+      "status": "pending",
+      "created_date": "2025-04-16"
+    },
+    {
+      "id": 51,
+      "subject": "Feature not working",
+      "email": "user392@company.io",
+      "priority": "medium",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2024-05-25"
+    },
+    {
+      "id": 52,
+      "subject": "Integration broken",
+      "email": "user429@corp.net",
+      "priority": "high",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2025-06-06"
+    },
+    {
+      "id": 53,
+      "subject": "API rate limit exceeded",
+      "email": "user466@company.io",
+      "priority": "low",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2024-07-15"
+    },
+    {
+      "id": 54,
+      "subject": "Payment failed",
+      "email": "user3@yahoo.com",
+      "priority": "low",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2025-04-04"
+    },
+    {
+      "id": 55,
+      "subject": "Cannot login to account",
+      "email": "user40@example.com",
+      "priority": "medium",
+      "category": "technical",
+      "status": "pending",
+      "created_date": "2024-05-13"
+    },
+    {
+      "id": 56,
+      "subject": "Password reset not received",
+      "email": "user77@gmail.com",
+      "priority": "high",
+      "category": "technical",
+      "status": "pending",
+      "created_date": "2025-06-22"
+    },
+    {
+      "id": 57,
+      "subject": "Account suspended",
+      "email": "user114@example.com",
+      "priority": "low",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2024-07-03"
+    },
+    {
+      "id": 58,
+      "subject": "Invoice discrepancy",
+      "email": "user151@gmail.com",
+      "priority": "medium",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2025-08-12"
+    },
+    {
+      "id": 59,
+      "subject": "Billing cycle question",
+      "email": "user188@company.io",
+      "priority": "high",
+      "category": "general",
+      "status": "pending",
+      "created_date": "2024-09-21"
+    },
+    {
+      "id": 60,
+      "subject": "Data export issue",
+      "email": "user225@gmail.com",
+      "priority": "low",
+      "category": "general",
+      "status": "pending",
+      "created_date": "2025-10-02"
+    },
+    {
+      "id": 61,
+      "subject": "Feature not working",
+      "email": "user262@company.io",
+      "priority": "medium",
+      "category": "general",
+      "status": "closed",
+      "created_date": "2024-11-11"
+    },
+    {
+      "id": 62,
+      "subject": "Integration broken",
+      "email": "user299@corp.net",
+      "priority": "high",
+      "category": "general",
+      "status": "open",
+      "created_date": "2025-12-20"
+    },
+    {
+      "id": 63,
+      "subject": "API rate limit exceeded",
+      "email": "user336@company.io",
+      "priority": "low",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2024-01-01"
+    },
+    {
+      "id": 64,
+      "subject": "Payment failed",
+      "email": "user373@corp.net",
+      "priority": "medium",
+      "category": "billing",
+      "status": "pending",
+      "created_date": "2025-02-10"
+    },
+    {
+      "id": 65,
+      "subject": "Cannot login to account",
+      "email": "user410@yahoo.com",
+      "priority": "high",
+      "category": "billing",
+      "status": "closed",
+      "created_date": "2024-03-19"
+    },
+    {
+      "id": 66,
+      "subject": "Password reset not received",
+      "email": "user447@corp.net",
+      "priority": "low",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2025-04-28"
+    },
+    {
+      "id": 67,
+      "subject": "Account suspended",
+      "email": "user484@yahoo.com",
+      "priority": "medium",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2024-05-09"
+    },
+    {
+      "id": 68,
+      "subject": "Invoice discrepancy",
+      "email": "user21@example.com",
+      "priority": "high",
+      "category": "technical",
+      "status": "pending",
+      "created_date": "2025-06-18"
+    },
+    {
+      "id": 69,
+      "subject": "Billing cycle question",
+      "email": "user58@yahoo.com",
+      "priority": "low",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2024-07-27"
+    },
+    {
+      "id": 70,
+      "subject": "Data export issue",
+      "email": "user95@example.com",
+      "priority": "medium",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2025-08-08"
+    },
+    {
+      "id": 71,
+      "subject": "Feature not working",
+      "email": "user132@gmail.com",
+      "priority": "high",
+      "category": "general",
+      "status": "open",
+      "created_date": "2024-09-17"
+    },
+    {
+      "id": 72,
+      "subject": "Integration broken",
+      "email": "user169@example.com",
+      "priority": "low",
+      "category": "general",
+      "status": "pending",
+      "created_date": "2025-10-26"
+    },
+    {
+      "id": 73,
+      "subject": "API rate limit exceeded",
+      "email": "user206@gmail.com",
+      "priority": "medium",
+      "category": "general",
+      "status": "closed",
+      "created_date": "2024-11-07"
+    },
+    {
+      "id": 74,
+      "subject": "Payment failed",
+      "email": "user243@company.io",
+      "priority": "high",
+      "category": "general",
+      "status": "closed",
+      "created_date": "2025-12-16"
+    },
+    {
+      "id": 75,
+      "subject": "Cannot login to account",
+      "email": "user280@gmail.com",
+      "priority": "low",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2024-01-25"
+    },
+    {
+      "id": 76,
+      "subject": "Password reset not received",
+      "email": "user317@company.io",
+      "priority": "medium",
+      "category": "billing",
+      "status": "pending",
+      "created_date": "2025-02-06"
+    },
+    {
+      "id": 77,
+      "subject": "Account suspended",
+      "email": "user354@corp.net",
+      "priority": "high",
+      "category": "billing",
+      "status": "pending",
+      "created_date": "2024-03-15"
+    },
+    {
+      "id": 78,
+      "subject": "Invoice discrepancy",
+      "email": "user391@company.io",
+      "priority": "low",
+      "category": "billing",
+      "status": "closed",
+      "created_date": "2025-04-24"
+    },
+    {
+      "id": 79,
+      "subject": "Billing cycle question",
+      "email": "user428@corp.net",
+      "priority": "medium",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2024-05-05"
+    },
+    {
+      "id": 80,
+      "subject": "Data export issue",
+      "email": "user465@yahoo.com",
+      "priority": "high",
+      "category": "technical",
+      "status": "pending",
+      "created_date": "2025-06-14"
+    },
+    {
+      "id": 81,
+      "subject": "Feature not working",
+      "email": "user2@gmail.com",
+      "priority": "high",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2024-03-03"
+    },
+    {
+      "id": 82,
+      "subject": "Integration broken",
+      "email": "user39@example.com",
+      "priority": "low",
+      "category": "billing",
+      "status": "pending",
+      "created_date": "2025-04-12"
+    },
+    {
+      "id": 83,
+      "subject": "API rate limit exceeded",
+      "email": "user76@gmail.com",
+      "priority": "medium",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2024-05-21"
+    },
+    {
+      "id": 84,
+      "subject": "Payment failed",
+      "email": "user113@company.io",
+      "priority": "high",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2025-06-02"
+    },
+    {
+      "id": 85,
+      "subject": "Cannot login to account",
+      "email": "user150@gmail.com",
+      "priority": "low",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2024-07-11"
+    },
+    {
+      "id": 86,
+      "subject": "Password reset not received",
+      "email": "user187@company.io",
+      "priority": "medium",
+      "category": "technical",
+      "status": "pending",
+      "created_date": "2025-08-20"
+    },
+    {
+      "id": 87,
+      "subject": "Account suspended",
+      "email": "user224@corp.net",
+      "priority": "high",
+      "category": "general",
+      "status": "pending",
+      "created_date": "2024-09-01"
+    },
+    {
+      "id": 88,
+      "subject": "Invoice discrepancy",
+      "email": "user261@company.io",
+      "priority": "low",
+      "category": "general",
+      "status": "closed",
+      "created_date": "2025-10-10"
+    },
+    {
+      "id": 89,
+      "subject": "Billing cycle question",
+      "email": "user298@corp.net",
+      "priority": "medium",
+      "category": "general",
+      "status": "open",
+      "created_date": "2024-11-19"
+    },
+    {
+      "id": 90,
+      "subject": "Data export issue",
+      "email": "user335@yahoo.com",
+      "priority": "high",
+      "category": "general",
+      "status": "pending",
+      "created_date": "2025-12-28"
+    },
+    {
+      "id": 91,
+      "subject": "Feature not working",
+      "email": "user372@corp.net",
+      "priority": "low",
+      "category": "billing",
+      "status": "pending",
+      "created_date": "2024-01-09"
+    },
+    {
+      "id": 92,
+      "subject": "Integration broken",
+      "email": "user409@yahoo.com",
+      "priority": "medium",
+      "category": "billing",
+      "status": "closed",
+      "created_date": "2025-02-18"
+    },
+    {
+      "id": 93,
+      "subject": "API rate limit exceeded",
+      "email": "user446@example.com",
+      "priority": "high",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2024-03-27"
+    },
+    {
+      "id": 94,
+      "subject": "Payment failed",
+      "email": "user483@yahoo.com",
+      "priority": "low",
+      "category": "billing",
+      "status": "open",
+      "created_date": "2025-04-08"
+    },
+    {
+      "id": 95,
+      "subject": "Cannot login to account",
+      "email": "user20@example.com",
+      "priority": "medium",
+      "category": "technical",
+      "status": "pending",
+      "created_date": "2024-05-17"
+    },
+    {
+      "id": 96,
+      "subject": "Password reset not received",
+      "email": "user57@gmail.com",
+      "priority": "high",
+      "category": "technical",
+      "status": "closed",
+      "created_date": "2025-06-26"
+    },
+    {
+      "id": 97,
+      "subject": "Account suspended",
+      "email": "user94@example.com",
+      "priority": "low",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2024-07-07"
+    },
+    {
+      "id": 98,
+      "subject": "Invoice discrepancy",
+      "email": "user131@gmail.com",
+      "priority": "medium",
+      "category": "technical",
+      "status": "open",
+      "created_date": "2025-08-16"
+    },
+    {
+      "id": 99,
+      "subject": "Billing cycle question",
+      "email": "user168@company.io",
+      "priority": "high",
+      "category": "general",
+      "status": "pending",
+      "created_date": "2024-09-25"
+    },
+    {
+      "id": 100,
+      "subject": "Data export issue",
+      "email": "user205@gmail.com",
+      "priority": "low",
+      "category": "general",
+      "status": "closed",
+      "created_date": "2025-10-06"
+    }
+  ]
+}

--- a/packages/benchmark/src/bricks_benchmark/web/presets/crm_pipeline.yaml
+++ b/packages/benchmark/src/bricks_benchmark/web/presets/crm_pipeline.yaml
@@ -1,0 +1,17 @@
+name: CRM Pipeline
+description: Filter active CRM customers and compute revenue statistics
+dataset_id: crm-customers
+task_text: |
+  Parse the JSON customer data. Filter to only active customers (status = "active").
+  Calculate: total number of active customers (active_count), sum of their monthly_revenue
+  (total_active_revenue), and average revenue per active customer (avg_active_revenue).
+expected_outputs:
+  active_count: 9
+  total_active_revenue: 1524.0
+  avg_active_revenue: 169.33
+required_bricks:
+  - extract_json_from_str
+  - filter_dict_list
+  - calculate_aggregates
+  - count_dict_list
+model: claudecode

--- a/packages/benchmark/src/bricks_benchmark/web/presets/ticket_pipeline.yaml
+++ b/packages/benchmark/src/bricks_benchmark/web/presets/ticket_pipeline.yaml
@@ -1,0 +1,17 @@
+name: Support Ticket Pipeline
+description: Find high-priority open tickets and count by category
+dataset_id: support-tickets
+task_text: |
+  Parse the JSON ticket data. Filter to tickets with priority="high" AND status="open".
+  Count the total (open_high_count), then count by category:
+  billing (billing_count), technical (technical_count), general (general_count).
+expected_outputs:
+  open_high_count: 9
+  billing_count: 4
+  technical_count: 2
+  general_count: 3
+required_bricks:
+  - extract_json_from_str
+  - filter_dict_list
+  - count_dict_list
+model: claudecode

--- a/packages/benchmark/src/bricks_benchmark/web/routes.py
+++ b/packages/benchmark/src/bricks_benchmark/web/routes.py
@@ -1,0 +1,181 @@
+"""API route handlers for the Bricks Benchmark web server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from bricks_benchmark.web.datasets import DatasetLoader
+from bricks_benchmark.web.schemas import BenchmarkRequest, BenchmarkResponse, EngineResultResponse
+
+router = APIRouter()
+
+_loader = DatasetLoader()
+_PRESETS_DIR = Path(__file__).parent / "presets"
+
+_CLAUDECODE_MODEL = "claudecode"
+
+
+def _build_provider(model: str) -> Any:
+    """Return an LLMProvider for the given model string.
+
+    ``'claudecode'`` routes through ClaudeCodeProvider. Any other string is
+    passed to LiteLLMProvider.
+
+    Args:
+        model: Model string — ``'claudecode'`` or a LiteLLM model string.
+
+    Returns:
+        An LLMProvider instance.
+    """
+    if model == _CLAUDECODE_MODEL:
+        from bricks_provider_claudecode import ClaudeCodeProvider  # type: ignore[import-untyped]
+
+        return ClaudeCodeProvider(timeout=300)
+
+    from bricks.llm.litellm_provider import LiteLLMProvider
+
+    return LiteLLMProvider(model=model)
+
+
+# ── /api/run ────────────────────────────────────────────────────────────────
+
+
+@router.post("/api/run", response_model=BenchmarkResponse)
+async def run_benchmark(req: BenchmarkRequest) -> BenchmarkResponse:
+    """Run both BricksEngine and RawLLMEngine on the same task, return comparison.
+
+    Args:
+        req: Benchmark request with task text, raw data, and optional settings.
+
+    Returns:
+        BenchmarkResponse with results from both engines and token savings stats.
+
+    Raises:
+        HTTPException: If engine construction fails (e.g. missing API key).
+    """
+    from bricks_benchmark.showcase.engine import BricksEngine, RawLLMEngine
+    from bricks_benchmark.showcase.result_writer import check_correctness
+
+    try:
+        provider = _build_provider(req.model)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Failed to build provider: {exc}") from exc
+
+    bricks_engine = BricksEngine(provider=provider)
+    llm_engine = RawLLMEngine(provider=provider)
+
+    bricks_raw = bricks_engine.solve(req.task_text, req.raw_data)
+    llm_raw = llm_engine.solve(req.task_text, req.raw_data)
+
+    bricks_correct: bool | None = None
+    llm_correct: bool | None = None
+    if req.expected_outputs is not None:
+        bricks_correct = check_correctness(bricks_raw.outputs, req.expected_outputs)
+        llm_correct = check_correctness(llm_raw.outputs, req.expected_outputs)
+
+    bricks_tokens = bricks_raw.tokens_in + bricks_raw.tokens_out
+    llm_tokens = llm_raw.tokens_in + llm_raw.tokens_out
+
+    savings_ratio = (llm_tokens / bricks_tokens) if bricks_tokens > 0 else 1.0
+    savings_percent = ((1 - bricks_tokens / llm_tokens) * 100) if llm_tokens > 0 else 0.0
+
+    return BenchmarkResponse(
+        bricks_result=EngineResultResponse(
+            engine_name="BricksEngine",
+            outputs=bricks_raw.outputs,
+            correct=bricks_correct,
+            tokens_in=bricks_raw.tokens_in,
+            tokens_out=bricks_raw.tokens_out,
+            duration_seconds=bricks_raw.duration_seconds,
+            model=bricks_raw.model,
+            raw_response=bricks_raw.raw_response,
+            error=bricks_raw.error,
+        ),
+        llm_result=EngineResultResponse(
+            engine_name="RawLLMEngine",
+            outputs=llm_raw.outputs,
+            correct=llm_correct,
+            tokens_in=llm_raw.tokens_in,
+            tokens_out=llm_raw.tokens_out,
+            duration_seconds=llm_raw.duration_seconds,
+            model=llm_raw.model,
+            raw_response=llm_raw.raw_response,
+            error=llm_raw.error,
+        ),
+        savings_ratio=round(savings_ratio, 2),
+        savings_percent=round(savings_percent, 1),
+    )
+
+
+# ── /api/datasets ────────────────────────────────────────────────────────────
+
+
+@router.get("/api/datasets")
+async def list_datasets() -> list[dict[str, Any]]:
+    """Return all built-in datasets with metadata, preview, and full data.
+
+    Returns:
+        List of dataset dicts with id, name, description, row_count, fields,
+        preview (first 3 rows), and full_data (JSON string).
+    """
+    return _loader.list_datasets()
+
+
+# ── /api/bricks ──────────────────────────────────────────────────────────────
+
+
+@router.get("/api/bricks")
+async def list_bricks() -> list[dict[str, Any]]:
+    """Return all registered stdlib bricks with name, description, and category.
+
+    Returns:
+        List of dicts with ``name``, ``description``, and ``category`` for each brick.
+    """
+    from bricks.core.registry import BrickRegistry
+
+    registry = BrickRegistry.from_stdlib()
+    return [
+        {
+            "name": name,
+            "description": meta.description,
+            "category": meta.category,
+        }
+        for name, meta in registry.list_all()
+    ]
+
+
+# ── /api/presets ─────────────────────────────────────────────────────────────
+
+
+@router.get("/api/presets")
+async def list_presets() -> list[dict[str, Any]]:
+    """Return preset benchmark scenarios from the presets directory.
+
+    Returns:
+        List of preset dicts with name, dataset_id, task_text, and expected_outputs.
+    """
+    import yaml
+
+    presets: list[dict[str, Any]] = []
+    if not _PRESETS_DIR.exists():
+        return presets
+
+    for path in sorted(_PRESETS_DIR.glob("*.yaml")):
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and "name" in data:
+                presets.append(
+                    {
+                        "name": data.get("name", ""),
+                        "dataset_id": data.get("dataset_id"),
+                        "task_text": data.get("task_text", ""),
+                        "expected_outputs": data.get("expected_outputs"),
+                    }
+                )
+        except Exception:  # noqa: S112
+            continue
+
+    return presets

--- a/packages/benchmark/src/bricks_benchmark/web/schemas.py
+++ b/packages/benchmark/src/bricks_benchmark/web/schemas.py
@@ -1,0 +1,67 @@
+"""Pydantic v2 schemas for the Bricks Benchmark web API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class BenchmarkRequest(BaseModel):
+    """Request body for POST /api/run.
+
+    Attributes:
+        task_text: Natural language description of the computation task.
+        raw_data: JSON string containing the input data.
+        expected_outputs: Optional ground-truth outputs for correctness checking.
+        required_bricks: Optional list of brick names to hint the composer.
+        model: LLM model string (default: ``'claudecode'``).
+    """
+
+    task_text: str
+    raw_data: str
+    expected_outputs: dict[str, Any] | None = None
+    required_bricks: list[str] | None = None
+    model: str = "claudecode"
+
+
+class EngineResultResponse(BaseModel):
+    """Result from one engine for one benchmark run.
+
+    Attributes:
+        engine_name: Class name of the engine (e.g. ``'BricksEngine'``).
+        outputs: Parsed structured outputs from the engine.
+        correct: True/False if expected_outputs were provided, None otherwise.
+        tokens_in: Input token count.
+        tokens_out: Output token count.
+        duration_seconds: Wall-clock time for this run.
+        model: Model identifier string used.
+        raw_response: Full LLM response text (YAML blueprint or JSON).
+        error: Non-empty string if the engine failed.
+    """
+
+    engine_name: str
+    outputs: dict[str, Any]
+    correct: bool | None
+    tokens_in: int
+    tokens_out: int
+    duration_seconds: float
+    model: str
+    raw_response: str
+    error: str
+
+
+class BenchmarkResponse(BaseModel):
+    """Complete benchmark comparison response.
+
+    Attributes:
+        bricks_result: Result from BricksEngine.
+        llm_result: Result from RawLLMEngine.
+        savings_ratio: llm_total_tokens / bricks_total_tokens (1.0 if bricks used 0 tokens).
+        savings_percent: ``(1 - bricks_tokens / llm_tokens) * 100``.
+    """
+
+    bricks_result: EngineResultResponse
+    llm_result: EngineResultResponse
+    savings_ratio: float
+    savings_percent: float

--- a/packages/benchmark/src/bricks_benchmark/web/ticket_generator.py
+++ b/packages/benchmark/src/bricks_benchmark/web/ticket_generator.py
@@ -1,0 +1,142 @@
+"""Support ticket data generator — deterministic 100-record dataset for benchmark scenarios."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class TicketRecord(BaseModel):
+    """A single support ticket record."""
+
+    id: int
+    subject: str
+    email: str
+    priority: str  # "low" | "medium" | "high"
+    category: str  # "billing" | "technical" | "general"
+    status: str  # "open" | "closed" | "pending"
+    created_date: str
+
+
+class TicketTask(BaseModel):
+    """A support ticket benchmark task with expected outputs."""
+
+    task_text: str
+    raw_api_response: str
+    expected_outputs: dict[str, Any]
+    required_bricks: list[str]
+
+
+_PRIORITIES = ["low", "medium", "high"]
+_CATEGORIES = ["billing", "technical", "general"]
+_STATUSES = ["open", "closed", "pending"]
+
+_SUBJECTS = [
+    "Cannot login to account",
+    "Invoice discrepancy",
+    "Feature not working",
+    "Payment failed",
+    "Account suspended",
+    "Data export issue",
+    "API rate limit exceeded",
+    "Password reset not received",
+    "Billing cycle question",
+    "Integration broken",
+]
+
+_DOMAINS = ["gmail.com", "yahoo.com", "company.io", "example.com", "corp.net"]
+
+
+def _make_ticket(i: int, seed: int) -> TicketRecord:
+    """Generate a single ticket record deterministically from index and seed.
+
+    Args:
+        i: Record index (0-based).
+        seed: Integer seed for deterministic generation.
+
+    Returns:
+        A deterministic TicketRecord.
+    """
+    combined = (i * 37 + seed) % 1000
+    subject = _SUBJECTS[combined % len(_SUBJECTS)]
+    domain = _DOMAINS[(combined // 3) % len(_DOMAINS)]
+    priority = _PRIORITIES[combined % len(_PRIORITIES)]
+    category = _CATEGORIES[(combined // 4) % len(_CATEGORIES)]
+    status = _STATUSES[(combined // 7) % len(_STATUSES)]
+    year = 2024 + (i % 2)
+    month = 1 + (combined % 12)
+    day = 1 + (combined % 28)
+    created_date = f"{year}-{month:02d}-{day:02d}"
+    user_num = combined % 500
+    return TicketRecord(
+        id=i + 1,
+        subject=subject,
+        email=f"user{user_num}@{domain}",
+        priority=priority,
+        category=category,
+        status=status,
+        created_date=created_date,
+    )
+
+
+def _compute_expected(records: list[TicketRecord]) -> dict[str, Any]:
+    """Compute expected outputs: high-priority open ticket counts by category.
+
+    Args:
+        records: List of ticket records.
+
+    Returns:
+        Dict with open_high_count and counts per category for high+open tickets.
+    """
+    high_open = [r for r in records if r.priority == "high" and r.status == "open"]
+    by_category: dict[str, int] = {}
+    for r in high_open:
+        by_category[r.category] = by_category.get(r.category, 0) + 1
+    return {
+        "open_high_count": len(high_open),
+        "billing_count": by_category.get("billing", 0),
+        "technical_count": by_category.get("technical", 0),
+        "general_count": by_category.get("general", 0),
+    }
+
+
+def generate_ticket_task(seed: int = 42) -> TicketTask:
+    """Generate a support ticket benchmark task with 100 deterministic records.
+
+    Args:
+        seed: Integer seed for deterministic generation.
+
+    Returns:
+        TicketTask with raw API response, expected outputs, and required brick list.
+    """
+    records = [_make_ticket(i, seed) for i in range(100)]
+    records_dicts = [r.model_dump() for r in records]
+    raw_json = json.dumps({"tickets": records_dicts}, indent=2)
+    raw_api_response = f"```json\n{raw_json}\n```"
+    expected = _compute_expected(records)
+    return TicketTask(
+        task_text=(
+            "The input 'raw_api_response' is a markdown-fenced JSON string "
+            "containing a dict with key 'tickets' — a list of objects with fields: "
+            "id, subject, email, priority (low/medium/high), category (billing/technical/general), "
+            "status (open/closed/pending), created_date. "
+            "Parse the JSON string, filter for priority='high' AND status='open', "
+            "count the total (save as 'open_high_count'), "
+            "then count how many are in each category: "
+            "billing (save as 'billing_count'), "
+            "technical (save as 'technical_count'), "
+            "general (save as 'general_count'). "
+            "Use count_dict_list for counting. "
+            "The outputs_map must use exactly these keys: "
+            "open_high_count, billing_count, technical_count, general_count."
+        ),
+        raw_api_response=raw_api_response,
+        expected_outputs=expected,
+        required_bricks=[
+            "extract_json_from_str",
+            "filter_dict_list",
+            "count_dict_list",
+        ],
+    )

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bricks-ai"
-version = "0.5.0"
+version = "0.5.1"
 description = "Deterministic execution engine: typed Python building blocks composed into auditable YAML blueprints."
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -6,7 +6,7 @@ from bricks.core.dag_builder import DAGBuilder
 from bricks.core.dsl import Node, branch, flow, for_each, step
 from bricks.core.engine import DAGExecutionEngine
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = [
     "DAG",


### PR DESCRIPTION
## Summary
- FastAPI server at `python -m bricks_benchmark.web` (port 8742) with 4 API endpoints
- Built-in datasets: CRM customers, support tickets, orders+customers (JSON files)
- New `ticket_generator.py` for deterministic 100-record support ticket data
- Pydantic v2 schemas for request/response; savings ratio computed from token counts
- 24 new tests for schemas and dataset loading (no live LLM calls)

## Test plan
- [ ] `python -m pytest` passes (24 new tests, pre-existing litellm/mcp failures unrelated)
- [ ] `ruff check .` clean
- [ ] `mypy packages/core/src/bricks --strict` clean
- [ ] `GET /api/datasets` returns 3 datasets with preview
- [ ] `GET /api/bricks` returns stdlib bricks list
- [ ] `GET /api/presets` returns 2 presets
- [ ] `POST /api/run` runs both engines when live model provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)