### PR TITLE
Mission 068: Portable YAML scenario format + --custom CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.5.3] — 2026-04-07
+
+### Added
+- **Portable YAML scenario format** — `ScenarioDefinition` dataclass with three data sources: inline `data`, `data_file`, or `dataset_id`
+- `web/scenario_format.py` — `ScenarioDefinition` dataclass
+- `web/scenario_loader.py` — `load_scenario`, `export_scenario`, `scenario_to_benchmark_request`; clear `ValueError` messages on invalid input
+- **`--custom` CLI flag** — `python -m bricks_benchmark.showcase.run --live --custom scenario.yaml` runs both engines on any YAML scenario
+- 4 preset YAML files: `crm_pipeline`, `ticket_pipeline`, `cross_dataset_join`, `custom_example`
+- `examples/` directory with `basic_custom.yaml`, `file_reference.yaml`, `no_expected.yaml`, `sample_data.json`
+- `packages/benchmark/README.md` — CLI, web GUI, custom scenarios, API reference, architecture
+- mypy override for `yaml` (PyYAML) in root `pyproject.toml`
+
 ## [0.5.2] — 2026-04-07
 
 ### Added

--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -1,0 +1,119 @@
+# Bricks Benchmark
+
+Controlled benchmark comparing **BricksEngine** (deterministic YAML blueprint execution) against **RawLLMEngine** (direct LLM data processing) on identical inputs with the same correctness checker. One variable changes at a time — the system under test — everything else is identical.
+
+---
+
+## Quick Start
+
+### CLI
+
+```bash
+# Run all built-in scenarios with ClaudeCode (free on Max plan)
+python -m bricks_benchmark.showcase.run --live
+
+# Run a single scenario
+python -m bricks_benchmark.showcase.run --live --scenario CRM-pipeline
+
+# Use a different LLM
+python -m bricks_benchmark.showcase.run --live --model gpt-4o-mini
+python -m bricks_benchmark.showcase.run --live --model gemini/gemini-2.0-flash
+
+# Run a custom scenario from a YAML file
+python -m bricks_benchmark.showcase.run --live --custom examples/basic_custom.yaml
+```
+
+### Web GUI
+
+```bash
+python -m bricks_benchmark.web
+```
+
+Open `http://localhost:8742` in your browser. The 3-step interface lets you:
+1. Pick a built-in dataset or paste your own JSON
+2. Write a task description
+3. See BricksEngine vs RawLLMEngine results side-by-side
+
+---
+
+## Custom Scenarios
+
+Define any benchmark task as a YAML file and run it with `--custom`:
+
+```yaml
+name: My Custom Scenario
+description: Filter products and compute inventory stats
+task_text: |
+  Parse the JSON product data. Filter to in-stock items (quantity > 0).
+  Count them (in_stock_count) and calculate total inventory value (total_value).
+data:
+  - {id: 1, name: Widget, quantity: 10, price: 9.99}
+  - {id: 2, name: Gadget, quantity: 0, price: 24.99}
+  - {id: 3, name: Doohickey, quantity: 5, price: 4.99}
+expected_outputs:
+  in_stock_count: 2
+  total_value: 124.85
+model: claudecode
+```
+
+Three data source options (use exactly one):
+
+| Option | Description |
+|---|---|
+| `data: [...]` | Inline list of records |
+| `data_file: path/to/data.json` | Reference an external JSON file |
+| `dataset_id: crm-customers` | Use a built-in dataset |
+
+Run it:
+```bash
+python -m bricks_benchmark.showcase.run --live --custom my_scenario.yaml
+```
+
+See `examples/` for ready-to-run examples.
+
+---
+
+## Built-in Datasets
+
+| ID | Name | Records | Fields |
+|---|---|---|---|
+| `crm-customers` | CRM Customers | 25 | id, name, email, status, monthly_revenue, signup_date |
+| `support-tickets` | Support Tickets | 100 | id, subject, email, priority, category, status, created_date |
+| `orders-customers` | Orders and Customers | 50 orders + 30 customers | order_id, customer_id, amount, status; id, name, email, plan |
+
+---
+
+## API Reference
+
+The web server exposes four endpoints:
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/api/datasets` | GET | List built-in datasets with preview and full data |
+| `/api/bricks` | GET | List all registered stdlib bricks with name + description |
+| `/api/presets` | GET | List preset YAML scenarios |
+| `/api/run` | POST | Run BricksEngine and RawLLMEngine, return comparison |
+
+### POST /api/run
+
+```json
+{
+  "task_text": "Filter active customers and count them",
+  "raw_data": "[{\"id\": 1, \"status\": \"active\"}, ...]",
+  "expected_outputs": {"active_count": 3},
+  "required_bricks": ["filter_dict_list"],
+  "model": "claudecode"
+}
+```
+
+Response includes `bricks_result`, `llm_result`, `savings_ratio`, and `savings_percent`.
+
+---
+
+## Architecture
+
+**BricksEngine**: The LLM receives only brick function signatures and the task description. It composes a YAML blueprint naming which bricks to call and in what order. The engine executes that blueprint deterministically against the raw data. The LLM never sees the actual data values.
+
+**RawLLMEngine**: The LLM receives the full task description **and** the raw data. It processes everything in one shot and returns structured JSON. No intermediate steps, no determinism guarantee.
+
+The benchmark measures token efficiency (how many tokens each approach uses), correctness (does the output match ground truth), and latency. BricksEngine typically uses 60–80% fewer tokens because the LLM only processes small schema descriptions, not large data payloads.

--- a/packages/benchmark/examples/basic_custom.yaml
+++ b/packages/benchmark/examples/basic_custom.yaml
@@ -1,0 +1,16 @@
+name: Basic Custom Example
+description: Simplest possible custom scenario with 5 rows of inline data
+task_text: |
+  Parse the JSON sales data. Filter to sales with amount > 100.
+  Count the number of qualifying sales (high_value_count) and
+  calculate the total amount (high_value_total).
+data:
+  - {id: 1, rep: Alice, amount: 250.00, region: North}
+  - {id: 2, rep: Bob, amount: 75.00, region: South}
+  - {id: 3, rep: Carol, amount: 410.00, region: North}
+  - {id: 4, rep: Dave, amount: 90.00, region: East}
+  - {id: 5, rep: Eve, amount: 320.00, region: West}
+expected_outputs:
+  high_value_count: 3
+  high_value_total: 980.0
+model: claudecode

--- a/packages/benchmark/examples/file_reference.yaml
+++ b/packages/benchmark/examples/file_reference.yaml
@@ -1,0 +1,12 @@
+name: File Reference Example
+description: Scenario that loads data from an external JSON file instead of inline
+task_text: |
+  Parse the JSON inventory data. Filter to products with quantity > 0 (in-stock).
+  Count in-stock products by category: hardware_count and software_count.
+  Also calculate total inventory value for hardware items
+  (hardware_value = sum of quantity * unit_price for hardware products).
+data_file: sample_data.json
+expected_outputs:
+  hardware_count: 2
+  software_count: 3
+model: claudecode

--- a/packages/benchmark/examples/no_expected.yaml
+++ b/packages/benchmark/examples/no_expected.yaml
@@ -1,0 +1,15 @@
+name: Exploratory Mode Example
+description: Scenario without expected outputs — useful for open-ended analysis
+task_text: |
+  Parse the JSON sales data. Group by region and calculate: total sales amount
+  per region, number of sales per region, and average sale amount per region.
+  Return results as region_summary with one entry per region.
+data:
+  - {id: 1, rep: Alice, amount: 250.00, region: North}
+  - {id: 2, rep: Bob, amount: 75.00, region: South}
+  - {id: 3, rep: Carol, amount: 410.00, region: North}
+  - {id: 4, rep: Dave, amount: 90.00, region: East}
+  - {id: 5, rep: Eve, amount: 320.00, region: West}
+  - {id: 6, rep: Frank, amount: 180.00, region: South}
+  - {id: 7, rep: Grace, amount: 540.00, region: East}
+model: claudecode

--- a/packages/benchmark/examples/sample_data.json
+++ b/packages/benchmark/examples/sample_data.json
@@ -1,0 +1,8 @@
+[
+  {"id": 1, "product": "Widget A", "category": "hardware", "quantity": 150, "unit_price": 12.50},
+  {"id": 2, "product": "Widget B", "category": "hardware", "quantity": 80, "unit_price": 24.99},
+  {"id": 3, "product": "Service X", "category": "software", "quantity": 500, "unit_price": 9.99},
+  {"id": 4, "product": "Service Y", "category": "software", "quantity": 200, "unit_price": 49.99},
+  {"id": 5, "product": "Widget C", "category": "hardware", "quantity": 0, "unit_price": 5.99},
+  {"id": 6, "product": "Service Z", "category": "software", "quantity": 350, "unit_price": 19.99}
+]

--- a/packages/benchmark/src/bricks_benchmark/showcase/run.py
+++ b/packages/benchmark/src/bricks_benchmark/showcase/run.py
@@ -215,6 +215,68 @@ def _setup_logger(run_dir: Path) -> logging.Logger:
     return logging.getLogger("bricks")
 
 
+# ── custom scenario runner ───────────────────────────────────────────────────
+
+
+def _run_custom_scenario(yaml_path: str, model: str = DEFAULT_MODEL) -> None:
+    """Load a YAML scenario file and run both engines on it, printing results.
+
+    Args:
+        yaml_path: Path to the scenario YAML file.
+        model: LLM model string to use for both engines.
+    """
+    from bricks_benchmark.showcase.engine import BricksEngine, RawLLMEngine
+    from bricks_benchmark.showcase.scenario_runner import _print_side_by_side, run_scenario
+    from bricks_benchmark.web.scenario_loader import _resolve_raw_data, load_scenario
+
+    path = Path(yaml_path)
+    if not path.exists():
+        print(f"Error: scenario file not found: {yaml_path}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        scenario = load_scenario(path)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        raw_data = _resolve_raw_data(scenario, base_dir=path.parent)
+    except ValueError as exc:
+        print(f"Error resolving data: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\nScenario: {scenario.name}")
+    print(f"  {scenario.description}")
+    print(f"  Model: {model}")
+    print()
+
+    provider = _build_provider(model)
+    bricks_engine = BricksEngine(provider=provider)
+    llm_engine = RawLLMEngine(provider=provider)
+
+    # Adapt scenario to BenchmarkTask protocol (dataclass with required fields)
+    from dataclasses import dataclass
+
+    @dataclass
+    class _ScenarioTask:
+        task_text: str
+        raw_api_response: str
+        expected_outputs: dict[str, Any]
+        required_bricks: list[str]
+
+    task = _ScenarioTask(
+        task_text=scenario.task_text,
+        raw_api_response=raw_data,
+        expected_outputs=scenario.expected_outputs or {},
+        required_bricks=scenario.required_bricks or [],
+    )
+
+    bricks_result = run_scenario(bricks_engine, task)
+    llm_result = run_scenario(llm_engine, task)
+    _print_side_by_side(scenario.name, bricks_result, llm_result, 0)
+
+
 # ── CLI ─────────────────────────────────────────────────────────────────────
 
 
@@ -265,6 +327,17 @@ def main() -> None:
         default=False,
         help="Required. Make real LLM calls. Requires an API key (or --model claudecode).",
     )
+    parser.add_argument(
+        "--custom",
+        type=str,
+        default=None,
+        metavar="YAML_FILE",
+        help=(
+            "Path to a custom scenario YAML file. "
+            "Runs both engines on the scenario and prints a side-by-side comparison. "
+            "Example: --custom examples/basic_custom.yaml"
+        ),
+    )
     args = parser.parse_args()
 
     if not args.live:
@@ -279,6 +352,10 @@ def main() -> None:
         print("API key is read from env (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.),")
         print("or use --model claudecode for zero-cost runs inside a Claude Code session.")
         sys.exit(1)
+
+    if args.custom:
+        _run_custom_scenario(args.custom, model=args.model)
+        return
 
     raw_scenarios = args.scenarios or ["all"]
     scenarios = expand_scenarios(raw_scenarios)

--- a/packages/benchmark/src/bricks_benchmark/tests/test_scenario_loader.py
+++ b/packages/benchmark/src/bricks_benchmark/tests/test_scenario_loader.py
@@ -1,0 +1,286 @@
+"""Tests for web/scenario_loader.py — load_scenario, export_scenario, round-trip."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from bricks_benchmark.web.scenario_format import ScenarioDefinition
+from bricks_benchmark.web.scenario_loader import (
+    export_scenario,
+    load_scenario,
+    scenario_to_benchmark_request,
+)
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+_INLINE_DATA = [{"id": 1, "val": "a"}, {"id": 2, "val": "b"}]
+
+_MINIMAL_DOC: dict[str, Any] = {
+    "name": "test",
+    "description": "test scenario",
+    "task_text": "count items",
+    "data": _INLINE_DATA,
+}
+
+
+def _write_yaml(tmp_path: Path, doc: dict[str, Any], filename: str = "scenario.yaml") -> Path:
+    """Write a YAML doc to a temp file and return the path."""
+    path = tmp_path / filename
+    path.write_text(yaml.dump(doc), encoding="utf-8")
+    return path
+
+
+# ── load_scenario ─────────────────────────────────────────────────────────────
+
+
+def test_load_scenario_inline_data(tmp_path: Path) -> None:
+    """load_scenario returns ScenarioDefinition with inline data list."""
+    path = _write_yaml(tmp_path, _MINIMAL_DOC)
+    scenario = load_scenario(path)
+
+    assert scenario.name == "test"
+    assert scenario.description == "test scenario"
+    assert scenario.task_text == "count items"
+    assert scenario.data == _INLINE_DATA
+    assert scenario.data_file is None
+    assert scenario.dataset_id is None
+
+
+def test_load_scenario_default_model(tmp_path: Path) -> None:
+    """model defaults to 'claudecode' when not specified."""
+    path = _write_yaml(tmp_path, _MINIMAL_DOC)
+    scenario = load_scenario(path)
+    assert scenario.model == "claudecode"
+
+
+def test_load_scenario_explicit_model(tmp_path: Path) -> None:
+    """model is read from YAML when present."""
+    doc = {**_MINIMAL_DOC, "model": "gpt-4o-mini"}
+    path = _write_yaml(tmp_path, doc)
+    scenario = load_scenario(path)
+    assert scenario.model == "gpt-4o-mini"
+
+
+def test_load_scenario_with_expected_outputs(tmp_path: Path) -> None:
+    """expected_outputs are loaded when present."""
+    doc = {**_MINIMAL_DOC, "expected_outputs": {"count": 2, "total": 3.14}}
+    path = _write_yaml(tmp_path, doc)
+    scenario = load_scenario(path)
+    assert scenario.expected_outputs == {"count": 2, "total": 3.14}
+
+
+def test_load_scenario_expected_outputs_none_when_absent(tmp_path: Path) -> None:
+    """expected_outputs is None when not in YAML."""
+    path = _write_yaml(tmp_path, _MINIMAL_DOC)
+    scenario = load_scenario(path)
+    assert scenario.expected_outputs is None
+
+
+def test_load_scenario_dataset_id_source(tmp_path: Path) -> None:
+    """dataset_id data source is parsed correctly."""
+    doc = {
+        "name": "ds",
+        "description": "uses dataset_id",
+        "task_text": "filter",
+        "dataset_id": "crm-customers",
+    }
+    path = _write_yaml(tmp_path, doc)
+    scenario = load_scenario(path)
+    assert scenario.dataset_id == "crm-customers"
+    assert scenario.data is None
+    assert scenario.data_file is None
+
+
+def test_load_scenario_data_file_source(tmp_path: Path) -> None:
+    """data_file data source is parsed correctly."""
+    doc = {
+        "name": "file-test",
+        "description": "uses data_file",
+        "task_text": "count",
+        "data_file": "data.json",
+    }
+    path = _write_yaml(tmp_path, doc)
+    scenario = load_scenario(path)
+    assert scenario.data_file == "data.json"
+
+
+def test_load_scenario_missing_task_text_raises(tmp_path: Path) -> None:
+    """Missing task_text raises ValueError with clear message."""
+    doc = {"name": "x", "description": "y", "data": []}
+    path = _write_yaml(tmp_path, doc)
+    with pytest.raises(ValueError, match="task_text"):
+        load_scenario(path)
+
+
+def test_load_scenario_missing_name_raises(tmp_path: Path) -> None:
+    """Missing name raises ValueError."""
+    doc = {"description": "y", "task_text": "z", "data": []}
+    path = _write_yaml(tmp_path, doc)
+    with pytest.raises(ValueError, match="name"):
+        load_scenario(path)
+
+
+def test_load_scenario_no_data_source_raises(tmp_path: Path) -> None:
+    """Missing data source raises ValueError with clear message."""
+    doc = {"name": "x", "description": "y", "task_text": "z"}
+    path = _write_yaml(tmp_path, doc)
+    with pytest.raises(ValueError, match="data source"):
+        load_scenario(path)
+
+
+def test_load_scenario_multiple_data_sources_raises(tmp_path: Path) -> None:
+    """Specifying both data and dataset_id raises ValueError."""
+    doc = {
+        "name": "x",
+        "description": "y",
+        "task_text": "z",
+        "data": [{"a": 1}],
+        "dataset_id": "crm-customers",
+    }
+    path = _write_yaml(tmp_path, doc)
+    with pytest.raises(ValueError, match="multiple"):
+        load_scenario(path)
+
+
+def test_load_scenario_invalid_yaml_raises(tmp_path: Path) -> None:
+    """Malformed YAML raises ValueError (not a raw yaml.YAMLError)."""
+    path = tmp_path / "bad.yaml"
+    path.write_text("name: foo\ndata: [unclosed bracket\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid YAML"):
+        load_scenario(path)
+
+
+# ── export_scenario + round-trip ─────────────────────────────────────────────
+
+
+def test_export_scenario_round_trip_inline(tmp_path: Path) -> None:
+    """export_scenario then load_scenario produces equivalent ScenarioDefinition."""
+    original = ScenarioDefinition(
+        name="roundtrip",
+        description="round-trip test",
+        task_text="count items",
+        data=_INLINE_DATA,
+        expected_outputs={"count": 2},
+        required_bricks=["filter_dict_list"],
+        model="gpt-4o-mini",
+    )
+    out = tmp_path / "exported.yaml"
+    export_scenario(original, out)
+    loaded = load_scenario(out)
+
+    assert loaded.name == original.name
+    assert loaded.description == original.description
+    assert loaded.task_text == original.task_text
+    assert loaded.data == original.data
+    assert loaded.expected_outputs == original.expected_outputs
+    assert loaded.required_bricks == original.required_bricks
+    assert loaded.model == original.model
+
+
+def test_export_scenario_round_trip_dataset_id(tmp_path: Path) -> None:
+    """export/load round-trip works for dataset_id source."""
+    original = ScenarioDefinition(
+        name="ds-test",
+        description="dataset id test",
+        task_text="filter",
+        dataset_id="support-tickets",
+    )
+    out = tmp_path / "ds.yaml"
+    export_scenario(original, out)
+    loaded = load_scenario(out)
+    assert loaded.dataset_id == "support-tickets"
+    assert loaded.data is None
+    assert loaded.data_file is None
+
+
+def test_export_scenario_omits_none_fields(tmp_path: Path) -> None:
+    """expected_outputs and required_bricks are absent from YAML when not set."""
+    scenario = ScenarioDefinition(
+        name="minimal",
+        description="minimal export",
+        task_text="count",
+        data=[{"x": 1}],
+    )
+    out = tmp_path / "min.yaml"
+    export_scenario(scenario, out)
+    doc = yaml.safe_load(out.read_text(encoding="utf-8"))
+    assert "expected_outputs" not in doc
+    assert "required_bricks" not in doc
+
+
+# ── scenario_to_benchmark_request ────────────────────────────────────────────
+
+
+def test_scenario_to_request_inline_data(tmp_path: Path) -> None:
+    """scenario_to_benchmark_request resolves inline data to JSON string."""
+    scenario = ScenarioDefinition(
+        name="t",
+        description="d",
+        task_text="count",
+        data=_INLINE_DATA,
+    )
+    req = scenario_to_benchmark_request(scenario)
+    assert req.task_text == "count"
+    parsed = json.loads(req.raw_data)
+    assert parsed == _INLINE_DATA
+
+
+def test_scenario_to_request_data_file(tmp_path: Path) -> None:
+    """scenario_to_benchmark_request resolves data_file to JSON string."""
+    data = [{"key": "value"}]
+    data_path = tmp_path / "data.json"
+    data_path.write_text(json.dumps(data), encoding="utf-8")
+
+    scenario = ScenarioDefinition(
+        name="t",
+        description="d",
+        task_text="count",
+        data_file="data.json",
+    )
+    req = scenario_to_benchmark_request(scenario, base_dir=tmp_path)
+    parsed = json.loads(req.raw_data)
+    assert parsed == data
+
+
+def test_scenario_to_request_dataset_id(tmp_path: Path) -> None:
+    """scenario_to_benchmark_request resolves dataset_id to JSON string."""
+    scenario = ScenarioDefinition(
+        name="t",
+        description="d",
+        task_text="count",
+        dataset_id="crm-customers",
+    )
+    req = scenario_to_benchmark_request(scenario)
+    parsed = json.loads(req.raw_data)
+    assert isinstance(parsed, list)
+    assert len(parsed) > 0
+
+
+def test_scenario_to_request_expected_outputs_passed(tmp_path: Path) -> None:
+    """expected_outputs forwarded to BenchmarkRequest."""
+    scenario = ScenarioDefinition(
+        name="t",
+        description="d",
+        task_text="count",
+        data=[{"x": 1}],
+        expected_outputs={"count": 1},
+    )
+    req = scenario_to_benchmark_request(scenario)
+    assert req.expected_outputs == {"count": 1}
+
+
+def test_scenario_to_request_missing_data_file_raises(tmp_path: Path) -> None:
+    """ValueError raised when data_file does not exist."""
+    scenario = ScenarioDefinition(
+        name="t",
+        description="d",
+        task_text="count",
+        data_file="nonexistent.json",
+    )
+    with pytest.raises(ValueError, match="not found"):
+        scenario_to_benchmark_request(scenario, base_dir=tmp_path)

--- a/packages/benchmark/src/bricks_benchmark/web/presets/cross_dataset_join.yaml
+++ b/packages/benchmark/src/bricks_benchmark/web/presets/cross_dataset_join.yaml
@@ -1,0 +1,18 @@
+name: Orders Customer Join
+description: Join orders to customers, compute completed revenue per plan tier
+dataset_id: orders-customers
+task_text: |
+  Parse the JSON data containing two tables: "orders" (order_id, customer_id,
+  amount, status, order_date) and "customers" (id, name, email, plan).
+  Join orders to customers on customer_id = id. Filter to completed orders only.
+  Calculate total completed order amount per customer plan tier:
+  basic_revenue (sum of completed order amounts for basic plan customers),
+  pro_revenue (for pro plan), enterprise_revenue (for enterprise plan),
+  and total_completed (total completed orders count).
+expected_outputs:
+  total_completed: 24
+required_bricks:
+  - extract_json_from_str
+  - filter_dict_list
+  - calculate_aggregates
+model: claudecode

--- a/packages/benchmark/src/bricks_benchmark/web/presets/custom_example.yaml
+++ b/packages/benchmark/src/bricks_benchmark/web/presets/custom_example.yaml
@@ -1,0 +1,21 @@
+name: Custom Inline Example
+description: Minimal working example using inline data — safe to edit and share
+task_text: |
+  Parse the JSON product data. Filter to products with stock > 0.
+  Count the number of available products (available_count) and
+  calculate the total value of available inventory (total_value =
+  sum of price * stock for each available product).
+data:
+  - {id: 1, name: Keyboard, price: 79.99, stock: 12}
+  - {id: 2, name: Mouse, price: 29.99, stock: 0}
+  - {id: 3, name: Monitor, price: 299.99, stock: 5}
+  - {id: 4, name: Headset, price: 49.99, stock: 8}
+  - {id: 5, name: Webcam, price: 89.99, stock: 0}
+expected_outputs:
+  available_count: 3
+  total_value: 2459.82
+required_bricks:
+  - extract_json_from_str
+  - filter_dict_list
+  - calculate_aggregates
+model: claudecode

--- a/packages/benchmark/src/bricks_benchmark/web/scenario_format.py
+++ b/packages/benchmark/src/bricks_benchmark/web/scenario_format.py
@@ -1,0 +1,43 @@
+"""Portable YAML scenario format for Bricks Benchmark.
+
+A ScenarioDefinition describes a complete benchmark task in a single file:
+what data to use, what to compute, and optionally what to expect.
+
+The format supports three mutually exclusive data sources:
+
+- ``data``: inline list of records (easiest for sharing)
+- ``data_file``: path to a JSON file with the records
+- ``dataset_id``: one of the built-in dataset IDs (e.g. ``'crm-customers'``)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ScenarioDefinition:
+    """A portable benchmark scenario that can be loaded from or saved to YAML.
+
+    Attributes:
+        name: Short human-readable name for this scenario.
+        description: One-sentence description of what the scenario measures.
+        task_text: Natural language task description passed to both engines.
+        data: Inline list of records (mutually exclusive with data_file/dataset_id).
+        data_file: Relative path to a JSON file containing records.
+        dataset_id: ID of a built-in dataset (e.g. ``'crm-customers'``).
+        expected_outputs: Optional ground-truth dict for correctness checking.
+        required_bricks: Optional list of stdlib brick names expected to appear.
+        model: LLM model string (default: ``'claudecode'``).
+    """
+
+    name: str
+    description: str
+    task_text: str
+    data: list[dict[str, Any]] | None = None
+    data_file: str | None = None
+    dataset_id: str | None = None
+    expected_outputs: dict[str, Any] | None = None
+    required_bricks: list[str] = field(default_factory=list)
+    model: str = "claudecode"

--- a/packages/benchmark/src/bricks_benchmark/web/scenario_loader.py
+++ b/packages/benchmark/src/bricks_benchmark/web/scenario_loader.py
@@ -1,0 +1,177 @@
+"""Load, convert, and export benchmark scenarios from/to YAML files.
+
+Functions
+---------
+load_scenario(path)
+    Parse a YAML scenario file into a ScenarioDefinition.
+scenario_to_benchmark_request(scenario)
+    Convert a ScenarioDefinition to a BenchmarkRequest for the web API.
+export_scenario(scenario, path)
+    Write a ScenarioDefinition back to a YAML file (round-trip safe).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+from bricks_benchmark.web.scenario_format import ScenarioDefinition
+from bricks_benchmark.web.schemas import BenchmarkRequest
+
+# Required keys every valid scenario YAML must contain.
+_REQUIRED_KEYS = ("name", "description", "task_text")
+
+
+def load_scenario(path: Path) -> ScenarioDefinition:
+    """Parse a YAML scenario file into a ScenarioDefinition.
+
+    Validates that required keys are present and exactly one data source is
+    specified (``data``, ``data_file``, or ``dataset_id``).
+
+    Args:
+        path: Absolute or relative path to the ``.yaml`` file.
+
+    Returns:
+        Populated ScenarioDefinition.
+
+    Raises:
+        ValueError: If the file is missing required keys, contains invalid YAML,
+            or specifies zero or multiple data sources.
+    """
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Scenario {path.name!r}: invalid YAML — {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"Scenario {path.name!r}: top-level must be a YAML mapping, got {type(raw).__name__}")
+
+    for key in _REQUIRED_KEYS:
+        if not raw.get(key):
+            raise ValueError(f"Scenario {path.name!r}: missing required key {key!r}")
+
+    data_sources = [k for k in ("data", "data_file", "dataset_id") if raw.get(k)]
+    if not data_sources:
+        raise ValueError(
+            f"Scenario {path.name!r}: must specify exactly one data source "
+            "('data', 'data_file', or 'dataset_id') — none found"
+        )
+    if len(data_sources) > 1:
+        raise ValueError(
+            f"Scenario {path.name!r}: only one data source allowed, "
+            f"but found multiple: {data_sources!r}"
+        )
+
+    return ScenarioDefinition(
+        name=raw["name"],
+        description=raw["description"],
+        task_text=raw["task_text"],
+        data=raw.get("data"),
+        data_file=raw.get("data_file"),
+        dataset_id=raw.get("dataset_id"),
+        expected_outputs=raw.get("expected_outputs"),
+        required_bricks=raw.get("required_bricks") or [],
+        model=raw.get("model", "claudecode"),
+    )
+
+
+def _resolve_raw_data(scenario: ScenarioDefinition, base_dir: Path | None = None) -> str:
+    """Return the JSON string for the scenario's data source.
+
+    Args:
+        scenario: The scenario to resolve data for.
+        base_dir: Directory to resolve relative ``data_file`` paths against.
+            Defaults to the current working directory.
+
+    Returns:
+        JSON-encoded string of the dataset records.
+
+    Raises:
+        ValueError: If the data source cannot be resolved.
+    """
+    if scenario.data is not None:
+        return json.dumps(scenario.data)
+
+    if scenario.data_file is not None:
+        ref = Path(scenario.data_file)
+        if not ref.is_absolute() and base_dir is not None:
+            ref = base_dir / ref
+        if not ref.exists():
+            raise ValueError(f"data_file {scenario.data_file!r} not found at {ref}")
+        return ref.read_text(encoding="utf-8")
+
+    if scenario.dataset_id is not None:
+        from bricks_benchmark.web.datasets import DatasetLoader
+
+        loader = DatasetLoader()
+        ds = loader.get_dataset(scenario.dataset_id)
+        if ds is None:
+            raise ValueError(f"dataset_id {scenario.dataset_id!r} not found in built-in datasets")
+        return json.dumps(ds["data"])
+
+    raise ValueError("ScenarioDefinition has no data source (data, data_file, or dataset_id)")
+
+
+def scenario_to_benchmark_request(
+    scenario: ScenarioDefinition,
+    base_dir: Path | None = None,
+) -> BenchmarkRequest:
+    """Convert a ScenarioDefinition to a BenchmarkRequest for the web API.
+
+    Resolves the data source (inline data, file reference, or built-in dataset)
+    into a JSON string suitable for ``POST /api/run``.
+
+    Args:
+        scenario: The loaded scenario.
+        base_dir: Directory to resolve relative ``data_file`` paths against.
+
+    Returns:
+        BenchmarkRequest ready to pass to the ``/api/run`` endpoint.
+
+    Raises:
+        ValueError: If the data source cannot be resolved.
+    """
+    raw_data = _resolve_raw_data(scenario, base_dir=base_dir)
+    return BenchmarkRequest(
+        task_text=scenario.task_text,
+        raw_data=raw_data,
+        expected_outputs=scenario.expected_outputs,
+        required_bricks=scenario.required_bricks or None,
+        model=scenario.model,
+    )
+
+
+def export_scenario(scenario: ScenarioDefinition, path: Path) -> None:
+    """Write a ScenarioDefinition to a YAML file.
+
+    The output is round-trip safe: loading the written file produces an
+    equivalent ScenarioDefinition.
+
+    Args:
+        scenario: The scenario to serialise.
+        path: Destination file path. Parent directories must exist.
+    """
+    doc: dict[str, Any] = {
+        "name": scenario.name,
+        "description": scenario.description,
+        "task_text": scenario.task_text,
+        "model": scenario.model,
+    }
+
+    if scenario.data is not None:
+        doc["data"] = scenario.data
+    elif scenario.data_file is not None:
+        doc["data_file"] = scenario.data_file
+    elif scenario.dataset_id is not None:
+        doc["dataset_id"] = scenario.dataset_id
+
+    if scenario.expected_outputs is not None:
+        doc["expected_outputs"] = scenario.expected_outputs
+
+    if scenario.required_bricks:
+        doc["required_bricks"] = scenario.required_bricks
+
+    path.write_text(yaml.dump(doc, allow_unicode=True, sort_keys=False), encoding="utf-8")

--- a/packages/benchmark/src/bricks_benchmark/web/scenario_loader.py
+++ b/packages/benchmark/src/bricks_benchmark/web/scenario_loader.py
@@ -60,10 +60,7 @@ def load_scenario(path: Path) -> ScenarioDefinition:
             "('data', 'data_file', or 'dataset_id') — none found"
         )
     if len(data_sources) > 1:
-        raise ValueError(
-            f"Scenario {path.name!r}: only one data source allowed, "
-            f"but found multiple: {data_sources!r}"
-        )
+        raise ValueError(f"Scenario {path.name!r}: only one data source allowed, but found multiple: {data_sources!r}")
 
     return ScenarioDefinition(
         name=raw["name"],

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bricks-ai"
-version = "0.5.2"
+version = "0.5.3"
 description = "Deterministic execution engine: typed Python building blocks composed into auditable YAML blueprints."
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -6,7 +6,7 @@ from bricks.core.dag_builder import DAGBuilder
 from bricks.core.dsl import Node, branch, flow, for_each, step
 from bricks.core.engine import DAGExecutionEngine
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 
 __all__ = [
     "DAG",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ module = ["bricks_provider_claudecode", "bricks_provider_claudecode.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = ["yaml"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = ["bricks.mcp.server", "bricks.cli.check_env"]
 warn_unused_ignores = false
 


### PR DESCRIPTION
## Summary
- `ScenarioDefinition` dataclass with three data sources: inline `data`, `data_file`, or `dataset_id`
- `load_scenario` / `export_scenario` / `scenario_to_benchmark_request` with clear error messages
- `--custom YAML_FILE` flag added to `bricks_benchmark.showcase.run` CLI
- 4 preset YAMLs, 3 example YAMLs, sample data file, and `packages/benchmark/README.md`

## Test plan
- [ ] `python -m bricks_benchmark.showcase.run --live --custom examples/basic_custom.yaml` runs
- [ ] `load_scenario` raises `ValueError` (not stack trace) on missing required keys
- [ ] `export_scenario` + `load_scenario` round-trip is lossless
- [ ] `scenario_to_benchmark_request` resolves all three data sources correctly
- [ ] All 142 benchmark tests pass
- [ ] `ruff check .` and `mypy packages/core/src/bricks --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)