### PR TITLE
Mission 069: Node.output property for DSL step chaining

### DIFF
--- a/packages/core/src/bricks/core/dsl.py
+++ b/packages/core/src/bricks/core/dsl.py
@@ -88,6 +88,16 @@ class Node:
     # DAG wiring — populated by DAGBuilder (Mission 059)
     depends_on: list[str] = field(default_factory=list)
 
+    @property
+    def output(self) -> Node:
+        """Allow step1.output syntax — returns self for use as param reference.
+
+        During @flow trace, step.X() returns a Node. LLM-generated DSL often
+        chains steps via step1.output. This property makes that work by returning
+        the Node itself, which DAGBuilder resolves as a dependency edge.
+        """
+        return self
+
     def __repr__(self) -> str:
         """Return a concise string representation.
 

--- a/packages/core/tests/core/test_dsl.py
+++ b/packages/core/tests/core/test_dsl.py
@@ -130,6 +130,33 @@ class TestNode:
         n1.depends_on.append("abc")
         assert n2.depends_on == []  # no shared state
 
+    def test_node_output_returns_self(self) -> None:
+        """step1.output is step1 — property returns the node itself."""
+        step1 = step.brick_a()
+        assert step1.output is step1
+
+    def test_node_output_as_param_reference(self) -> None:
+        """step2.params['data'] is step1 when passed via step1.output."""
+        step1 = step.brick_a()
+        step2 = step.brick_b(data=step1.output)
+        assert step2.params["data"] is step1
+
+    def test_flow_with_output_chaining_no_error(self) -> None:
+        """@flow with .output chaining traces and converts to DAG without AttributeError."""
+        from bricks.core.dsl import flow as dsl_flow
+
+        @dsl_flow
+        def chained_flow(inp: None) -> None:
+            s1 = step.a(x=inp)
+            s2 = step.b(y=s1.output)
+            return s2
+
+        dag = chained_flow.to_dag()
+        assert len(dag.nodes) == 2
+        # s2 must depend on s1
+        edges_flat = [dep for deps in dag.edges.values() for dep in deps]
+        assert len(edges_flat) == 1
+
 
 class TestImports:
     """Tests that public exports work as documented."""


### PR DESCRIPTION
## Summary
- Add `output` property to `Node` dataclass in `dsl.py` — returns `self`
- Fixes `AttributeError` when LLM-generated DSL uses `step1.output` syntax
- `DAGBuilder` already resolves `Node`-in-params as dependency edges, so returning `self` is semantically correct

## Test plan
- [x] `test_node_output_returns_self` — `step1.output is step1`
- [x] `test_node_output_as_param_reference` — `step2.params["data"] is step1`
- [x] `test_flow_with_output_chaining_no_error` — DAG has 2 nodes + 1 edge
- [x] `pytest -q` — 1050 passed, 18 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)