### PR TITLE
Mission 070: Eliminate YAML roundtrip — execute FlowDefinition directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.5.4] — 2026-04-07
+
+### Fixed
+- **YAML roundtrip bug** — `@flow` traces with `None` args (structural trace), so `to_yaml()` baked `null` into all step params; bricks received `None` instead of real runtime data causing `expected string or bytes-like object` failures
+- `FlowDefinition.execute(engine, **kwargs)` now re-traces `_fn` with real inputs, building a fresh DAG with actual param values, bypassing the YAML roundtrip entirely
+
+### Added
+- `FlowDefinition._fn` — original flow function stored at `@flow` decoration time for re-use during execution
+- `ComposeResult.flow_def: FlowDefinition | None` — live `FlowDefinition` object carried through composition result
+- `BricksEngine.solve()` direct execution path: uses `flow_def.execute()` when available; falls back to YAML loader for cached/legacy results
+
 ## [0.5.3] — 2026-04-07
 
 ### Added

--- a/packages/benchmark/src/bricks_benchmark/showcase/engine.py
+++ b/packages/benchmark/src/bricks_benchmark/showcase/engine.py
@@ -154,11 +154,18 @@ class BricksEngine(Engine):
             )
 
         try:
-            bp_def = self._loader.load_string(compose_result.blueprint_yaml)
-            exec_result = self._engine.run(bp_def, inputs={"raw_api_response": raw_data})
-            logger.debug("[BricksEngine] Execution outputs: %s", exec_result.outputs)
+            if compose_result.flow_def is not None:
+                exec_outputs = compose_result.flow_def.execute(
+                    engine=self._engine, raw_api_response=raw_data
+                )
+            else:
+                bp_def = self._loader.load_string(compose_result.blueprint_yaml)
+                exec_outputs = self._engine.run(
+                    bp_def, inputs={"raw_api_response": raw_data}
+                ).outputs
+            logger.debug("[BricksEngine] Execution outputs: %s", exec_outputs)
             return EngineResult(
-                outputs=exec_result.outputs,
+                outputs=exec_outputs,
                 tokens_in=compose_result.total_input_tokens,
                 tokens_out=compose_result.total_output_tokens,
                 duration_seconds=time.monotonic() - t0,

--- a/packages/benchmark/src/bricks_benchmark/showcase/engine.py
+++ b/packages/benchmark/src/bricks_benchmark/showcase/engine.py
@@ -155,14 +155,10 @@ class BricksEngine(Engine):
 
         try:
             if compose_result.flow_def is not None:
-                exec_outputs = compose_result.flow_def.execute(
-                    engine=self._engine, raw_api_response=raw_data
-                )
+                exec_outputs = compose_result.flow_def.execute(engine=self._engine, raw_api_response=raw_data)
             else:
                 bp_def = self._loader.load_string(compose_result.blueprint_yaml)
-                exec_outputs = self._engine.run(
-                    bp_def, inputs={"raw_api_response": raw_data}
-                ).outputs
+                exec_outputs = self._engine.run(bp_def, inputs={"raw_api_response": raw_data}).outputs
             logger.debug("[BricksEngine] Execution outputs: %s", exec_outputs)
             return EngineResult(
                 outputs=exec_outputs,

--- a/packages/benchmark/src/bricks_benchmark/tests/test_engine.py
+++ b/packages/benchmark/src/bricks_benchmark/tests/test_engine.py
@@ -148,3 +148,62 @@ class TestRawLLMEngine:
         provider = self._make_provider("{}")
         engine = RawLLMEngine(provider=provider)
         assert engine.__class__.__name__ == "RawLLMEngine"
+
+
+class TestBricksEngineSolveDirectExecution:
+    """Tests that BricksEngine.solve() uses flow_def.execute() when available."""
+
+    def test_uses_direct_execution_when_flow_def_available(self) -> None:
+        """solve() calls flow_def.execute() and skips BlueprintLoader when flow_def is set."""
+        from bricks_benchmark.showcase.engine import BricksEngine
+
+        mock_flow_def = MagicMock()
+        mock_flow_def.execute.return_value = {"active_count": 3}
+
+        mock_compose_result = MagicMock()
+        mock_compose_result.is_valid = True
+        mock_compose_result.flow_def = mock_flow_def
+        mock_compose_result.blueprint_yaml = "yaml: placeholder"
+        mock_compose_result.total_input_tokens = 10
+        mock_compose_result.total_output_tokens = 5
+        mock_compose_result.model = "test-model"
+
+        engine = BricksEngine.__new__(BricksEngine)
+        engine._composer = MagicMock()
+        engine._composer.compose.return_value = mock_compose_result
+        engine._engine = MagicMock()
+        engine._loader = MagicMock()
+        engine._registry = MagicMock()
+
+        result = engine.solve("task", "raw data")
+
+        mock_flow_def.execute.assert_called_once()
+        engine._loader.load_string.assert_not_called()
+        assert result.outputs == {"active_count": 3}
+
+    def test_falls_back_to_yaml_when_flow_def_is_none(self) -> None:
+        """solve() falls back to BlueprintLoader when flow_def is None."""
+        from bricks.core.models import ExecutionResult
+
+        from bricks_benchmark.showcase.engine import BricksEngine
+
+        mock_compose_result = MagicMock()
+        mock_compose_result.is_valid = True
+        mock_compose_result.flow_def = None
+        mock_compose_result.blueprint_yaml = "yaml: placeholder"
+        mock_compose_result.total_input_tokens = 10
+        mock_compose_result.total_output_tokens = 5
+        mock_compose_result.model = "test-model"
+
+        engine = BricksEngine.__new__(BricksEngine)
+        engine._composer = MagicMock()
+        engine._composer.compose.return_value = mock_compose_result
+        engine._engine = MagicMock()
+        engine._engine.run.return_value = ExecutionResult(outputs={"x": 1}, steps=[])
+        engine._loader = MagicMock()
+        engine._registry = MagicMock()
+
+        result = engine.solve("task", "raw data")
+
+        engine._loader.load_string.assert_called_once_with("yaml: placeholder")
+        assert result.outputs == {"x": 1}

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bricks-ai"
-version = "0.5.3"
+version = "0.5.4"
 description = "Deterministic execution engine: typed Python building blocks composed into auditable YAML blueprints."
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -6,7 +6,7 @@ from bricks.core.dag_builder import DAGBuilder
 from bricks.core.dsl import Node, branch, flow, for_each, step
 from bricks.core.engine import DAGExecutionEngine
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 __all__ = [
     "DAG",

--- a/packages/core/src/bricks/ai/composer.py
+++ b/packages/core/src/bricks/ai/composer.py
@@ -12,7 +12,7 @@ import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from bricks.core.dsl import FlowDefinition, branch, flow, for_each, step
 from bricks.core.exceptions import BlueprintValidationError, BrickError, DuplicateBlueprintError
@@ -64,9 +64,12 @@ class CallDetail(BaseModel):
 class ComposeResult(BaseModel):
     """Result of a Blueprint composition attempt."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     task: str
     blueprint_yaml: str = ""
     dsl_code: str = ""
+    flow_def: FlowDefinition | None = None
     is_valid: bool = False
     validation_errors: list[str] = Field(default_factory=list)
     calls: list[CallDetail] = Field(default_factory=list)
@@ -270,6 +273,7 @@ class BlueprintComposer:
 
         blueprint_yaml = ""
         dsl_code = ""
+        flow_def: FlowDefinition | None = None
         if last.is_valid:
             flow_def = self._parse_dsl_response(last.yaml_text)
             blueprint_yaml = flow_def.to_yaml()
@@ -279,6 +283,7 @@ class BlueprintComposer:
             task=task,
             blueprint_yaml=blueprint_yaml,
             dsl_code=dsl_code,
+            flow_def=flow_def,
             is_valid=last.is_valid,
             validation_errors=last.validation_errors,
             calls=calls,

--- a/packages/core/src/bricks/core/dsl.py
+++ b/packages/core/src/bricks/core/dsl.py
@@ -42,7 +42,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from bricks.core.dag import DAG
-    from bricks.core.models import BlueprintDefinition, ExecutionResult
+    from bricks.core.models import BlueprintDefinition
 
 
 @dataclass
@@ -290,17 +290,27 @@ class FlowDefinition:
         dag: The resolved :class:`~bricks.core.dag.DAG`.
     """
 
-    def __init__(self, name: str, description: str, dag: DAG) -> None:
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        dag: DAG,
+        fn: Callable[..., Any] | None = None,
+    ) -> None:
         """Initialise with a name, description, and pre-built DAG.
 
         Args:
             name: Blueprint / flow name.
             description: Human-readable description.
             dag: The resolved DAG from the trace phase.
+            fn: The original undecorated flow function. When provided,
+                :meth:`execute` re-traces it with real inputs instead of using
+                the ``None``-param DAG captured at decoration time.
         """
         self.name = name
         self.description = description
         self.dag = dag
+        self._fn = fn
 
     def to_dag(self) -> DAG:
         """Return the raw DAG.
@@ -329,28 +339,47 @@ class FlowDefinition:
 
         return blueprint_to_yaml(self.to_blueprint())
 
-    def execute(
-        self,
-        inputs: dict[str, Any] | None = None,
-        engine: Any = None,
-    ) -> ExecutionResult:
-        """Execute the flow through :class:`~bricks.core.engine.BlueprintEngine`.
+    def execute(self, engine: Any = None, **kwargs: Any) -> dict[str, Any]:
+        """Execute the flow with real inputs by re-tracing and running the DAG.
+
+        Re-traces ``_fn`` with actual ``kwargs`` so step params hold real values
+        (not the ``None`` placeholders baked in at ``@flow`` decoration time).
+        Builds a fresh DAG and runs it through the provided engine.
 
         Args:
-            inputs: Runtime input values for ``${inputs.X}`` references.
-            engine: A :class:`~bricks.core.engine.BlueprintEngine` instance.
-                When ``None``, a default engine with an empty registry is
-                created (suitable for flows that only use built-in bricks).
+            engine: Optional :class:`~bricks.core.engine.BlueprintEngine`
+                instance. When ``None``, a default engine with an empty
+                :class:`~bricks.core.registry.BrickRegistry` is created —
+                suitable for unit tests only. Production callers must supply
+                their registry-backed engine so that brick lookups succeed.
+            **kwargs: Runtime inputs matching the flow function's parameter
+                names (e.g. ``raw_api_response="..."``)
 
         Returns:
-            :class:`~bricks.core.models.ExecutionResult` from the engine.
+            Dict of execution outputs from the engine run.
         """
+        from bricks.core.dag_builder import DAGBuilder  # noqa: PLC0415
         from bricks.core.engine import BlueprintEngine  # noqa: PLC0415
         from bricks.core.registry import BrickRegistry  # noqa: PLC0415
 
-        bp = self.to_blueprint()
-        resolved_engine: BlueprintEngine = engine if engine is not None else BlueprintEngine(BrickRegistry())
-        return resolved_engine.run(bp, inputs or {})
+        if self._fn is not None and kwargs:
+            _tracer.start()
+            try:
+                return_value = self._fn(**kwargs)
+            finally:
+                _tracer.stop()
+            traced_nodes = _tracer.get_nodes()
+            root = return_value if isinstance(return_value, Node) else None
+            dag = DAGBuilder().build(traced_nodes, root=root)
+            bp = dag.to_blueprint(name=self.name, description=self.description)
+        else:
+            bp = self.to_blueprint()
+
+        resolved_engine: BlueprintEngine = (
+            engine if engine is not None else BlueprintEngine(BrickRegistry())
+        )
+        result = resolved_engine.run(bp, inputs={})
+        return dict(result.outputs)
 
 
 def flow(func: Callable[..., Any]) -> FlowDefinition:
@@ -399,4 +428,5 @@ def flow(func: Callable[..., Any]) -> FlowDefinition:
         name=func.__name__,
         description=func.__doc__ or "",
         dag=dag,
+        fn=func,
     )

--- a/packages/core/src/bricks/core/dsl.py
+++ b/packages/core/src/bricks/core/dsl.py
@@ -375,9 +375,7 @@ class FlowDefinition:
         else:
             bp = self.to_blueprint()
 
-        resolved_engine: BlueprintEngine = (
-            engine if engine is not None else BlueprintEngine(BrickRegistry())
-        )
+        resolved_engine: BlueprintEngine = engine if engine is not None else BlueprintEngine(BrickRegistry())
         result = resolved_engine.run(bp, inputs={})
         return dict(result.outputs)
 

--- a/packages/core/tests/ai/test_composer.py
+++ b/packages/core/tests/ai/test_composer.py
@@ -260,3 +260,38 @@ class TestComposePopulatesPrompts:
         retry_call = result.calls[1]
         assert "Original task:" in retry_call.user_prompt
         assert "Add numbers" in retry_call.user_prompt
+
+
+# ── flow_def preservation ──────────────────────────────────────────────────
+
+
+class TestComposeResultFlowDef:
+    """Tests that ComposeResult.flow_def is correctly populated."""
+
+    def test_compose_result_preserves_flow_def(self, math_registry: BrickRegistry) -> None:
+        """compose() populates flow_def with a FlowDefinition when DSL is valid."""
+        from bricks.core.dsl import FlowDefinition
+
+        composer = _make_composer(math_registry)
+        composer._provider.complete.return_value = CompletionResult(text=_VALID_DSL)
+        result = composer.compose("Add 3 + 4", math_registry)
+        assert result.flow_def is not None
+        assert isinstance(result.flow_def, FlowDefinition)
+
+    def test_compose_result_blueprint_yaml_still_populated(self, math_registry: BrickRegistry) -> None:
+        """compose() still populates blueprint_yaml (no regression for web GUI)."""
+        composer = _make_composer(math_registry)
+        composer._provider.complete.return_value = CompletionResult(text=_VALID_DSL)
+        result = composer.compose("Add 3 + 4", math_registry)
+        assert result.blueprint_yaml != ""
+
+    def test_compose_result_flow_def_none_on_invalid_dsl(self, math_registry: BrickRegistry) -> None:
+        """compose() sets flow_def to None when DSL is invalid."""
+        composer = _make_composer(math_registry)
+        composer._provider.complete.side_effect = [
+            CompletionResult(text=_INVALID_DSL),
+            CompletionResult(text=_INVALID_DSL),
+        ]
+        result = composer.compose("task", math_registry)
+        assert result.is_valid is False
+        assert result.flow_def is None

--- a/packages/core/tests/core/test_dsl.py
+++ b/packages/core/tests/core/test_dsl.py
@@ -158,6 +158,47 @@ class TestNode:
         assert len(edges_flat) == 1
 
 
+class TestFlowDefinitionExecute:
+    """Tests for FlowDefinition.execute() with real-input re-tracing."""
+
+    def test_execute_with_kwargs_calls_engine_with_real_params(self) -> None:
+        """execute() re-traces _fn with real inputs so step params hold real values."""
+        from unittest.mock import MagicMock
+
+        from bricks.core.dsl import flow as dsl_flow
+        from bricks.core.models import ExecutionResult
+
+        @dsl_flow
+        def my_flow(text: None) -> None:
+            """Test flow."""
+            return step.my_brick(text=text)
+
+        mock_engine = MagicMock()
+        mock_engine.run.return_value = ExecutionResult(outputs={"result": "done"}, steps=[])
+        result = my_flow.execute(engine=mock_engine, text="hello")
+        assert result == {"result": "done"}
+        # Verify the blueprint passed to engine has real param value
+        call_bp = mock_engine.run.call_args[0][0]
+        assert call_bp.steps[0].params.get("text") == "hello"
+
+    def test_execute_returns_dict(self) -> None:
+        """execute() always returns a dict."""
+        from unittest.mock import MagicMock
+
+        from bricks.core.dsl import flow as dsl_flow
+        from bricks.core.models import ExecutionResult
+
+        @dsl_flow
+        def simple_flow(data: None) -> None:
+            """Test flow."""
+            return step.process(data=data)
+
+        mock_engine = MagicMock()
+        mock_engine.run.return_value = ExecutionResult(outputs={"x": 1}, steps=[])
+        result = simple_flow.execute(engine=mock_engine, data="test")
+        assert isinstance(result, dict)
+
+
 class TestImports:
     """Tests that public exports work as documented."""
 


### PR DESCRIPTION
## Summary
- `FlowDefinition.execute(engine, **kwargs)` re-traces `_fn` with real inputs, building a fresh DAG where step params hold actual values instead of `None`
- `ComposeResult.flow_def: FlowDefinition | None` carries the live object through composition
- `BricksEngine.solve()` uses `flow_def.execute()` directly when available; falls back to `BlueprintLoader` for cached/legacy YAML results

## Root Cause Fixed
`@flow` traces with `None` args (structural trace). `to_yaml()` serialized those `None` params as `null`. `BlueprintEngine` then called bricks with `None` → `extract_markdown_fences` failed with `expected string or bytes-like object`.

## Test plan
- [ ] `test_flow_definition_execute_with_kwargs` — re-trace with real input, verify blueprint params are real values
- [ ] `test_flow_definition_execute_returns_dict` — return type is dict
- [ ] `test_compose_result_preserves_flow_def` — flow_def is not None after valid compose
- [ ] `test_compose_result_blueprint_yaml_still_populated` — no regression for web GUI
- [ ] `test_compose_result_flow_def_none_on_invalid_dsl` — flow_def is None when invalid
- [ ] `test_uses_direct_execution_when_flow_def_available` — load_string never called
- [ ] `test_falls_back_to_yaml_when_flow_def_is_none` — fallback path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)