### PR TITLE
Mission 071: CI benchmark smoke test — DSL→execute pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.5.5] — 2026-04-08
+
+### Added
+- **CI smoke test** — `test_smoke_pipeline.py` in benchmark tests: `test_smoke_compose_to_execute` verifies real DSL → execute → correct output with no LLM; `test_compose_result_flow_def_survives_to_engine` is a regression guard ensuring `flow_def.execute()` is used (not `BlueprintLoader`)
+- `dag.to_blueprint()` now sets `outputs_map = {"result": "${final_step.result}"}` for single-output brick flows, so `FlowDefinition.execute()` returns `{"result": value}` instead of `{}`
+
 ## [0.5.4] — 2026-04-07
 
 ### Fixed

--- a/packages/benchmark/src/bricks_benchmark/tests/test_smoke_pipeline.py
+++ b/packages/benchmark/src/bricks_benchmark/tests/test_smoke_pipeline.py
@@ -1,0 +1,122 @@
+"""Smoke tests for the full DSL → FlowDefinition → execute pipeline.
+
+These tests run in CI with zero external dependencies (no LLM, no network).
+They verify the end-to-end path that Mission 070 fixed: DSL string parsed
+into a FlowDefinition, then executed with real bricks and real data.
+
+If these tests break, the YAML-roundtrip bug (Mission 070) has been
+reintroduced — bricks are receiving None instead of real runtime data.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import MagicMock
+
+from bricks.ai.composer import BlueprintComposer, ComposeResult
+from bricks.core.brick import BrickFunction, brick
+from bricks.core.dsl import FlowDefinition
+from bricks.core.engine import BlueprintEngine
+from bricks.core.registry import BrickRegistry
+
+
+def _make_registry() -> BrickRegistry:
+    """Build a BrickRegistry with two inline test bricks.
+
+    Both bricks return ``{"result": value}`` so ``${step_name.result}``
+    references resolve correctly in the blueprint.
+
+    Returns:
+        Registry containing ``count_chars`` and ``repeat_text`` bricks.
+    """
+    registry = BrickRegistry()
+
+    @brick(description="Count characters in text. Returns {result: count}.")
+    def count_chars(text: str) -> dict:  # type: ignore[type-arg]
+        """Count chars."""
+        return {"result": len(text)}
+
+    @brick(description="Repeat text N times. Returns {result: repeated}.")
+    def repeat_text(text: str, times: int) -> dict:  # type: ignore[type-arg]
+        """Repeat text."""
+        return {"result": text * times}
+
+    for fn in (count_chars, repeat_text):
+        typed = cast(BrickFunction, fn)
+        registry.register(typed.__brick_meta__.name, typed, typed.__brick_meta__)
+
+    return registry
+
+
+class TestSmokePipeline:
+    """Full pipeline smoke tests: DSL → FlowDefinition → execute → output."""
+
+    def test_smoke_compose_to_execute(self) -> None:
+        """DSL string → FlowDefinition → execute with real bricks → correct output.
+
+        Bypasses the LLM by calling _parse_dsl_response() directly. Verifies
+        that step params receive real input values (not None from the @flow
+        structural trace), and that the pipeline produces the expected output.
+
+        If the YAML-roundtrip bug (Mission 070) is reintroduced, count_chars
+        will receive None and raise AttributeError, failing this test.
+        """
+        dsl_code = """\
+@flow
+def count_pipeline(raw_text):
+    result = step.count_chars(text=raw_text)
+    return result
+"""
+        # _parse_dsl_response bypasses the LLM — no provider needed
+        composer = BlueprintComposer.__new__(BlueprintComposer)
+        composer._provider = MagicMock()
+        from bricks.core.selector import AllBricksSelector
+
+        composer._selector = AllBricksSelector()
+        composer._store = None
+
+        flow_def = composer._parse_dsl_response(dsl_code)
+        assert isinstance(flow_def, FlowDefinition)
+
+        registry = _make_registry()
+        engine = BlueprintEngine(registry=registry)
+
+        # If re-tracing is broken (params are None), count_chars raises
+        # AttributeError("'NoneType' object has no attribute '__len__'").
+        result = flow_def.execute(engine=engine, raw_text="hello")
+
+        assert "result" in result, f"Expected 'result' key in outputs, got: {result}"
+        assert result["result"] == 5, f"Expected 5 chars in 'hello', got: {result['result']}"
+
+    def test_compose_result_flow_def_survives_to_engine(self) -> None:
+        """Regression: ComposeResult.flow_def must be used by BricksEngine (not BlueprintLoader).
+
+        Asserts that when ComposeResult.flow_def is set, BricksEngine.solve()
+        calls flow_def.execute() and never calls BlueprintLoader.load_string().
+        If this test fails, the YAML-roundtrip regression has been reintroduced.
+        """
+        from bricks_benchmark.showcase.engine import BricksEngine
+
+        mock_flow_def = MagicMock(spec=FlowDefinition)
+        mock_flow_def.execute.return_value = {"active_count": 5}
+
+        mock_compose_result = MagicMock(spec=ComposeResult)
+        mock_compose_result.is_valid = True
+        mock_compose_result.flow_def = mock_flow_def
+        mock_compose_result.blueprint_yaml = "name: placeholder"
+        mock_compose_result.total_input_tokens = 0
+        mock_compose_result.total_output_tokens = 0
+        mock_compose_result.model = "test-model"
+
+        engine = BricksEngine.__new__(BricksEngine)
+        engine._composer = MagicMock()
+        engine._composer.compose.return_value = mock_compose_result
+        engine._engine = MagicMock()
+        engine._loader = MagicMock()
+        engine._registry = MagicMock()
+
+        result = engine.solve("count active customers", '{"data": []}')
+
+        mock_flow_def.execute.assert_called_once()
+        engine._loader.load_string.assert_not_called()
+        assert result.outputs == {"active_count": 5}

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bricks-ai"
-version = "0.5.4"
+version = "0.5.5"
 description = "Deterministic execution engine: typed Python building blocks composed into auditable YAML blueprints."
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -6,7 +6,7 @@ from bricks.core.dag_builder import DAGBuilder
 from bricks.core.dsl import Node, branch, flow, for_each, step
 from bricks.core.engine import DAGExecutionEngine
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 
 __all__ = [
     "DAG",

--- a/packages/core/src/bricks/core/dag.py
+++ b/packages/core/src/bricks/core/dag.py
@@ -124,10 +124,20 @@ class DAG:
             step = self._node_to_step(node, step_name, node_to_step_name)
             steps.append(step)
 
+        # Surface the terminal brick node's result via outputs_map so execute()
+        # callers receive {"result": <value>} instead of an empty dict.
+        # Only applies to plain brick nodes — for_each/branch manage their own output.
+        outputs_map: dict[str, str] = {}
+        root_node = self.nodes.get(self.root_id) if self.root_id else None
+        if root_node is not None and root_node.type == "brick" and self.root_id in node_to_step_name:
+            root_step = node_to_step_name[self.root_id]
+            outputs_map = {"result": f"${{{root_step}.result}}"}
+
         return BlueprintDefinition(
             name=name,
             description=description or f"DSL-generated pipeline with {len(steps)} steps",
             steps=steps,
+            outputs_map=outputs_map,
         )
 
     def _node_to_step(


### PR DESCRIPTION
## Summary
- `test_smoke_pipeline.py`: `test_smoke_compose_to_execute` — real DSL string → `_parse_dsl_response()` → `execute()` with real bricks and real data → assert correct output. No LLM, no network.
- `test_compose_result_flow_def_survives_to_engine` — regression guard: verifies `flow_def.execute()` is called and `BlueprintLoader.load_string` is never called when `flow_def` is set
- `dag.to_blueprint()` now sets `outputs_map = {"result": "${final_step.result}"}` for single-output brick flows, so `execute()` returns meaningful outputs

## Test plan
- [ ] `test_smoke_compose_to_execute` passes — verifies params are real (not None)
- [ ] `test_compose_result_flow_def_survives_to_engine` passes — regression guard
- [ ] Full suite passes, mypy clean, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)