### PR TITLE
Mission 072: DSL pipeline correctness — exclude, validator, dict-return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.5.6] — 2026-04-07
+
+### Fixed
+- `ComposeResult.flow_def`: changed to `Field(exclude=True)` so `model_dump()` never tries to serialize the non-Pydantic `FlowDefinition` object
+- `validator_dsl.py`: accept `@flow(outputs_map={...})` call syntax alongside bare `@flow` — previously raised a false "not decorated with @flow" error
+- `FlowDefinition.execute()`: accept `inputs=` dict alongside `**kwargs`, merging both; enables `execute(inputs={"raw_api_response": data}, engine=engine)` pattern
+
+### Added
+- `@flow` decorator: detect `dict[str, Node]` return value — stores `output_nodes` on `FlowDefinition` and raises `TypeError` for non-Node values
+- `FlowDefinition.execute()` multi-output path: when re-traced return is `dict[str, Node]`, builds `outputs_map` from topologically-sorted node IDs so multi-output flows produce all declared outputs
+- End-to-end smoke test `test_direct_flow_execution_with_real_bricks` verifying dict-return multi-output DSL with real registry
+
 ## [0.5.5] — 2026-04-08
 
 ### Added

--- a/packages/benchmark/src/bricks_benchmark/showcase/engine.py
+++ b/packages/benchmark/src/bricks_benchmark/showcase/engine.py
@@ -155,7 +155,10 @@ class BricksEngine(Engine):
 
         try:
             if compose_result.flow_def is not None:
-                exec_outputs = compose_result.flow_def.execute(engine=self._engine, raw_api_response=raw_data)
+                exec_outputs = compose_result.flow_def.execute(
+                    inputs={"raw_api_response": raw_data},
+                    engine=self._engine,
+                )
             else:
                 bp_def = self._loader.load_string(compose_result.blueprint_yaml)
                 exec_outputs = self._engine.run(bp_def, inputs={"raw_api_response": raw_data}).outputs

--- a/packages/benchmark/src/bricks_benchmark/tests/test_smoke_pipeline.py
+++ b/packages/benchmark/src/bricks_benchmark/tests/test_smoke_pipeline.py
@@ -120,3 +120,37 @@ def count_pipeline(raw_text):
         mock_flow_def.execute.assert_called_once()
         engine._loader.load_string.assert_not_called()
         assert result.outputs == {"active_count": 5}
+
+    def test_direct_flow_execution_with_real_bricks(self) -> None:
+        """Full pipeline: pre-written DSL → FlowDefinition → execute with real registry.
+
+        No LLM. No mocked engine. Uses inline bricks and a dict-return flow to
+        verify the multi-output path introduced in Mission 072. Asserts that both
+        output keys are remapped correctly and hold real computed values.
+        """
+        dsl_code = """\
+@flow
+def multi_pipeline(raw_text):
+    char_count = step.count_chars(text=raw_text)
+    repeated = step.repeat_text(text=raw_text, times=2)
+    return {"char_count": char_count, "doubled": repeated}
+"""
+        composer = BlueprintComposer.__new__(BlueprintComposer)
+        composer._provider = MagicMock()
+        from bricks.core.selector import AllBricksSelector
+
+        composer._selector = AllBricksSelector()
+        composer._store = None
+
+        flow_def = composer._parse_dsl_response(dsl_code)
+        assert isinstance(flow_def, FlowDefinition)
+
+        registry = _make_registry()
+        engine = BlueprintEngine(registry=registry)
+
+        result = flow_def.execute(inputs={"raw_text": "hello"}, engine=engine)
+
+        assert "char_count" in result, f"Expected 'char_count' in outputs, got: {result}"
+        assert "doubled" in result, f"Expected 'doubled' in outputs, got: {result}"
+        assert result["char_count"] == 5, f"Expected 5, got: {result['char_count']}"
+        assert result["doubled"] == "hellohello", f"Expected 'hellohello', got: {result['doubled']}"

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bricks-ai"
-version = "0.5.5"
+version = "0.5.6"
 description = "Deterministic execution engine: typed Python building blocks composed into auditable YAML blueprints."
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -6,7 +6,7 @@ from bricks.core.dag_builder import DAGBuilder
 from bricks.core.dsl import Node, branch, flow, for_each, step
 from bricks.core.engine import DAGExecutionEngine
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 __all__ = [
     "DAG",

--- a/packages/core/src/bricks/ai/composer.py
+++ b/packages/core/src/bricks/ai/composer.py
@@ -69,7 +69,7 @@ class ComposeResult(BaseModel):
     task: str
     blueprint_yaml: str = ""
     dsl_code: str = ""
-    flow_def: FlowDefinition | None = None
+    flow_def: FlowDefinition | None = Field(default=None, exclude=True)
     is_valid: bool = False
     validation_errors: list[str] = Field(default_factory=list)
     calls: list[CallDetail] = Field(default_factory=list)

--- a/packages/core/src/bricks/core/dsl.py
+++ b/packages/core/src/bricks/core/dsl.py
@@ -288,6 +288,9 @@ class FlowDefinition:
         name: Function name used as the blueprint name.
         description: Function docstring used as the blueprint description.
         dag: The resolved :class:`~bricks.core.dag.DAG`.
+        output_nodes: For multi-output flows that return a ``dict[str, Node]``,
+            maps output key names to the terminal :class:`Node` objects captured
+            during the structural trace.  ``None`` for single-output flows.
     """
 
     def __init__(
@@ -296,6 +299,7 @@ class FlowDefinition:
         description: str,
         dag: DAG,
         fn: Callable[..., Any] | None = None,
+        output_nodes: dict[str, Node] | None = None,
     ) -> None:
         """Initialise with a name, description, and pre-built DAG.
 
@@ -306,11 +310,14 @@ class FlowDefinition:
             fn: The original undecorated flow function. When provided,
                 :meth:`execute` re-traces it with real inputs instead of using
                 the ``None``-param DAG captured at decoration time.
+            output_nodes: Optional mapping of output key → terminal Node for
+                multi-output flows that return ``dict[str, Node]``.
         """
         self.name = name
         self.description = description
         self.dag = dag
         self._fn = fn
+        self.output_nodes = output_nodes
 
     def to_dag(self) -> DAG:
         """Return the raw DAG.
@@ -339,21 +346,36 @@ class FlowDefinition:
 
         return blueprint_to_yaml(self.to_blueprint())
 
-    def execute(self, engine: Any = None, **kwargs: Any) -> dict[str, Any]:
+    def execute(
+        self,
+        inputs: dict[str, Any] | None = None,
+        engine: Any = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
         """Execute the flow with real inputs by re-tracing and running the DAG.
 
-        Re-traces ``_fn`` with actual ``kwargs`` so step params hold real values
-        (not the ``None`` placeholders baked in at ``@flow`` decoration time).
-        Builds a fresh DAG and runs it through the provided engine.
+        Re-traces ``_fn`` with actual runtime values so step params hold real
+        data (not the ``None`` placeholders from the ``@flow`` structural
+        trace). Builds a fresh DAG and runs it through the provided engine.
+
+        Accepts runtime inputs as either a dict (``inputs={"key": value}``) or
+        keyword arguments (``key=value``). Both forms are merged, with keyword
+        arguments taking precedence.
+
+        For multi-output flows (those returning ``dict[str, Node]``), the
+        result dict is keyed by the declared output names. For single-output
+        flows, the result has a single ``"result"`` key.
 
         Args:
+            inputs: Optional dict of runtime inputs mapping parameter names to
+                values (e.g. ``{"raw_api_response": "..."}``)
             engine: Optional :class:`~bricks.core.engine.BlueprintEngine`
                 instance. When ``None``, a default engine with an empty
                 :class:`~bricks.core.registry.BrickRegistry` is created —
                 suitable for unit tests only. Production callers must supply
                 their registry-backed engine so that brick lookups succeed.
-            **kwargs: Runtime inputs matching the flow function's parameter
-                names (e.g. ``raw_api_response="..."``)
+            **kwargs: Additional runtime inputs as keyword arguments. Merged
+                with ``inputs``; keyword arguments take precedence on conflict.
 
         Returns:
             Dict of execution outputs from the engine run.
@@ -362,16 +384,35 @@ class FlowDefinition:
         from bricks.core.engine import BlueprintEngine  # noqa: PLC0415
         from bricks.core.registry import BrickRegistry  # noqa: PLC0415
 
-        if self._fn is not None and kwargs:
+        merged: dict[str, Any] = {**(inputs or {}), **kwargs}
+
+        if self._fn is not None and merged:
             _tracer.start()
             try:
-                return_value = self._fn(**kwargs)
+                return_value = self._fn(**merged)
             finally:
                 _tracer.stop()
             traced_nodes = _tracer.get_nodes()
-            root = return_value if isinstance(return_value, Node) else None
-            dag = DAGBuilder().build(traced_nodes, root=root)
-            bp = dag.to_blueprint(name=self.name, description=self.description)
+
+            if isinstance(return_value, dict) and all(isinstance(v, Node) for v in return_value.values()):
+                # Multi-output flow: build outputs_map from declared output keys
+                dag = DAGBuilder().build(traced_nodes, root=None)
+                ordered = dag.topological_sort()
+                node_id_to_step = {
+                    nid: f"step_{i + 1}_{dag.nodes[nid].brick_name or dag.nodes[nid].type}"
+                    for i, nid in enumerate(ordered)
+                }
+                outputs_map = {
+                    key: f"${{{node_id_to_step[node.id]}.result}}"
+                    for key, node in return_value.items()
+                    if node.id in node_id_to_step
+                }
+                bp = dag.to_blueprint(name=self.name, description=self.description)
+                bp = bp.model_copy(update={"outputs_map": outputs_map})
+            else:
+                root = return_value if isinstance(return_value, Node) else None
+                dag = DAGBuilder().build(traced_nodes, root=root)
+                bp = dag.to_blueprint(name=self.name, description=self.description)
         else:
             bp = self.to_blueprint()
 
@@ -419,7 +460,17 @@ def flow(func: Callable[..., Any]) -> FlowDefinition:
         _tracer.stop()
 
     traced_nodes = _tracer.get_nodes()
-    root = return_value if isinstance(return_value, Node) else None
+
+    output_nodes: dict[str, Node] | None = None
+    if isinstance(return_value, dict):
+        if not all(isinstance(v, Node) for v in return_value.values()):
+            bad = {k: type(v).__name__ for k, v in return_value.items() if not isinstance(v, Node)}
+            raise TypeError(f"@flow dict return must map str keys to Node values. Non-Node values: {bad}")
+        output_nodes = dict(return_value)
+        root = None
+    else:
+        root = return_value if isinstance(return_value, Node) else None
+
     dag = DAGBuilder().build(traced_nodes, root=root)
 
     return FlowDefinition(
@@ -427,4 +478,5 @@ def flow(func: Callable[..., Any]) -> FlowDefinition:
         description=func.__doc__ or "",
         dag=dag,
         fn=func,
+        output_nodes=output_nodes,
     )

--- a/packages/core/src/bricks/core/validator_dsl.py
+++ b/packages/core/src/bricks/core/validator_dsl.py
@@ -159,7 +159,11 @@ class PythonDSLValidator:
             return
 
         func = top_level_defs[0]
-        has_flow = any(isinstance(d, ast.Name) and d.id == "flow" for d in func.decorator_list)
+        has_flow = any(
+            (isinstance(d, ast.Name) and d.id == "flow")
+            or (isinstance(d, ast.Call) and isinstance(d.func, ast.Name) and d.func.id == "flow")
+            for d in func.decorator_list
+        )
         if not has_flow:
             result.valid = False
             result.errors.append("Function must be decorated with @flow.")

--- a/packages/core/tests/ai/test_composer.py
+++ b/packages/core/tests/ai/test_composer.py
@@ -295,3 +295,39 @@ class TestComposeResultFlowDef:
         result = composer.compose("task", math_registry)
         assert result.is_valid is False
         assert result.flow_def is None
+
+    def test_compose_result_flow_def_excluded_from_model_dump(self, math_registry: BrickRegistry) -> None:
+        """ComposeResult.model_dump() must NOT include flow_def (exclude=True required).
+
+        Without exclude=True, model_dump() on a ComposeResult with a live
+        FlowDefinition raises a serialization error.
+        """
+        from bricks.core.dsl import FlowDefinition
+
+        composer = _make_composer(math_registry)
+        composer._provider.complete.return_value = CompletionResult(text=_VALID_DSL)
+        result = composer.compose("Add 3 + 4", math_registry)
+
+        # flow_def must be set (sanity check)
+        assert isinstance(result.flow_def, FlowDefinition)
+
+        # model_dump() must succeed AND not include flow_def
+        dumped = result.model_dump()
+        assert "flow_def" not in dumped, "flow_def must be excluded from model_dump()"
+
+    def test_compose_result_flow_def_is_populated_after_valid_compose(self, math_registry: BrickRegistry) -> None:
+        """compose() with a valid DSL string populates flow_def with a FlowDefinition.
+
+        This is an integration test using a test double that returns pre-written
+        DSL — no LLM call is made.
+        """
+        from bricks.core.dsl import FlowDefinition
+
+        composer = _make_composer(math_registry)
+        composer._provider.complete.return_value = CompletionResult(text=_VALID_DSL)
+        result = composer.compose("Add numbers", math_registry)
+
+        assert result.is_valid is True
+        assert result.flow_def is not None
+        assert isinstance(result.flow_def, FlowDefinition)
+        assert result.flow_def.name  # must have a name derived from function name

--- a/packages/core/tests/core/test_dsl.py
+++ b/packages/core/tests/core/test_dsl.py
@@ -199,6 +199,75 @@ class TestFlowDefinitionExecute:
         assert isinstance(result, dict)
 
 
+class TestFlowDictReturn:
+    """Tests for @flow dict-return multi-output support (Mission 072 Fix 3)."""
+
+    def test_flow_dict_return_creates_output_nodes(self) -> None:
+        """@flow returning dict[str, Node] stores output_nodes on FlowDefinition."""
+        from bricks.core.dsl import flow as dsl_flow
+
+        @dsl_flow
+        def multi_flow(data: None) -> None:
+            a = step.brick_a(x=data)
+            b = step.brick_b(y=data)
+            return {"out_a": a, "out_b": b}  # type: ignore[return-value]
+
+        assert multi_flow.output_nodes is not None
+        assert set(multi_flow.output_nodes.keys()) == {"out_a", "out_b"}
+        assert all(isinstance(v, Node) for v in multi_flow.output_nodes.values())
+
+    def test_flow_dict_return_execute_remaps_outputs(self) -> None:
+        """execute() with dict-return flow remaps outputs to declared output keys."""
+        from typing import cast
+
+        from bricks.core.brick import BrickFunction, brick
+        from bricks.core.dsl import flow as dsl_flow
+        from bricks.core.engine import BlueprintEngine
+        from bricks.core.registry import BrickRegistry
+
+        registry = BrickRegistry()
+
+        @brick(description="Upper case. Returns {result: upper}.")
+        def upper_case(text: str) -> dict:  # type: ignore[type-arg]
+            """Upper case."""
+            return {"result": text.upper()}
+
+        @brick(description="Count chars. Returns {result: count}.")
+        def count_chars(text: str) -> dict:  # type: ignore[type-arg]
+            """Count chars."""
+            return {"result": len(text)}
+
+        for fn in (upper_case, count_chars):
+            typed = cast(BrickFunction, fn)
+            registry.register(typed.__brick_meta__.name, typed, typed.__brick_meta__)
+
+        @dsl_flow
+        def multi_flow(raw_text: None) -> None:
+            """Multi-output flow."""
+            upper = step.upper_case(text=raw_text)
+            count = step.count_chars(text=raw_text)
+            return {"uppercased": upper, "char_count": count}  # type: ignore[return-value]
+
+        engine = BlueprintEngine(registry=registry)
+        result = multi_flow.execute(engine=engine, raw_text="hello")
+
+        assert "uppercased" in result, f"Expected 'uppercased' in {result}"
+        assert "char_count" in result, f"Expected 'char_count' in {result}"
+        assert result["uppercased"] == "HELLO"
+        assert result["char_count"] == 5
+
+    def test_flow_dict_return_invalid_raises(self) -> None:
+        """@flow returning dict with non-Node values raises TypeError at decoration time."""
+        import pytest
+        from bricks.core.dsl import flow as dsl_flow
+
+        with pytest.raises(TypeError, match="Non-Node values"):
+
+            @dsl_flow
+            def bad_flow(data: None) -> None:
+                return {"a": "not_a_node"}  # type: ignore[return-value]
+
+
 class TestImports:
     """Tests that public exports work as documented."""
 

--- a/packages/core/tests/core/test_validator_dsl.py
+++ b/packages/core/tests/core/test_validator_dsl.py
@@ -354,3 +354,31 @@ def my_flow():
     result = validate_dsl(code)
     assert isinstance(result, ValidationResult)
     assert result.valid
+
+
+# ---------------------------------------------------------------------------
+# @flow(...) call syntax (Mission 072 Fix 2)
+# ---------------------------------------------------------------------------
+
+
+def test_validator_accepts_flow_with_kwargs() -> None:
+    """@flow(outputs_map={...}) passes validator — must not raise 'decorated with @flow' error."""
+    code = """
+@flow(outputs_map={"active_count": "step_1.result"})
+def my_flow(data):
+    return step.process(data=data)
+"""
+    result = validate_dsl(code)
+    assert result.valid, f"Expected valid, got errors: {result.errors}"
+    assert not any("decorated with @flow" in e for e in result.errors)
+
+
+def test_validator_accepts_bare_flow() -> None:
+    """Regression guard: bare @flow still passes after adding @flow(...) support."""
+    code = """
+@flow
+def my_flow(data):
+    return step.process(data=data)
+"""
+    result = validate_dsl(code)
+    assert result.valid, f"Bare @flow must still be valid, got: {result.errors}"


### PR DESCRIPTION
## Summary
- `ComposeResult.flow_def` now has `exclude=True` so `model_dump()` never fails trying to serialize the non-Pydantic `FlowDefinition`
- `validator_dsl.py` accepts `@flow(outputs_map={...})` call syntax alongside bare `@flow`
- `FlowDefinition.execute()` accepts `inputs=` dict merged with `**kwargs`; `@flow` detects dict-return and builds `outputs_map` for multi-output flows

## Test plan
- [ ] `python -m pytest packages/core/tests/ -q` — all 5 new tests pass
- [ ] `python -m pytest packages/benchmark/ -q` — smoke test with multi-output dict-return flow passes
- [ ] `python -m mypy packages/core/src/bricks --strict` — clean
- [ ] `ruff check . && ruff format --check .` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)