### PR TITLE
Mission 073: fix flow() kwargs, execute() inputs, system prompt rule 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.5.7] — 2026-04-08
+
+### Fixed
+- `flow()` crashed with `TypeError` when called with kwargs (e.g. `@flow(outputs_map={...})`). Function now accepts `func=None, **_kwargs` and returns a lambda decorator when `func is None`, allowing bare `@flow`, `@flow()`, and `@flow(key=val)` to all work.
+- `FlowDefinition.execute()` passed `inputs={}` to `BlueprintEngine.run()`, breaking `${variable}` reference resolution in multi-step flows. Now passes `inputs=merged` (the merged dict of `inputs=` and `**kwargs`).
+
+### Changed
+- `DSL_PROMPT_TEMPLATE` rule 8: teaches the LLM both single-output (`return step4`) and multi-output (`return {{"count": step3, "total": step4}}`) return syntax so multi-output tasks use dict-return correctly.
+
 ## [0.5.6] — 2026-04-07
 
 ### Fixed

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bricks-ai"
-version = "0.5.6"
+version = "0.5.7"
 description = "Deterministic execution engine: typed Python building blocks composed into auditable YAML blueprints."
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -6,7 +6,7 @@ from bricks.core.dag_builder import DAGBuilder
 from bricks.core.dsl import Node, branch, flow, for_each, step
 from bricks.core.engine import DAGExecutionEngine
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"
 
 __all__ = [
     "DAG",

--- a/packages/core/src/bricks/ai/composer.py
+++ b/packages/core/src/bricks/ai/composer.py
@@ -103,7 +103,10 @@ Rules:
 5. Only use step.brick_name() for brick calls — brick names must match the available bricks list above
 6. Parameters must be keyword-only: step.clean(text=data) NOT step.clean(data)
 7. You can assign step results to variables and pass them to other steps
-8. Return the final step result
+8. To return ONE output: return the final step node directly (e.g. return step4)
+   To return MULTIPLE named outputs: return a dict of names to step nodes
+   (e.g. return {{"count": step3, "total": step4}})
+   Use dict return whenever the task requires multiple output keys.
 9. on_error="fail" (default) stops on first error. on_error="collect" continues and gathers errors.
 10. branch condition must be a brick name string that returns boolean
 

--- a/packages/core/src/bricks/core/dsl.py
+++ b/packages/core/src/bricks/core/dsl.py
@@ -417,11 +417,14 @@ class FlowDefinition:
             bp = self.to_blueprint()
 
         resolved_engine: BlueprintEngine = engine if engine is not None else BlueprintEngine(BrickRegistry())
-        result = resolved_engine.run(bp, inputs={})
+        result = resolved_engine.run(bp, inputs=merged)
         return dict(result.outputs)
 
 
-def flow(func: Callable[..., Any]) -> FlowDefinition:
+def flow(
+    func: Callable[..., Any] | None = None,
+    **_kwargs: Any,
+) -> FlowDefinition | Callable[..., FlowDefinition]:
     """Decorator that traces a function once and returns a :class:`FlowDefinition`.
 
     The decorated function is called **once at decoration time** with ``None``
@@ -430,12 +433,21 @@ def flow(func: Callable[..., Any]) -> FlowDefinition:
     :class:`Node` objects.  Actual values are irrelevant during tracing;
     only the graph structure is captured.
 
+    Supports three call forms::
+
+        @flow               # bare decorator
+        @flow()             # empty call
+        @flow(outputs_map={...})  # call with kwargs (kwargs are ignored)
+
     Args:
-        func: The pipeline function to trace. Its parameters become mock
-            ``None`` values during the trace phase.
+        func: The pipeline function to trace. Pass ``None`` (implicitly) when
+            the decorator is called with keyword arguments.
+        **_kwargs: Ignored keyword arguments — allows ``@flow(outputs_map={...})``
+            without raising ``TypeError``.
 
     Returns:
-        A :class:`FlowDefinition` with the traced DAG.
+        A :class:`FlowDefinition` when called directly on a function, or a
+        single-argument decorator when called with keyword arguments.
 
     Example::
 
@@ -448,6 +460,9 @@ def flow(func: Callable[..., Any]) -> FlowDefinition:
 
         bp = clean_pipeline.to_blueprint()
     """
+    if func is None:
+        return lambda f: flow(f)  # type: ignore[return-value]
+
     from bricks.core.dag_builder import DAGBuilder  # noqa: PLC0415
 
     sig = inspect.signature(func)

--- a/packages/core/tests/core/test_dsl.py
+++ b/packages/core/tests/core/test_dsl.py
@@ -268,6 +268,110 @@ class TestFlowDictReturn:
                 return {"a": "not_a_node"}  # type: ignore[return-value]
 
 
+class TestFlowCallForm:
+    """Tests for @flow(), @flow(kwargs), and bare @flow call forms (Mission 073)."""
+
+    def test_flow_accepts_kwargs(self) -> None:
+        """@flow(outputs_map={}) decorates without raising TypeError."""
+        from bricks.core.dsl import FlowDefinition
+        from bricks.core.dsl import flow as dsl_flow
+
+        @dsl_flow(outputs_map={})
+        def my_flow(data: None) -> None:
+            return step.some_brick(text=data)
+
+        assert isinstance(my_flow, FlowDefinition)
+
+    def test_flow_accepts_empty_call(self) -> None:
+        """@flow() (empty parentheses) decorates without error."""
+        from bricks.core.dsl import FlowDefinition
+        from bricks.core.dsl import flow as dsl_flow
+
+        @dsl_flow()
+        def my_flow(data: None) -> None:
+            return step.some_brick(text=data)
+
+        assert isinstance(my_flow, FlowDefinition)
+
+    def test_flow_bare_still_works(self) -> None:
+        """Regression: bare @flow still returns FlowDefinition after Mission 073 changes."""
+        from bricks.core.dsl import FlowDefinition
+        from bricks.core.dsl import flow as dsl_flow
+
+        @dsl_flow
+        def my_flow(data: None) -> None:
+            return step.some_brick(text=data)
+
+        assert isinstance(my_flow, FlowDefinition)
+
+    def test_flow_dict_return_multi_output(self) -> None:
+        """Flow returning dict of Nodes produces all declared output keys with correct values."""
+        from typing import cast
+
+        from bricks.core.brick import BrickFunction, brick
+        from bricks.core.dsl import FlowDefinition
+        from bricks.core.dsl import flow as dsl_flow
+        from bricks.core.engine import BlueprintEngine
+        from bricks.core.registry import BrickRegistry
+
+        registry = BrickRegistry()
+
+        @brick(description="Double the number. Returns {result: doubled}.")
+        def double_num(n: int) -> dict:  # type: ignore[type-arg]
+            """Double."""
+            return {"result": n * 2}
+
+        @brick(description="Square the number. Returns {result: squared}.")
+        def square_num(n: int) -> dict:  # type: ignore[type-arg]
+            """Square."""
+            return {"result": n * n}
+
+        for fn in (double_num, square_num):
+            typed = cast(BrickFunction, fn)
+            registry.register(typed.__brick_meta__.name, typed, typed.__brick_meta__)
+
+        @dsl_flow
+        def multi_flow(val: None) -> None:
+            a = step.double_num(n=val)
+            b = step.square_num(n=val)
+            return {"doubled": a, "squared": b}  # type: ignore[return-value]
+
+        assert isinstance(multi_flow, FlowDefinition)
+        engine = BlueprintEngine(registry=registry)
+        result = multi_flow.execute(inputs={"val": 4}, engine=engine)
+
+        assert result["doubled"] == 8, f"Expected 8, got {result['doubled']}"
+        assert result["squared"] == 16, f"Expected 16, got {result['squared']}"
+
+    def test_execute_passes_inputs_to_engine(self) -> None:
+        """execute(inputs=...) passes the dict to BlueprintEngine.run() so step params resolve."""
+        from typing import cast
+
+        from bricks.core.brick import BrickFunction, brick
+        from bricks.core.dsl import flow as dsl_flow
+        from bricks.core.engine import BlueprintEngine
+        from bricks.core.registry import BrickRegistry
+
+        registry = BrickRegistry()
+
+        @brick(description="Echo text. Returns {result: text}.")
+        def echo_text(text: str) -> dict:  # type: ignore[type-arg]
+            """Echo."""
+            return {"result": text}
+
+        typed = cast(BrickFunction, echo_text)
+        registry.register(typed.__brick_meta__.name, typed, typed.__brick_meta__)
+
+        @dsl_flow
+        def echo_flow(raw_text: None) -> None:
+            return step.echo_text(text=raw_text)
+
+        engine = BlueprintEngine(registry=registry)
+        result = echo_flow.execute(inputs={"raw_text": "hello world"}, engine=engine)
+
+        assert result.get("result") == "hello world", f"Expected 'hello world', got: {result}"
+
+
 class TestImports:
     """Tests that public exports work as documented."""
 


### PR DESCRIPTION
## Summary
- `@flow(outputs_map={...})` no longer raises `TypeError` — `flow()` accepts `func=None, **_kwargs` and returns a lambda when called with kwargs
- `FlowDefinition.execute()` now passes `inputs=merged` to `BlueprintEngine.run()` so `${variable}` references resolve correctly in multi-step flows
- `DSL_PROMPT_TEMPLATE` rule 8 updated to teach dict-return syntax for multi-output tasks

## Test plan
- [ ] `test_flow_accepts_kwargs` — `@flow(outputs_map={})` decorates without TypeError
- [ ] `test_flow_accepts_empty_call` — `@flow()` works
- [ ] `test_flow_bare_still_works` — bare `@flow` regression guard
- [ ] `test_flow_dict_return_multi_output` — real bricks, both output keys correct
- [ ] `test_execute_passes_inputs_to_engine` — inputs reach step params, not None
- [ ] Full pytest suite passes, mypy clean, ruff clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)