### PR TITLE
Mission 077: richer DSL prompt — Literal signatures, data flow, worked example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.5.9] — 2026-04-12
+
+### Added
+- `_format_annotation()` in `schema.py`: formats `Literal` types as `'sum'|'avg'|'min'|'max'` instead of verbose `typing.Literal[...]` in brick signatures
+- `Literal` annotations on 6 stdlib/core bricks: `calculate_aggregates`, `convert_case`, `compute_hash`, `random_string`, `compare_values`, `_for_each_impl`
+- Data flow contract in `DSL_PROMPT_TEMPLATE`: teaches LLM that `step.X()` returns a Node, `.output` chains, and every brick returns `{"result": value}`
+- Worked `@flow` example in `DSL_PROMPT_TEMPLATE`: demonstrates multi-step chaining, dict-return for multiple outputs, and correct brick parameter names
+
 ## [0.5.8] — 2026-04-08
 
 ### Fixed

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bricks-ai"
-version = "0.5.8"
+version = "0.5.9"
 description = "Deterministic execution engine: typed Python building blocks composed into auditable YAML blueprints."
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/core/src/bricks/__init__.py
+++ b/packages/core/src/bricks/__init__.py
@@ -6,7 +6,7 @@ from bricks.core.dag_builder import DAGBuilder
 from bricks.core.dsl import Node, branch, flow, for_each, step
 from bricks.core.engine import DAGExecutionEngine
 
-__version__ = "0.5.8"
+__version__ = "0.5.9"
 
 __all__ = [
     "DAG",

--- a/packages/core/src/bricks/ai/composer.py
+++ b/packages/core/src/bricks/ai/composer.py
@@ -95,6 +95,14 @@ Available primitives:
 - for_each(items, do=lambda item: step.brick(...), on_error="fail"|"collect") → maps a step over a list
 - branch(condition="brick_name", if_true=lambda: step.X(...), if_false=lambda: step.Y(...)) → conditional routing
 
+Data flow:
+- step.X(**kwargs) returns a Node — it does NOT return a value yet
+- Pass a Node to the next step: result = step.X(a=prev_step.output)
+- .output on any Node returns the same Node (for chaining syntax)
+- At execution time the engine substitutes each Node with its actual result value
+- Every brick returns a dict with a "result" key: step.add(a=1, b=2) → {{"result": 3}}
+- Use .output to chain: total = step.add(a=x, b=y); rounded = step.round_value(value=total.output)
+
 Rules:
 1. Write a single function decorated with @flow
 2. Function name should describe the task (e.g., def clean_and_process)
@@ -113,6 +121,16 @@ Rules:
     CORRECT: for_each(items=data, do=lambda item: step.count_dict_list(items=item))
     WRONG:   for_each(items=data, do=lambda item: step.count_dict_list(item=item))
 12. Prefer filter_dict_list + calculate_aggregates over for_each when filtering and aggregating a single list.
+
+Example (study this pattern — do not copy it literally):
+@flow
+def crm_summary(raw_api_response):
+    parsed   = step.extract_json_from_str(text=raw_api_response)
+    actives  = step.filter_dict_list(items=parsed.output, key="status", value="active")
+    count    = step.count_dict_list(items=actives.output)
+    total    = step.calculate_aggregates(items=actives.output, field="monthly_revenue", operation="sum")
+    average  = step.calculate_aggregates(items=actives.output, field="monthly_revenue", operation="avg")
+    return {{"active_count": count, "total_revenue": total, "avg_revenue": average}}
 
 Task: {task}
 {input_context}

--- a/packages/core/src/bricks/core/builtins.py
+++ b/packages/core/src/bricks/core/builtins.py
@@ -7,7 +7,7 @@ name starts with ``__`` is excluded from ``list_public()`` and signature output.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from bricks.core.models import BrickMeta
 from bricks.core.registry import BrickRegistry
@@ -16,7 +16,7 @@ from bricks.core.registry import BrickRegistry
 def _for_each_impl(
     items: list[Any],
     do_brick: str,
-    on_error: str = "fail",
+    on_error: Literal["fail", "collect"] = "fail",
     registry: BrickRegistry | None = None,
 ) -> dict[str, Any]:
     """Execute a brick for each item in the list.

--- a/packages/core/src/bricks/core/schema.py
+++ b/packages/core/src/bricks/core/schema.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import re
+import typing
 from typing import TYPE_CHECKING, Any
 
 from bricks.core.models import BlueprintDefinition
@@ -182,6 +183,27 @@ def parse_description_keys(description: str) -> list[str]:
     return re.findall(r"\{(\w+):", description)
 
 
+def _format_annotation(ann: Any) -> str:
+    """Format a type annotation for LLM-readable signature output.
+
+    Handles ``Literal`` types specially so the LLM sees valid values
+    instead of the verbose ``typing.Literal[...]`` repr.
+
+    Args:
+        ann: A type annotation (e.g. ``str``, ``Literal["sum", "avg"]``).
+
+    Returns:
+        Formatted string — e.g. ``'"sum"|"avg"'`` for Literal types,
+        ``'str'`` for standard types.
+    """
+    origin = getattr(ann, "__origin__", None)
+    if origin is typing.Literal:
+        return "|".join(repr(a) for a in ann.__args__)
+    if hasattr(ann, "__name__"):
+        return str(ann.__name__)
+    return str(ann)
+
+
 def signature_params(callable_: Any) -> str:
     """Format parameter signature for a callable.
 
@@ -194,11 +216,20 @@ def signature_params(callable_: Any) -> str:
     parts: list[str] = []
     try:
         sig = inspect.signature(callable_)
+        # Resolve stringified annotations (from __future__ import annotations)
+        try:
+            resolved_hints = typing.get_type_hints(
+                callable_,
+                localns=vars(typing),
+                include_extras=True,
+            )
+        except Exception:
+            resolved_hints = {}
         for pname, param in sig.parameters.items():
             if pname in ("self", "inputs", "metadata"):
                 continue
-            ann = param.annotation
-            type_name = ann.__name__ if hasattr(ann, "__name__") else str(ann)
+            ann = resolved_hints.get(pname, param.annotation)
+            type_name = _format_annotation(ann)
             if ann is inspect.Parameter.empty:
                 type_name = "Any"
             if param.default is not inspect.Parameter.empty:

--- a/packages/core/tests/ai/test_composer.py
+++ b/packages/core/tests/ai/test_composer.py
@@ -331,3 +331,30 @@ class TestComposeResultFlowDef:
         assert result.flow_def is not None
         assert isinstance(result.flow_def, FlowDefinition)
         assert result.flow_def.name  # must have a name derived from function name
+
+
+class TestDSLPromptTemplate:
+    """Tests for DSL_PROMPT_TEMPLATE content (Mission 077)."""
+
+    def test_prompt_contains_data_flow_contract(self) -> None:
+        """DSL_PROMPT_TEMPLATE includes the data flow contract block."""
+        from bricks.ai.composer import DSL_PROMPT_TEMPLATE
+
+        prompt = DSL_PROMPT_TEMPLATE.format(
+            brick_signatures="add(a: float, b: float) → dict",
+            task="test task",
+            input_context="",
+        )
+        assert "every brick returns a dict" in prompt.lower(), "Data flow contract missing from DSL_PROMPT_TEMPLATE"
+
+    def test_prompt_contains_worked_example(self) -> None:
+        """DSL_PROMPT_TEMPLATE includes the worked @flow example."""
+        from bricks.ai.composer import DSL_PROMPT_TEMPLATE
+
+        prompt = DSL_PROMPT_TEMPLATE.format(
+            brick_signatures="add(a: float, b: float) → dict",
+            task="test task",
+            input_context="",
+        )
+        assert "crm_summary" in prompt, "Worked example missing from DSL_PROMPT_TEMPLATE"
+        assert "do not copy it literally" in prompt, "Example instruction missing"

--- a/packages/core/tests/core/test_schema.py
+++ b/packages/core/tests/core/test_schema.py
@@ -293,3 +293,38 @@ class TestOutputKeyTable:
 
         reg = BrickRegistry()
         assert output_key_table(reg) == ""
+
+
+class TestLiteralAnnotation:
+    """Tests for Literal type formatting in signatures (Mission 077)."""
+
+    def test_literal_annotation_formatted_cleanly(self) -> None:
+        """_format_annotation(Literal["sum", "avg"]) returns '"sum"|"avg"'."""
+        from typing import Literal
+
+        from bricks.core.schema import _format_annotation
+
+        result = _format_annotation(Literal["sum", "avg"])
+        assert result == "'sum'|'avg'", f"Expected \"'sum'|'avg'\", got {result!r}"
+
+    def test_format_annotation_standard_type(self) -> None:
+        """_format_annotation(str) returns 'str'."""
+        from bricks.core.schema import _format_annotation
+
+        assert _format_annotation(str) == "str"
+        assert _format_annotation(int) == "int"
+
+    def test_compact_signatures_include_literal_values(self) -> None:
+        """compact_brick_signatures() emits Literal values for bricks that declare them."""
+        from typing import Literal
+
+        reg = BrickRegistry()
+
+        @brick(tags=["test"], description="Aggregate values.")
+        def aggregate(data: list, operation: Literal["sum", "avg", "min"]) -> dict:  # type: ignore[type-arg]
+            """Aggregate."""
+            return {"result": 0}
+
+        reg.register("aggregate", aggregate, aggregate.__brick_meta__)
+        result = compact_brick_signatures(reg)
+        assert "'sum'|'avg'|'min'" in result, f"Expected Literal values in signatures, got:\n{result}"

--- a/packages/stdlib/src/bricks_stdlib/data_transformation.py
+++ b/packages/stdlib/src/bricks_stdlib/data_transformation.py
@@ -6,7 +6,7 @@ import csv
 import io
 import json
 import xml.etree.ElementTree as ET
-from typing import Any
+from typing import Any, Literal
 
 from bricks.core.brick import brick
 
@@ -261,7 +261,11 @@ def unflatten_dict(data: dict[str, Any], separator: str = ".") -> dict[str, Any]
 
 
 @brick(tags=["data", "aggregate", "math"], category="data_transformation", destructive=False)
-def calculate_aggregates(items: list[dict[str, Any]], field: str, operation: str) -> dict[str, float]:
+def calculate_aggregates(
+    items: list[dict[str, Any]],
+    field: str,
+    operation: Literal["sum", "avg", "min", "max", "count"],
+) -> dict[str, float]:
     """Aggregate a numeric field across a list of dicts. Returns {result: aggregated_value}.
 
     Args:

--- a/packages/stdlib/src/bricks_stdlib/encoding_security.py
+++ b/packages/stdlib/src/bricks_stdlib/encoding_security.py
@@ -8,6 +8,7 @@ import html
 import secrets
 import string
 import uuid
+from typing import Literal
 from urllib.parse import quote, unquote
 
 from bricks.core.brick import brick
@@ -40,7 +41,7 @@ def base64_decode(encoded: str) -> dict[str, str]:
 
 
 @brick(tags=["security", "hash", "digest"], category="encoding_security", destructive=False)
-def compute_hash(data: str, algorithm: str = "sha256") -> dict[str, str]:
+def compute_hash(data: str, algorithm: Literal["md5", "sha1", "sha256", "sha512"] = "sha256") -> dict[str, str]:
     """Compute a hash digest of a string. Returns {result: hex_digest}.
 
     Args:
@@ -140,7 +141,10 @@ def generate_uuid() -> dict[str, str]:
 
 
 @brick(tags=["security", "random", "token"], category="encoding_security", destructive=False)
-def random_string(length: int, charset: str = "alphanumeric") -> dict[str, str]:
+def random_string(
+    length: int,
+    charset: Literal["alphanumeric", "hex", "alpha", "digits"] = "alphanumeric",
+) -> dict[str, str]:
     """Generate a cryptographically secure random string. Returns {result: random_str}.
 
     Args:

--- a/packages/stdlib/src/bricks_stdlib/string_processing.py
+++ b/packages/stdlib/src/bricks_stdlib/string_processing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import unicodedata
 from datetime import datetime
+from typing import Literal
 
 from bricks.core.brick import brick
 
@@ -156,7 +157,7 @@ def remove_html_tags(text: str) -> dict[str, str]:
 
 
 @brick(tags=["string", "case", "transform"], category="string_processing", destructive=False)
-def convert_case(text: str, case: str) -> dict[str, str]:
+def convert_case(text: str, case: Literal["upper", "lower", "title", "snake", "camel"]) -> dict[str, str]:
     """Convert string case. Returns {result: converted}.
 
     Args:

--- a/packages/stdlib/src/bricks_stdlib/validation.py
+++ b/packages/stdlib/src/bricks_stdlib/validation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 from bricks.core.brick import brick
@@ -146,7 +146,7 @@ def is_iso_date(text: str) -> dict[str, bool]:
 
 
 @brick(tags=["validation", "comparison"], category="validation", destructive=False)
-def compare_values(a: Any, b: Any, operator: str) -> dict[str, bool]:
+def compare_values(a: Any, b: Any, operator: Literal["eq", "ne", "lt", "le", "gt", "ge"]) -> dict[str, bool]:
     """Compare two values using an operator. Returns {result: bool}.
 
     Args:


### PR DESCRIPTION
## Summary
- `schema.py`: `_format_annotation()` formats `Literal` types as `'sum'|'avg'|'min'|'max'` for LLM-readable signatures
- `Literal` annotations on 6 stdlib/core bricks so the LLM sees valid enum values, not bare `str`
- Data flow contract in `DSL_PROMPT_TEMPLATE`: Node return, `.output` chaining, `{"result": value}` shape
- Worked `@flow` example with multi-step chaining and dict-return for multiple outputs

## Test plan
- [ ] `test_literal_annotation_formatted_cleanly` — `Literal["sum", "avg"]` → `'sum'|'avg'`
- [ ] `test_compact_signatures_include_literal_values` — real brick with `Literal` param emits values in signature
- [ ] `test_prompt_contains_data_flow_contract` — contract present in formatted prompt
- [ ] `test_prompt_contains_worked_example` — `crm_summary` example present
- [ ] Full pytest suite passes, mypy clean, ruff clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)