### PR TITLE
fix(dsl): detect Node deps nested inside list/dict kwargs

### DIFF
--- a/src/bricks/core/dag_builder.py
+++ b/src/bricks/core/dag_builder.py
@@ -11,8 +11,10 @@ class DAGBuilder:
 
     Resolves dependency edges by inspecting:
 
-    - ``params`` values that are themselves :class:`~bricks.core.dsl.Node` objects
-      (brick→brick data flow).
+    - ``params`` values that are themselves :class:`~bricks.core.dsl.Node` objects,
+      including Nodes nested inside list or dict values (brick→brick data flow).
+      Must stay symmetric with :func:`bricks.core.dag._resolve_param`, which
+      recurses into the same containers when writing reference strings.
     - ``items`` field of ``for_each`` nodes when it is a
       :class:`~bricks.core.dsl.Node`.
 
@@ -77,8 +79,7 @@ class DAGBuilder:
 
         if node.type == "brick":
             for value in node.params.values():
-                if isinstance(value, Node) and value.id in node_map:
-                    deps.append(value.id)
+                self._collect_node_deps(value, node_map, deps)
 
         elif node.type == "for_each" and isinstance(node.items, Node) and node.items.id in node_map:
             deps.append(node.items.id)
@@ -87,3 +88,27 @@ class DAGBuilder:
         # traced list; no extra wiring needed at this stage.
 
         return deps
+
+    def _collect_node_deps(
+        self,
+        value: object,
+        node_map: dict[str, Node],
+        deps: list[str],
+    ) -> None:
+        """Append dep ids from any :class:`Node` refs reachable inside *value*.
+
+        Recurses into list and dict containers, mirroring
+        :func:`bricks.core.dag._resolve_param`. De-duplicates while preserving
+        first-seen order.
+        """
+        if isinstance(value, Node):
+            if value.id in node_map and value.id not in deps:
+                deps.append(value.id)
+            return
+        if isinstance(value, list):
+            for item in value:
+                self._collect_node_deps(item, node_map, deps)
+            return
+        if isinstance(value, dict):
+            for item in value.values():
+                self._collect_node_deps(item, node_map, deps)

--- a/tests/core/test_dag.py
+++ b/tests/core/test_dag.py
@@ -75,6 +75,61 @@ class TestDAGBuilder:
         dag = _build(nodes)
         assert data.id in dag.edges[fe.id]
 
+    def test_dag_builder_detects_nodes_inside_list_kwarg(self) -> None:
+        """Node refs nested inside a list param register as dependencies.
+
+        Regression for issue #25: when the LLM emits
+        ``step.reduce_sum(values=[a.output, b.output])`` the consumer must
+        declare edges on both producers so topological sort orders them
+        before the consumer.
+        """
+        _tracer.start()
+        a = step.count_a()
+        b = step.count_b()
+        total = step.reduce_sum(values=[a, b])
+        _tracer.stop()
+        nodes = _tracer.get_nodes()
+
+        dag = _build(nodes)
+        assert a.id in dag.edges[total.id]
+        assert b.id in dag.edges[total.id]
+
+    def test_dag_builder_detects_nodes_inside_dict_kwarg(self) -> None:
+        """Node refs nested inside a dict param register as dependencies."""
+        _tracer.start()
+        a = step.load_a()
+        b = step.load_b()
+        merged = step.merge(sources={"x": a, "y": b})
+        _tracer.stop()
+        nodes = _tracer.get_nodes()
+
+        dag = _build(nodes)
+        assert a.id in dag.edges[merged.id]
+        assert b.id in dag.edges[merged.id]
+
+    def test_dag_to_blueprint_with_list_kwarg_serialises_to_yaml(self) -> None:
+        """End-to-end regression: list-of-Nodes kwarg round-trips to YAML.
+
+        Pre-fix this raised ``RepresenterError`` because the consumer's list
+        kwarg kept raw ``Node`` objects through blueprint_to_yaml.
+        """
+        from bricks.core.utils import blueprint_to_yaml
+
+        _tracer.start()
+        a = step.count_a()
+        b = step.count_b()
+        step.reduce_sum(values=[a, b])
+        _tracer.stop()
+        nodes = _tracer.get_nodes()
+
+        dag = _build(nodes)
+        blueprint = dag.to_blueprint()
+        yaml_text = blueprint_to_yaml(blueprint)
+
+        # Both producer refs must appear as ${...result} strings in the YAML.
+        assert yaml_text.count(".result}") >= 2
+        assert "Node(" not in yaml_text
+
     def test_dag_builder_root_is_last_node(self) -> None:
         """root_id defaults to the last node in the list."""
         _tracer.start()


### PR DESCRIPTION
## Summary
- `DAGBuilder._find_dependencies` now recurses into list and dict param values so nested `Node` refs are picked up as edges, matching `dag._resolve_param` which already recursed on the serialisation side.
- Fixes the `RepresenterError: cannot represent an object: Node(...)` crash hit by the showcase benchmark's TICKET-pipeline scenario when the LLM emitted `step.reduce_sum(values=[a.output, b.output])`.

## Root cause
Asymmetry between edge-detection and param-resolution: `_resolve_param` recursed into collections, `_find_dependencies` did not. Topological sort could emit the consumer before a nested producer, the producer's id was then missing from `node_to_step_name`, and the raw `Node` object fell through `dag.py`'s defensive fallback into `ruamel.yaml.dump`.

## Test plan
- [x] `pytest tests/core/test_dag.py` — 25 pass (3 new + 22 existing)
- [x] `ruff check` + `ruff format --check` on edited files
- [x] CI green
- [x] Re-run `python -m bricks.benchmark.showcase.run --live --model claudecode` and confirm TICKET-pipeline completes without crashing

Closes #25