### PR TITLE
Improve compose robustness: fix prompt + healing chain + prompt caching

### DIFF
--- a/src/bricks/ai/composer.py
+++ b/src/bricks/ai/composer.py
@@ -9,13 +9,15 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from bricks.core.dsl import FlowDefinition, branch, flow, for_each, step
-from bricks.core.exceptions import BlueprintValidationError, BrickError, DuplicateBlueprintError
+from bricks.core.exceptions import BlueprintValidationError, BrickError, BrickExecutionError, DuplicateBlueprintError
 from bricks.core.registry import BrickRegistry
 from bricks.core.schema import compact_brick_signatures
 from bricks.core.selector import AllBricksSelector, BrickSelector
@@ -77,10 +79,15 @@ class ComposeResult(BaseModel):
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     total_tokens: int = 0
+    total_cached_input_tokens: int = 0
     model: str = ""
     duration_seconds: float = 0.0
     system_prompt: str = ""
     cache_hit: bool = False
+    # Populated only when compose() is called with executor=<callable>.
+    exec_outputs: dict[str, Any] | None = None
+    exec_error: str = ""
+    heal_attempts: list[Any] = Field(default_factory=list)
 
 
 # System prompt — instructs the LLM to produce Python DSL instead of YAML.
@@ -187,6 +194,25 @@ _MAX_TOKENS = 2048
 _MAX_API_CALLS = 2
 
 
+@dataclass
+class _EmptyChainResult:
+    """Stand-in for ChainResult when the caller passed ``healers=[]``.
+
+    The composer still needs something with ``.attempts``, ``.success``,
+    and ``.final_error`` to fold into the ComposeResult, so this avoids a
+    late import and matches the shape. Not exported.
+    """
+
+    success: bool = False
+    outputs: dict[str, Any] | None = None
+    final_flow: FlowDefinition | None = None
+    final_dsl: str = ""
+    final_error: str = ""
+    attempts: list[Any] = field(default_factory=list)
+    total_tokens_in: int = 0
+    total_tokens_out: int = 0
+
+
 def _build_input_context(input_keys: list[str] | None) -> str:
     """Build an input hint line for the prompt.
 
@@ -225,6 +251,7 @@ class BlueprintComposer:
         provider: LLMProvider,
         selector: BrickSelector | None = None,
         store: BlueprintStore | None = None,
+        healers: list[Any] | None = None,
     ) -> None:
         """Initialise the composer.
 
@@ -233,16 +260,25 @@ class BlueprintComposer:
             selector: BrickSelector for Stage 1 filtering. Defaults to AllBricksSelector.
             store: Optional blueprint store for caching. When provided, cache hits
                    return immediately with zero API calls.
+            healers: Optional explicit healer list for the runtime-retry chain.
+                Only consulted when ``compose(..., executor=...)`` is called.
+                ``None`` means "build a sensible default chain with all five
+                shipped tiers at compose time" — we need the system prompt
+                to construct the LLM-backed tiers, so the default chain is
+                built lazily inside ``compose``. Pass ``[]`` to disable
+                healing entirely while still accepting an executor.
         """
         self._provider = provider
         self._selector = selector or AllBricksSelector()
         self._store = store
+        self._explicit_healers = healers
 
     def compose(
         self,
         task: str,
         registry: BrickRegistry,
         input_keys: list[str] | None = None,
+        executor: Callable[[FlowDefinition], dict[str, Any]] | None = None,
     ) -> ComposeResult:
         """Compose a Blueprint from a natural language task using Python DSL.
 
@@ -325,7 +361,6 @@ class BlueprintComposer:
         last = calls[-1]
         total_input = sum(c.input_tokens for c in calls)
         total_output = sum(c.output_tokens for c in calls)
-        elapsed = time.monotonic() - t0
 
         blueprint_yaml = ""
         dsl_code = ""
@@ -334,6 +369,37 @@ class BlueprintComposer:
             flow_def = self._parse_dsl_response(last.yaml_text)
             blueprint_yaml = flow_def.to_yaml()
             dsl_code = self._strip_fences(last.yaml_text)
+
+        exec_outputs: dict[str, Any] | None = None
+        exec_error = ""
+        heal_attempts: list[Any] = []
+
+        if executor is not None and last.is_valid and flow_def is not None:
+            try:
+                exec_outputs = executor(flow_def)
+            except BrickExecutionError as exc:
+                # Hand control to the healer chain — deterministic tiers first.
+                chain_result = self._run_healer_chain(
+                    task=task,
+                    flow_def=flow_def,
+                    dsl_code=dsl_code,
+                    error=exc,
+                    system_prompt=system,
+                    registry=registry,
+                    executor=executor,
+                )
+                heal_attempts = chain_result.attempts
+                total_input += chain_result.total_tokens_in
+                total_output += chain_result.total_tokens_out
+                if chain_result.success:
+                    exec_outputs = chain_result.outputs
+                    if chain_result.final_flow is not None:
+                        flow_def = chain_result.final_flow
+                        blueprint_yaml = flow_def.to_yaml()
+                    if chain_result.final_dsl:
+                        dsl_code = chain_result.final_dsl
+                else:
+                    exec_error = chain_result.final_error
 
         result = ComposeResult(
             task=task,
@@ -348,15 +414,19 @@ class BlueprintComposer:
             total_output_tokens=total_output,
             total_tokens=total_input + total_output,
             model="",
-            duration_seconds=elapsed,
+            duration_seconds=time.monotonic() - t0,
             system_prompt=system,
+            exec_outputs=exec_outputs,
+            exec_error=exec_error,
+            heal_attempts=heal_attempts,
         )
 
         logger.info(
-            "Compose complete: valid=%s, %d calls, %.1fs",
+            "Compose complete: valid=%s, %d calls, %.1fs, heal_attempts=%d",
             result.is_valid,
             result.api_calls,
             result.duration_seconds,
+            len(heal_attempts),
         )
 
         # Auto-save validated blueprint to store
@@ -364,6 +434,61 @@ class BlueprintComposer:
             self._auto_save(task, flow_def.name, blueprint_yaml)
 
         return result
+
+    def _run_healer_chain(
+        self,
+        *,
+        task: str,
+        flow_def: FlowDefinition,
+        dsl_code: str,
+        error: BrickExecutionError,
+        system_prompt: str,
+        registry: BrickRegistry,
+        executor: Callable[[FlowDefinition], dict[str, Any]],
+    ) -> Any:
+        """Assemble (or reuse) a HealerChain and ask it to recover from *error*.
+
+        Imported lazily so ``healing`` can depend on composer types without
+        creating an import cycle at module load time.
+        """
+        from bricks.ai.healing import (  # noqa: PLC0415
+            DictUnwrapHealer,
+            HealContext,
+            HealerChain,
+            LLMRetryHealer,
+            ParamNameHealer,
+            ShapeAwareLLMHealer,
+        )
+
+        if self._explicit_healers is not None:
+            healers: list[Any] = list(self._explicit_healers)
+        else:
+            healers = [
+                ParamNameHealer(),
+                DictUnwrapHealer(),
+                LLMRetryHealer(provider=self._provider, system_prompt=system_prompt),
+                ShapeAwareLLMHealer(provider=self._provider, system_prompt=system_prompt),
+                # Tier 40 (FullRecomposeHealer) intentionally omitted from the
+                # default chain — it recursively invokes compose() and needs a
+                # caller-supplied fresh_compose. Enable it by passing an
+                # explicit healers= list that includes it.
+            ]
+
+        if not healers:
+            # Caller opted out of healing.
+            return _EmptyChainResult(final_error=str(error))
+
+        chain = HealerChain(healers=healers, max_attempts=4)
+        ctx = HealContext(
+            task=task,
+            failed_flow=flow_def,
+            failed_dsl=dsl_code,
+            error=error,
+            attempt=0,
+            prior_attempts=[],
+            registry=registry,
+        )
+        return chain.heal(ctx, executor=executor, parser=self._parse_dsl_response)
 
     def _auto_save(self, task: str, blueprint_name: str, blueprint_yaml: str) -> None:
         """Auto-save a validated blueprint to the store.

--- a/src/bricks/ai/composer.py
+++ b/src/bricks/ai/composer.py
@@ -56,6 +56,7 @@ class CallDetail(BaseModel):
     user_prompt: str = ""
     input_tokens: int = 0
     output_tokens: int = 0
+    cached_input_tokens: int = 0
     total_tokens: int = 0
     duration_seconds: float = 0.0
     yaml_text: str = ""
@@ -361,6 +362,7 @@ class BlueprintComposer:
         last = calls[-1]
         total_input = sum(c.input_tokens for c in calls)
         total_output = sum(c.output_tokens for c in calls)
+        total_cached_in = sum(c.cached_input_tokens for c in calls)
 
         blueprint_yaml = ""
         dsl_code = ""
@@ -413,6 +415,7 @@ class BlueprintComposer:
             total_input_tokens=total_input,
             total_output_tokens=total_output,
             total_tokens=total_input + total_output,
+            total_cached_input_tokens=total_cached_in,
             model="",
             duration_seconds=time.monotonic() - t0,
             system_prompt=system,
@@ -552,16 +555,17 @@ class BlueprintComposer:
         )
 
         call_t0 = time.monotonic()
-        raw_text, in_tok, out_tok = self._make_api_call(system, user_message)
+        raw_text, in_tok, out_tok, cached_in = self._make_api_call(system, user_message)
         is_valid, errors = self._validate_dsl_text(raw_text)
         call_elapsed = time.monotonic() - call_t0
 
         logger.info(
-            "Compose call #%d: valid=%s, code=%d chars, %.1fs",
+            "Compose call #%d: valid=%s, code=%d chars, %.1fs (cached_in=%d)",
             call_number,
             is_valid,
             len(raw_text),
             call_elapsed,
+            cached_in,
         )
         if not is_valid:
             logger.warning("Compose call #%d validation failed: %s", call_number, errors)
@@ -572,6 +576,7 @@ class BlueprintComposer:
             user_prompt=user_message,
             input_tokens=in_tok,
             output_tokens=out_tok,
+            cached_input_tokens=cached_in,
             total_tokens=in_tok + out_tok,
             duration_seconds=call_elapsed,
             yaml_text=raw_text,
@@ -579,15 +584,17 @@ class BlueprintComposer:
             validation_errors=errors,
         )
 
-    def _make_api_call(self, system: str, user_message: str) -> tuple[str, int, int]:
-        """Make a single LLM call and return (raw_text, input_tokens, output_tokens).
+    def _make_api_call(self, system: str, user_message: str) -> tuple[str, int, int, int]:
+        """Make a single LLM call.
 
         Args:
             system: System prompt.
             user_message: User message.
 
         Returns:
-            Tuple of (raw text from LLM, input tokens, output tokens).
+            Tuple of ``(raw_text, input_tokens, output_tokens, cached_input_tokens)``.
+            The cached counter is ``0`` when the provider doesn't surface
+            cache metrics or when caching is inactive.
 
         Raises:
             ComposerError: If the API call fails or returns no text.
@@ -601,7 +608,12 @@ class BlueprintComposer:
         except Exception as exc:
             logger.error("API call failed: %s", exc, exc_info=True)
             raise ComposerError(f"API call failed: {exc}", cause=exc) from exc
-        return completion.text, completion.input_tokens, completion.output_tokens
+        return (
+            completion.text,
+            completion.input_tokens,
+            completion.output_tokens,
+            getattr(completion, "cached_input_tokens", 0),
+        )
 
     def _validate_dsl_text(self, code: str) -> tuple[bool, list[str]]:
         """Run AST whitelist validation on raw DSL text (strips fences first).

--- a/src/bricks/ai/composer.py
+++ b/src/bricks/ai/composer.py
@@ -122,15 +122,46 @@ Rules:
     WRONG:   for_each(items=data, do=lambda item: step.count_dict_list(item=item))
 12. Prefer filter_dict_list + calculate_aggregates over for_each when filtering and aggregating a single list.
 
-Example (study this pattern — do not copy it literally):
+Examples (study these patterns — do not copy them literally):
+
+# Example A — unwrap a dict-wrapped list before filtering, then aggregate
 @flow
 def crm_summary(raw_api_response):
-    parsed   = step.extract_json_from_str(text=raw_api_response)
-    actives  = step.filter_dict_list(items=parsed.output, key="status", value="active")
-    count    = step.count_dict_list(items=actives.output)
-    total    = step.calculate_aggregates(items=actives.output, field="monthly_revenue", operation="sum")
-    average  = step.calculate_aggregates(items=actives.output, field="monthly_revenue", operation="avg")
+    parsed    = step.extract_json_from_str(text=raw_api_response)
+    customers = step.extract_dict_field(data=parsed.output, field="customers")
+    actives   = step.filter_dict_list(items=customers.output, key="status", value="active")
+    count     = step.count_dict_list(items=actives.output)
+    total     = step.calculate_aggregates(items=actives.output, field="monthly_revenue", operation="sum")
+    average   = step.calculate_aggregates(items=actives.output, field="monthly_revenue", operation="avg")
     return {{"active_count": count, "total_revenue": total, "avg_revenue": average}}
+
+# Example B — for_each over extracted values + reduce_sum across multiple counts
+@flow
+def ticket_urgency_report(raw_api_response):
+    parsed       = step.extract_json_from_str(text=raw_api_response)
+    tickets      = step.extract_dict_field(data=parsed.output, field="tickets")
+    emails       = step.map_values(items=tickets.output, key="customer_email")
+    validations  = for_each(items=emails.output, do=lambda e: step.is_email_valid(email=e))
+    valid_count  = step.count_dict_list(items=validations.output)
+    high         = step.filter_dict_list(items=tickets.output, key="priority", value="high")
+    critical     = step.filter_dict_list(items=tickets.output, key="priority", value="critical")
+    high_count   = step.count_dict_list(items=high.output)
+    crit_count   = step.count_dict_list(items=critical.output)
+    urgent_total = step.reduce_sum(values=[high_count, crit_count])
+    return {{"valid_count": valid_count, "high_count": high_count,
+            "critical_count": crit_count, "total_urgent": urgent_total}}
+
+# Example C — branch on a computed condition, returning one of two summaries
+@flow
+def file_report(raw_api_response):
+    parsed       = step.extract_json_from_str(text=raw_api_response)
+    record_count = step.count_dict_list(items=parsed.output)
+    summary      = branch(
+        condition="is_nonempty_list",
+        if_true=lambda: step.generate_summary(count=record_count.output, status="ok"),
+        if_false=lambda: step.generate_summary(count=0, status="empty"),
+    )
+    return summary
 
 Task: {task}
 {input_context}

--- a/src/bricks/ai/healing.py
+++ b/src/bricks/ai/healing.py
@@ -27,6 +27,9 @@ and calls the caller-supplied ``executor`` to run it. No direct DAG mutation.
 
 from __future__ import annotations
 
+import ast
+import difflib
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
@@ -99,6 +102,125 @@ with ``new_flow`` set on success (and tokens_in/out populated). Used by
 tier 40 (:class:`FullRecomposeHealer`). When compose fails validation, the
 callable returns ``HealResult()`` (no flow, no DSL) so the chain records
 the tokens spent and moves on."""
+
+
+def _rewrite_kwarg_name(source: str, brick_name: str, from_name: str, to_name: str) -> str:
+    """Rename a keyword argument in every ``step.<brick_name>(...)`` call.
+
+    Args:
+        source: The DSL text.
+        brick_name: Only calls on ``step.<brick_name>`` are touched.
+        from_name: The wrong kwarg name to replace.
+        to_name: The corrected kwarg name.
+
+    Returns:
+        The rewritten DSL. If the brick call or the kwarg is not present
+        in the source, the original string is returned unchanged so the
+        caller can detect the no-op.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return source
+
+    class _Renamer(ast.NodeTransformer):
+        changed = False
+
+        def visit_Call(self, node: ast.Call) -> ast.AST:  # ast API
+            self.generic_visit(node)
+            func = node.func
+            if not (
+                isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "step"
+                and func.attr == brick_name
+            ):
+                return node
+            for kw in node.keywords:
+                if kw.arg == from_name:
+                    kw.arg = to_name
+                    self.changed = True
+            return node
+
+    renamer = _Renamer()
+    new_tree = renamer.visit(tree)
+    if not renamer.changed:
+        return source
+    ast.fix_missing_locations(new_tree)
+    return ast.unparse(new_tree)
+
+
+def _insert_unwrap_before_step(source: str, failing_brick: str, wrapper_key: str) -> str:
+    """Insert ``extract_dict_field`` before the first ``step.<failing_brick>`` call.
+
+    Locates the assignment statement whose RHS is ``step.<failing_brick>(...)``,
+    finds the kwarg whose value is ``<name>.output`` (the wrapper-dict Node
+    ref), and rewrites the flow as::
+
+        <name>_items = step.extract_dict_field(data=<name>.output, field=<wrapper_key>)
+        <old_target> = step.<failing_brick>(..., items=<name>_items.output, ...)
+
+    Args:
+        source: The DSL text.
+        failing_brick: The brick whose consumer call needs an unwrap before it.
+        wrapper_key: The key name to pass to ``extract_dict_field``.
+
+    Returns:
+        The rewritten DSL, or the original string when the pattern cannot be
+        matched (no enclosing function, no matching call, or the kwarg is not
+        a ``<name>.output`` reference).
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return source
+
+    fn = next((n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)), None)
+    if fn is None:
+        return source
+
+    for idx, stmt in enumerate(list(fn.body)):
+        if not isinstance(stmt, ast.Assign) or not isinstance(stmt.value, ast.Call):
+            continue
+        call = stmt.value
+        func = call.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "step"
+            and func.attr == failing_brick
+        ):
+            continue
+
+        target_kw: ast.keyword | None = None
+        producer_name: str | None = None
+        for kw in call.keywords:
+            value = kw.value
+            if isinstance(value, ast.Attribute) and isinstance(value.value, ast.Name) and value.attr == "output":
+                target_kw = kw
+                producer_name = value.value.id
+                break
+        if target_kw is None or producer_name is None:
+            continue
+
+        unwrap_target = f"{producer_name}_items"
+
+        unwrap_stmt = ast.parse(
+            f'{unwrap_target} = step.extract_dict_field(data={producer_name}.output, field="{wrapper_key}")'
+        ).body[0]
+
+        # Rewire the consumer kwarg to the unwrapped ref.
+        target_kw.value = ast.Attribute(
+            value=ast.Name(id=unwrap_target, ctx=ast.Load()),
+            attr="output",
+            ctx=ast.Load(),
+        )
+
+        fn.body.insert(idx, unwrap_stmt)
+        ast.fix_missing_locations(tree)
+        return ast.unparse(tree)
+
+    return source
 
 
 def _strip_fences(code: str) -> str:
@@ -527,6 +649,155 @@ class ShapeAwareLLMHealer:
             tokens_in=completion.input_tokens,
             tokens_out=completion.output_tokens,
         )
+
+
+class ParamNameHealer:
+    """Tier 10 — deterministic fix for ``TypeError: unexpected keyword argument``.
+
+    Parses the offending argument name out of the ``TypeError`` message,
+    asks the registry for the failing brick's real parameter names, and
+    swaps the wrong name for the closest match via ``difflib``. The DSL
+    is rewritten through Python's AST so the surrounding code shape is
+    preserved byte-for-byte.
+
+    The healer only fires when:
+
+    - The underlying cause is a ``TypeError`` whose message matches either
+      ``unexpected keyword argument '<X>'`` or
+      ``missing … required … argument '<X>'`` / ``required keyword-only argument: '<X>'``.
+    - A ``difflib`` match of ratio ≥ 0.6 exists among the brick's valid
+      param names. Anything weaker is a guess — we fall through to tier 20.
+    - ``ctx.registry`` is set — without it we cannot look up the brick.
+    """
+
+    tier: int = 10
+    name: str = "ParamNameHealer"
+
+    _BAD_KWARG_RE = re.compile(
+        r"unexpected keyword argument ['\"]([^'\"]+)['\"]",
+    )
+    _MISSING_KWARG_RE = re.compile(
+        r"(?:missing \d+ required (?:positional|keyword-only) arguments?: )['\"]([^'\"]+)['\"]"
+        r"|required keyword-only argument: ['\"]([^'\"]+)['\"]",
+    )
+
+    def can_heal(self, ctx: HealContext) -> bool:
+        """Accept only ``TypeError`` causes we recognise, with a registry available."""
+        if ctx.registry is None:
+            return False
+        cause = ctx.error.cause
+        if not isinstance(cause, TypeError):
+            return False
+        msg = str(cause)
+        return bool(self._BAD_KWARG_RE.search(msg) or self._MISSING_KWARG_RE.search(msg))
+
+    def heal(self, ctx: HealContext) -> HealResult:
+        """Rewrite the failing ``step.<brick>(...)`` call with the corrected kwarg."""
+        bad_kwarg = self._extract_kwarg(str(ctx.error.cause))
+        if bad_kwarg is None:
+            return HealResult()
+        try:
+            callable_, _ = ctx.registry.get(ctx.error.brick_name)
+        except Exception:  # brick vanished from registry — not our problem
+            return HealResult()
+
+        from bricks.core.schema import _callable_params  # noqa: PLC0415
+
+        valid_params = list(_callable_params(callable_).keys())
+        matches = difflib.get_close_matches(bad_kwarg, valid_params, n=1, cutoff=0.6)
+        if not matches:
+            return HealResult()
+        good_kwarg = matches[0]
+
+        # Avoid looping: if this exact rewrite was tried already, decline.
+        rewrite_sig = (ctx.error.brick_name, bad_kwarg, good_kwarg)
+        for att in ctx.prior_attempts:
+            if att.healer_name == self.name and att.error_after and rewrite_sig[1] in att.error_after:
+                return HealResult()
+
+        new_dsl = _rewrite_kwarg_name(
+            source=ctx.failed_dsl,
+            brick_name=ctx.error.brick_name,
+            from_name=bad_kwarg,
+            to_name=good_kwarg,
+        )
+        if new_dsl == ctx.failed_dsl:
+            # Rewrite did not find the call — nothing to change.
+            return HealResult()
+        return HealResult(new_dsl=new_dsl)
+
+    def _extract_kwarg(self, message: str) -> str | None:
+        """Return the offending kwarg name from the TypeError message, or None."""
+        match = self._BAD_KWARG_RE.search(message)
+        if match:
+            return match.group(1)
+        match = self._MISSING_KWARG_RE.search(message)
+        if match:
+            return match.group(1) or match.group(2)
+        return None
+
+
+class DictUnwrapHealer:
+    """Tier 15 — insert ``extract_dict_field`` before a consumer that
+    expects a list but received a wrapper dict.
+
+    Fires on ``AttributeError: 'str' object has no attribute 'get'`` (the
+    signature of iterating a dict's keys through code that assumed it had
+    dicts). Many bricks in the stdlib treat ``list[dict]`` inputs this way
+    — ``filter_dict_list``, ``count_dict_list``, ``map_values``,
+    ``calculate_aggregates`` — so the wrapper-dict mistake is common.
+
+    Strategy:
+
+    1. Find the failing ``step.<X>(...)`` call in the DSL AST.
+    2. Identify the kwarg whose value is ``<producer>.output``.
+    3. Guess the wrapper key the producer returned: parse a phrase like
+       ``key 'tickets'`` or ``under the key 'tickets'`` from the task text.
+       When nothing matches, fall through to tier 20.
+    4. Splice a new assignment ``<producer>_items =
+       step.extract_dict_field(data=<producer>.output, field=<key>)`` before
+       the failing step, rewire the kwarg to ``<producer>_items.output``,
+       and unparse.
+    """
+
+    tier: int = 15
+    name: str = "DictUnwrapHealer"
+
+    _CAUSE_RE = re.compile(
+        r"'str' object has no attribute 'get'|'dict' object has no attribute '(append|extend|insert|pop|sort)'",
+    )
+    _KEY_HINT_RE = re.compile(r"key ['\"]([a-zA-Z_][\w]*)['\"]")
+
+    def can_heal(self, ctx: HealContext) -> bool:
+        """Accept only AttributeError shapes consistent with wrapper-dict input."""
+        cause = ctx.error.cause
+        if not isinstance(cause, AttributeError):
+            return False
+        if not self._CAUSE_RE.search(str(cause)):
+            return False
+        # Avoid loops: if we tried the same wrap and it still failed, step aside.
+        return not any(att.healer_name == self.name and att.exec_succeeded is False for att in ctx.prior_attempts)
+
+    def heal(self, ctx: HealContext) -> HealResult:
+        """Insert extract_dict_field before the failing step."""
+        wrapper_key = self._guess_wrapper_key(ctx.task)
+        if wrapper_key is None:
+            return HealResult()
+        new_dsl = _insert_unwrap_before_step(
+            source=ctx.failed_dsl,
+            failing_brick=ctx.error.brick_name,
+            wrapper_key=wrapper_key,
+        )
+        if new_dsl == ctx.failed_dsl:
+            return HealResult()
+        return HealResult(new_dsl=new_dsl)
+
+    def _guess_wrapper_key(self, task: str) -> str | None:
+        """Pull the wrapper field name from phrases like ``key 'tickets'``."""
+        match = self._KEY_HINT_RE.search(task)
+        if match:
+            return match.group(1)
+        return None
 
 
 class FullRecomposeHealer:

--- a/src/bricks/ai/healing.py
+++ b/src/bricks/ai/healing.py
@@ -1,0 +1,329 @@
+"""Runtime self-heal for composed blueprints — tiered :class:`Healer` chain.
+
+Composer today retries only on *static* (AST) validation failure. When a
+blueprint validates but a brick crashes at execution time, the composer has
+no recovery path. This module adds one.
+
+The abstraction is a **chain of healing strategies**, each living at a
+distinct ``tier`` (lower runs first). A healer inspects the failure context
+and either returns new DSL (``HealResult.new_dsl``) that the chain re-parses
+and re-executes, or passes (``new_flow=None``) so the next tier gets a turn.
+
+Tiered layout — healers ship in follow-up commits inside this PR:
+
+    10  ParamNameHealer            deterministic, 0 LLM calls
+    15  DictUnwrapHealer           deterministic, 0 LLM calls
+    20  LLMRetryHealer             LLM re-prompt with error context
+    30  ShapeAwareLLMHealer        LLM re-prompt with observed shapes
+    40  FullRecomposeHealer        fresh compose with filtered selector
+
+This commit ships only the scaffolding — the five tiers land in later
+commits on the same PR (see #29).
+
+Common substrate: every healer returns DSL **text**. The chain parses the
+text back to a ``FlowDefinition`` via ``BlueprintComposer._parse_dsl_response``
+and calls the caller-supplied ``executor`` to run it. No direct DAG mutation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from bricks.core.exceptions import BrickExecutionError
+
+if TYPE_CHECKING:
+    from bricks.core.dsl import FlowDefinition
+
+
+Executor = Callable[["FlowDefinition"], dict[str, Any]]
+"""Caller-provided closure that runs a ``FlowDefinition`` and returns its
+outputs. Raises :class:`BrickExecutionError` on brick-level failure; other
+exceptions propagate through the chain unhandled."""
+
+
+DSLParser = Callable[[str], "FlowDefinition"]
+"""Parses DSL text back to a ``FlowDefinition``. The composer passes
+its ``_parse_dsl_response`` method so the chain does not re-implement
+AST validation / exec / extraction."""
+
+
+@dataclass
+class HealContext:
+    """Inputs a :class:`Healer` sees for a single healing attempt.
+
+    Attributes:
+        task: Natural-language task the composer was asked to solve.
+        failed_flow: The :class:`FlowDefinition` whose execution just crashed.
+        failed_dsl: The DSL text that produced ``failed_flow``. Kept alongside
+            the flow so healers that rewrite the DSL (all of them) have the
+            source to manipulate.
+        error: The brick-level execution error. Only ``BrickExecutionError``
+            enters the chain — any other exception propagates unhandled.
+        attempt: 0-based index of this healing attempt within the chain's
+            ``max_attempts`` budget.
+        prior_attempts: Outcome of every previous attempt in this chain
+            invocation. Healers consult this to avoid repeating themselves
+            (e.g. :class:`ShapeAwareLLMHealer` only fires *after* a tier-20
+            attempt has failed).
+        registry: The :class:`BrickRegistry` in use. Needed by deterministic
+            healers for signature introspection.
+    """
+
+    task: str
+    failed_flow: FlowDefinition
+    failed_dsl: str
+    error: BrickExecutionError
+    attempt: int
+    prior_attempts: list[HealAttempt] = field(default_factory=list)
+    registry: Any = None  # BrickRegistry — kept loose to avoid cycles at import time
+
+
+@dataclass
+class HealResult:
+    """What a :class:`Healer` returns.
+
+    Attributes:
+        new_dsl: Rewritten DSL text. Empty string when ``new_flow is None``.
+        new_flow: Pre-parsed flow if the healer already materialised it.
+            Most healers return ``new_dsl`` only and let the chain parse;
+            :class:`FullRecomposeHealer` returns the flow directly because
+            it runs the composer and already has one.
+        tokens_in: Input tokens this healer spent (0 for deterministic tiers).
+        tokens_out: Output tokens this healer spent.
+    """
+
+    new_dsl: str = ""
+    new_flow: FlowDefinition | None = None
+    tokens_in: int = 0
+    tokens_out: int = 0
+
+    @property
+    def produced_something(self) -> bool:
+        """True iff the healer has a candidate to hand back to the executor."""
+        return bool(self.new_dsl) or self.new_flow is not None
+
+
+@dataclass
+class HealAttempt:
+    """Trace entry for one iteration of the chain.
+
+    Attributes:
+        healer_name: The :attr:`Healer.name` of the strategy that ran.
+        tier: The :attr:`Healer.tier` of that strategy.
+        produced_flow: Whether the healer returned anything executable.
+        exec_succeeded: True if re-executing the produced flow returned
+            without raising; False if it raised another ``BrickExecutionError``;
+            ``None`` when no flow was produced (nothing to execute).
+        error_after: String form of the re-execution error when
+            ``exec_succeeded is False``. Empty otherwise.
+        tokens_in: Tokens spent by this attempt's healer.
+        tokens_out: Tokens spent by this attempt's healer.
+    """
+
+    healer_name: str
+    tier: int
+    produced_flow: bool
+    exec_succeeded: bool | None
+    error_after: str = ""
+    tokens_in: int = 0
+    tokens_out: int = 0
+
+
+@dataclass
+class ChainResult:
+    """Terminal state of a :meth:`HealerChain.heal` run.
+
+    Attributes:
+        success: True iff some attempt produced a flow that executed cleanly.
+        outputs: Brick outputs from the successful run. ``None`` on failure.
+        final_flow: The FlowDefinition that actually succeeded. ``None`` on
+            failure.
+        final_dsl: The DSL text of the successful flow.
+        final_error: Human-readable final error when ``success is False``.
+        attempts: Ordered trace of every healing attempt, including the ones
+            that produced nothing — useful for observability and tests.
+        total_tokens_in: Sum across attempts; caller folds this into
+            ``ComposeResult.total_input_tokens``.
+        total_tokens_out: Same, for output tokens.
+    """
+
+    success: bool
+    outputs: dict[str, Any] | None = None
+    final_flow: FlowDefinition | None = None
+    final_dsl: str = ""
+    final_error: str = ""
+    attempts: list[HealAttempt] = field(default_factory=list)
+    total_tokens_in: int = 0
+    total_tokens_out: int = 0
+
+
+@runtime_checkable
+class Healer(Protocol):
+    """Strategy for recovering from a runtime brick failure.
+
+    Attributes:
+        tier: Ordering hint — lower tiers run first. Leave gaps between
+            concrete values so future healers can slot in.
+        name: Stable identifier used in logs and ``HealAttempt.healer_name``.
+
+    Implementations must not depend on which other healers sit earlier or
+    later in the chain; the only shared state is :class:`HealContext`.
+    """
+
+    tier: int
+    name: str
+
+    def can_heal(self, ctx: HealContext) -> bool:
+        """Return True iff :meth:`heal` is likely to produce a candidate
+        for *ctx*. Returning False lets the chain move to the next tier."""
+
+    def heal(self, ctx: HealContext) -> HealResult:
+        """Produce a rewritten DSL (or materialised flow). Return a
+        :class:`HealResult` with ``produced_something`` False to decline
+        and let the chain continue."""
+
+
+class HealerChain:
+    """Runs a list of :class:`Healer` strategies against one failure.
+
+    On each iteration the chain finds the lowest-tier applicable healer,
+    calls it, re-executes the produced flow, and either returns success or
+    records a :class:`HealAttempt` and moves to the next iteration. The
+    total number of iterations is bounded by ``max_attempts``.
+
+    The chain does **not** retry on non-``BrickExecutionError`` exceptions
+    raised by the executor — those escape unchanged so framework bugs
+    surface instead of being masked.
+
+    Args:
+        healers: The ordered pool of strategies. Sorted internally by
+            :attr:`Healer.tier` ascending.
+        max_attempts: Hard cap on iterations. Default 2 keeps total LLM
+            cost predictable. Set higher for aggressive recovery.
+    """
+
+    def __init__(self, healers: list[Healer], max_attempts: int = 2) -> None:
+        """Initialise the chain with a pool of healers."""
+        self._healers: list[Healer] = sorted(healers, key=lambda h: h.tier)
+        self._max_attempts = max_attempts
+
+    @property
+    def healers(self) -> list[Healer]:
+        """Read-only view of the sorted healer pool — for tests and logs."""
+        return list(self._healers)
+
+    def heal(
+        self,
+        ctx: HealContext,
+        executor: Executor,
+        parser: DSLParser,
+    ) -> ChainResult:
+        """Attempt to recover from the failure described by *ctx*.
+
+        Args:
+            ctx: Initial failure context. The chain mutates its ``attempt``
+                and ``prior_attempts`` fields as it iterates.
+            executor: Runs a candidate flow. Must raise
+                :class:`BrickExecutionError` on brick failure.
+            parser: Turns DSL text into a :class:`FlowDefinition`. Pass the
+                composer's ``_parse_dsl_response`` bound method.
+
+        Returns:
+            A :class:`ChainResult` reflecting the final state. Never raises
+            ``BrickExecutionError`` itself — that is captured in
+            ``ChainResult.final_error`` when all attempts exhaust.
+        """
+        attempts: list[HealAttempt] = []
+        tokens_in = 0
+        tokens_out = 0
+
+        for attempt_idx in range(self._max_attempts):
+            ctx.attempt = attempt_idx
+            ctx.prior_attempts = attempts
+
+            healer = self._pick_healer(ctx)
+            if healer is None:
+                # No tier applies — stop; whatever error is in ctx is final.
+                break
+
+            result = healer.heal(ctx)
+            tokens_in += result.tokens_in
+            tokens_out += result.tokens_out
+
+            if not result.produced_something:
+                attempts.append(
+                    HealAttempt(
+                        healer_name=healer.name,
+                        tier=healer.tier,
+                        produced_flow=False,
+                        exec_succeeded=None,
+                        tokens_in=result.tokens_in,
+                        tokens_out=result.tokens_out,
+                    )
+                )
+                continue
+
+            new_flow = result.new_flow if result.new_flow is not None else parser(result.new_dsl)
+
+            try:
+                outputs = executor(new_flow)
+            except BrickExecutionError as exc:
+                attempts.append(
+                    HealAttempt(
+                        healer_name=healer.name,
+                        tier=healer.tier,
+                        produced_flow=True,
+                        exec_succeeded=False,
+                        error_after=str(exc),
+                        tokens_in=result.tokens_in,
+                        tokens_out=result.tokens_out,
+                    )
+                )
+                # Swap in the new failure context for the next iteration.
+                ctx = HealContext(
+                    task=ctx.task,
+                    failed_flow=new_flow,
+                    failed_dsl=result.new_dsl or ctx.failed_dsl,
+                    error=exc,
+                    attempt=attempt_idx,  # re-set on next loop
+                    prior_attempts=attempts,
+                    registry=ctx.registry,
+                )
+                continue
+
+            attempts.append(
+                HealAttempt(
+                    healer_name=healer.name,
+                    tier=healer.tier,
+                    produced_flow=True,
+                    exec_succeeded=True,
+                    tokens_in=result.tokens_in,
+                    tokens_out=result.tokens_out,
+                )
+            )
+            return ChainResult(
+                success=True,
+                outputs=outputs,
+                final_flow=new_flow,
+                final_dsl=result.new_dsl,
+                attempts=attempts,
+                total_tokens_in=tokens_in,
+                total_tokens_out=tokens_out,
+            )
+
+        return ChainResult(
+            success=False,
+            final_error=str(ctx.error),
+            attempts=attempts,
+            total_tokens_in=tokens_in,
+            total_tokens_out=tokens_out,
+        )
+
+    def _pick_healer(self, ctx: HealContext) -> Healer | None:
+        """Return the lowest-tier healer whose ``can_heal`` accepts *ctx*."""
+        for healer in self._healers:
+            if healer.can_heal(ctx):
+                return healer
+        return None

--- a/src/bricks/ai/healing.py
+++ b/src/bricks/ai/healing.py
@@ -35,6 +35,80 @@ from bricks.core.exceptions import BrickExecutionError
 
 if TYPE_CHECKING:
     from bricks.core.dsl import FlowDefinition
+    from bricks.llm.base import LLMProvider
+
+
+_RUNTIME_RETRY_PROMPT = """\
+Original task:
+{task}
+
+Your previous DSL compiled but crashed at runtime:
+
+{code}
+
+Runtime error — brick {brick_name!r} at step {step_name!r}:
+{cause}
+
+Common fixes:
+- If parsing JSON that wraps a list (e.g. {{"customers": [...]}}), use
+  step.extract_dict_field(data=parsed.output, field="customers") before filtering.
+- reduce_sum takes a LIST of node refs: step.reduce_sum(values=[a, b, c]).
+- Brick parameter names must match the signatures exactly.
+
+Output ONLY the corrected Python code. Nothing else.\
+"""
+
+
+_SHAPE_AWARE_RETRY_PROMPT = """\
+Original task:
+{task}
+
+Your previous DSL compiled but crashed at runtime. Here are the actual
+runtime shapes of each step output up to the failure, so you can see
+where the data became incompatible:
+
+{shapes}
+
+Failed DSL:
+
+{code}
+
+Runtime error — brick {brick_name!r} at step {step_name!r}:
+{cause}
+
+Use the observed shapes to pick the right brick and parameters. If an
+earlier step output is a dict that wraps the list you need, insert
+extract_dict_field before the consuming step.
+
+Output ONLY the corrected Python code. Nothing else.\
+"""
+
+
+TraceExecutor = Callable[["FlowDefinition"], dict[str, Any]]
+"""Variant of :data:`Executor` that returns a mapping of step name to a
+short shape description (e.g. ``"list[dict]<len=42>"``). Used by tier 30
+(:class:`ShapeAwareLLMHealer`). Raises :class:`BrickExecutionError`
+naturally if the blueprint still crashes — the caller is expected to
+capture whatever shapes were observed before the raise, not to swallow
+the exception itself."""
+
+
+FreshCompose = Callable[[str, list[str]], "HealResult"]
+"""Variant of compose() taking (task, excluded_bricks). Returns a HealResult
+with ``new_flow`` set on success (and tokens_in/out populated). Used by
+tier 40 (:class:`FullRecomposeHealer`). When compose fails validation, the
+callable returns ``HealResult()`` (no flow, no DSL) so the chain records
+the tokens spent and moves on."""
+
+
+def _strip_fences(code: str) -> str:
+    """Remove markdown code fences from LLM output, stripping surrounding whitespace."""
+    cleaned = code.strip()
+    if cleaned.startswith("```"):
+        lines = cleaned.split("\n")
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        cleaned = "\n".join(lines)
+    return cleaned.strip()
 
 
 Executor = Callable[["FlowDefinition"], dict[str, Any]]
@@ -327,3 +401,184 @@ class HealerChain:
             if healer.can_heal(ctx):
                 return healer
         return None
+
+
+class LLMRetryHealer:
+    """Tier 20 — ask the LLM to correct the DSL given the runtime error.
+
+    Accepts any :class:`BrickExecutionError`. Sends a short retry prompt
+    (task + failed DSL + brick/step/cause) to the LLM, reusing the same
+    system prompt the composer used, so brick signatures remain in scope.
+
+    Args:
+        provider: The LLM provider the composer is using. The healer calls
+            ``provider.complete(prompt=..., system=...)`` and strips fences.
+        system_prompt: The full system prompt composer built for this
+            compose call — contains brick signatures and DSL rules. Reused
+            verbatim so the LLM has the same context it had on the original
+            attempt.
+    """
+
+    tier: int = 20
+    name: str = "LLMRetryHealer"
+
+    def __init__(self, provider: LLMProvider, system_prompt: str) -> None:
+        """Initialise with provider + system prompt."""
+        self._provider = provider
+        self._system_prompt = system_prompt
+
+    def can_heal(self, ctx: HealContext) -> bool:
+        """Always applies — this is the general-purpose tier."""
+        del ctx
+        return True
+
+    def heal(self, ctx: HealContext) -> HealResult:
+        """Send the retry prompt, strip fences, return the corrected DSL."""
+        user_prompt = _RUNTIME_RETRY_PROMPT.format(
+            task=ctx.task,
+            code=ctx.failed_dsl,
+            brick_name=ctx.error.brick_name,
+            step_name=ctx.error.step_name,
+            cause=ctx.error.cause,
+        )
+        completion = self._provider.complete(prompt=user_prompt, system=self._system_prompt)
+        return HealResult(
+            new_dsl=_strip_fences(completion.text),
+            tokens_in=completion.input_tokens,
+            tokens_out=completion.output_tokens,
+        )
+
+
+class ShapeAwareLLMHealer:
+    """Tier 30 — LLM retry with observed runtime shapes spliced into the prompt.
+
+    Only fires *after* a tier-20 attempt has already failed — otherwise we
+    would pay the cost of a shape trace on the first attempt, when a plain
+    LLM retry might have sufficed.
+
+    The healer runs the failed flow through a ``trace_executor`` which is
+    expected to capture step outputs even when a later step raises. The
+    captured ``{step_name: shape_string}`` dict is included in the retry
+    prompt so the LLM can see where data shape diverged from what the
+    consuming brick expected.
+
+    Args:
+        provider: The LLM provider.
+        system_prompt: Same system prompt the composer used.
+        trace_executor: Runs the blueprint and returns a ``{step_name:
+            shape}`` mapping. If ``None`` the healer's :meth:`can_heal`
+            returns False — trace execution is a caller capability and
+            not every caller can supply it.
+    """
+
+    tier: int = 30
+    name: str = "ShapeAwareLLMHealer"
+
+    def __init__(
+        self,
+        provider: LLMProvider,
+        system_prompt: str,
+        trace_executor: TraceExecutor | None = None,
+    ) -> None:
+        """Initialise. trace_executor is optional; without it can_heal is False."""
+        self._provider = provider
+        self._system_prompt = system_prompt
+        self._trace_executor = trace_executor
+
+    def can_heal(self, ctx: HealContext) -> bool:
+        """Fire only after a prior tier-20 attempt failed and we have a trace path."""
+        if self._trace_executor is None:
+            return False
+        return any(att.tier == LLMRetryHealer.tier and att.exec_succeeded is False for att in ctx.prior_attempts)
+
+    def heal(self, ctx: HealContext) -> HealResult:
+        """Capture shapes via trace_executor, then call the LLM with them."""
+        trace_executor = self._trace_executor
+        if trace_executor is None:
+            # Should be unreachable — can_heal guards this — but we keep a
+            # runtime check rather than an assert so production behavior
+            # is deterministic instead of silently optimised away under -O.
+            return HealResult()
+        try:
+            shapes = trace_executor(ctx.failed_flow)
+        except BrickExecutionError:
+            # The flow still crashes under the trace executor — no shapes for
+            # the failing step itself, but any earlier shapes captured are
+            # better than nothing. trace_executor contract: it records what
+            # it saw even on crash. If it genuinely captured nothing, fall
+            # back to empty dict.
+            shapes = {}
+        except Exception:  # tracer is best-effort observability
+            shapes = {}
+
+        shapes_block = "\n".join(f"- {name}: {shape}" for name, shape in shapes.items()) or "(no shape info available)"
+
+        user_prompt = _SHAPE_AWARE_RETRY_PROMPT.format(
+            task=ctx.task,
+            code=ctx.failed_dsl,
+            shapes=shapes_block,
+            brick_name=ctx.error.brick_name,
+            step_name=ctx.error.step_name,
+            cause=ctx.error.cause,
+        )
+        completion = self._provider.complete(prompt=user_prompt, system=self._system_prompt)
+        return HealResult(
+            new_dsl=_strip_fences(completion.text),
+            tokens_in=completion.input_tokens,
+            tokens_out=completion.output_tokens,
+        )
+
+
+class FullRecomposeHealer:
+    """Tier 40 — recompose from scratch with failed bricks excluded.
+
+    Last-ditch healer. Fires only after three prior attempts failed, so
+    the chain has genuine evidence the current blueprint shape is broken.
+
+    Delegates to the caller-supplied ``fresh_compose`` callable, passing
+    the list of brick names that appeared in ``BrickExecutionError`` reports
+    across the prior attempts. The callable is expected to build a new
+    composer with a :class:`~bricks.core.filtering_selector.FilteringSelector`
+    wrapping the original selector and excluding those names, then run
+    compose. See :class:`BlueprintComposer` for the canonical wiring.
+
+    Args:
+        fresh_compose: Takes ``(task, excluded_bricks)`` and returns a
+            :class:`HealResult`. On compose-validation failure returns an
+            empty result; on success returns ``HealResult(new_flow=...)``.
+    """
+
+    tier: int = 40
+    name: str = "FullRecomposeHealer"
+
+    def __init__(self, fresh_compose: FreshCompose) -> None:
+        """Initialise with a fresh-compose callable."""
+        self._fresh_compose = fresh_compose
+
+    def can_heal(self, ctx: HealContext) -> bool:
+        """Only fire after we have real evidence the blueprint shape is wrong."""
+        return len(ctx.prior_attempts) >= 3
+
+    def heal(self, ctx: HealContext) -> HealResult:
+        """Collect brick names from prior errors and kick off a fresh compose."""
+        excluded: list[str] = []
+        seen: set[str] = set()
+        # Gather brick names from every attempt that produced a flow but
+        # whose re-execution failed. The order-of-first-seen is preserved
+        # so FilteringSelector's exclusion set is deterministic.
+        for att in ctx.prior_attempts:
+            if att.exec_succeeded is False and att.error_after:
+                # Best-effort parse of "Brick 'X' failed at step 'Y': ..."
+                marker = "Brick '"
+                if marker in att.error_after:
+                    start = att.error_after.index(marker) + len(marker)
+                    end = att.error_after.index("'", start)
+                    brick = att.error_after[start:end]
+                    if brick not in seen:
+                        seen.add(brick)
+                        excluded.append(brick)
+        # Always include the current error's brick — it just failed.
+        if ctx.error.brick_name not in seen:
+            excluded.append(ctx.error.brick_name)
+
+        return self._fresh_compose(ctx.task, excluded)

--- a/src/bricks/benchmark/showcase/engine.py
+++ b/src/bricks/benchmark/showcase/engine.py
@@ -137,6 +137,13 @@ class BricksEngine(Engine):
     def solve(self, task_text: str, raw_data: str) -> EngineResult:
         """Compose blueprint from task_text, execute it with raw_data.
 
+        The executor closure is handed to the composer so the HealerChain
+        owns runtime-retry end-to-end. When the LLM emits DSL that
+        validates but crashes at execution time, composer catches the
+        ``BrickExecutionError`` internally and routes through the tiered
+        healers. Successful outputs come back via ``compose_result.exec_outputs``;
+        a final failure surfaces via ``compose_result.exec_error``.
+
         Args:
             task_text: Natural language task description (used for compose).
             raw_data: Raw API response data (passed as blueprint input).
@@ -145,7 +152,30 @@ class BricksEngine(Engine):
             EngineResult with blueprint execution outputs.
         """
         t0 = time.monotonic()
-        compose_result = self._composer.compose(task_text, self._registry, input_keys=["raw_api_response"])
+
+        def _run(flow_def: Any) -> dict[str, Any]:
+            return flow_def.execute(inputs={"raw_api_response": raw_data}, engine=self._engine)
+
+        try:
+            compose_result = self._composer.compose(
+                task_text,
+                self._registry,
+                input_keys=["raw_api_response"],
+                executor=_run,
+            )
+        except Exception as exc:
+            # Framework errors from compose itself (not BrickExecutionError —
+            # those are caught inside compose). Surface them as a failed result.
+            logger.error("[BricksEngine] Compose raised: %s", exc)
+            return EngineResult(
+                outputs={},
+                tokens_in=0,
+                tokens_out=0,
+                duration_seconds=time.monotonic() - t0,
+                model="",
+                raw_response="",
+                error=str(exc),
+            )
 
         if not compose_result.is_valid:
             logger.error("[BricksEngine] Compose failed: %s", compose_result.validation_errors)
@@ -159,18 +189,14 @@ class BricksEngine(Engine):
                 error="; ".join(compose_result.validation_errors),
             )
 
-        try:
-            if compose_result.flow_def is not None:
-                exec_outputs = compose_result.flow_def.execute(
-                    inputs={"raw_api_response": raw_data},
-                    engine=self._engine,
-                )
-            else:
-                bp_def = self._loader.load_string(compose_result.blueprint_yaml)
-                exec_outputs = self._engine.run(bp_def, inputs={"raw_api_response": raw_data}).outputs
-            logger.debug("[BricksEngine] Execution outputs: %s", exec_outputs)
+        if compose_result.exec_outputs is not None:
+            logger.debug(
+                "[BricksEngine] Execution outputs: %s (heal_attempts=%d)",
+                compose_result.exec_outputs,
+                len(compose_result.heal_attempts),
+            )
             return EngineResult(
-                outputs=exec_outputs,
+                outputs=compose_result.exec_outputs,
                 tokens_in=compose_result.total_input_tokens,
                 tokens_out=compose_result.total_output_tokens,
                 duration_seconds=time.monotonic() - t0,
@@ -178,17 +204,23 @@ class BricksEngine(Engine):
                 raw_response=compose_result.blueprint_yaml,
                 flow_def=compose_result.flow_def,
             )
-        except Exception as exc:
-            logger.error("[BricksEngine] Execution failed: %s", exc)
-            return EngineResult(
-                outputs={},
-                tokens_in=compose_result.total_input_tokens,
-                tokens_out=compose_result.total_output_tokens,
-                duration_seconds=time.monotonic() - t0,
-                model=compose_result.model,
-                raw_response=compose_result.blueprint_yaml,
-                error=str(exc),
-            )
+
+        # exec_outputs is None while is_valid is True → execution failed
+        # after all healers were exhausted.
+        logger.error(
+            "[BricksEngine] Execution failed after %d heal attempts: %s",
+            len(compose_result.heal_attempts),
+            compose_result.exec_error,
+        )
+        return EngineResult(
+            outputs={},
+            tokens_in=compose_result.total_input_tokens,
+            tokens_out=compose_result.total_output_tokens,
+            duration_seconds=time.monotonic() - t0,
+            model=compose_result.model,
+            raw_response=compose_result.blueprint_yaml,
+            error=compose_result.exec_error or "unknown runtime error",
+        )
 
     def solve_reuse(self, blueprint_yaml: str, raw_data: str, flow_def: Any = None) -> EngineResult:
         """Execute an existing blueprint without recomposing (0 LLM tokens).

--- a/src/bricks/benchmark/tests/test_engine.py
+++ b/src/bricks/benchmark/tests/test_engine.py
@@ -150,23 +150,27 @@ class TestRawLLMEngine:
         assert engine.__class__.__name__ == "RawLLMEngine"
 
 
-class TestBricksEngineSolveDirectExecution:
-    """Tests that BricksEngine.solve() uses flow_def.execute() when available."""
+class TestBricksEngineSolveDelegatesToComposer:
+    """BricksEngine.solve() now delegates execution to the composer via its
+    ``executor=`` param — the duplicated direct/yaml fallback was removed
+    when the HealerChain landed (#27). These tests pin the new contract.
+    """
 
-    def test_uses_direct_execution_when_flow_def_available(self) -> None:
-        """solve() calls flow_def.execute() and skips BlueprintLoader when flow_def is set."""
+    def test_passes_executor_closure_and_returns_exec_outputs(self) -> None:
+        """solve() must forward an executor to compose() and surface
+        ``exec_outputs`` on the resulting EngineResult."""
         from bricks.benchmark.showcase.engine import BricksEngine
-
-        mock_flow_def = MagicMock()
-        mock_flow_def.execute.return_value = {"active_count": 3}
 
         mock_compose_result = MagicMock()
         mock_compose_result.is_valid = True
-        mock_compose_result.flow_def = mock_flow_def
+        mock_compose_result.flow_def = MagicMock()
         mock_compose_result.blueprint_yaml = "yaml: placeholder"
         mock_compose_result.total_input_tokens = 10
         mock_compose_result.total_output_tokens = 5
         mock_compose_result.model = "test-model"
+        mock_compose_result.exec_outputs = {"active_count": 3}
+        mock_compose_result.exec_error = ""
+        mock_compose_result.heal_attempts = []
 
         engine = BricksEngine.__new__(BricksEngine)
         engine._composer = MagicMock()
@@ -177,32 +181,40 @@ class TestBricksEngineSolveDirectExecution:
 
         result = engine.solve("task", "raw data")
 
-        mock_flow_def.execute.assert_called_once()
+        # compose() must be called with an executor closure.
+        engine._composer.compose.assert_called_once()
+        kwargs = engine._composer.compose.call_args.kwargs
+        assert "executor" in kwargs and callable(kwargs["executor"])
+        # YAML fallback is gone — loader must not be touched.
         engine._loader.load_string.assert_not_called()
         assert result.outputs == {"active_count": 3}
 
-    def test_falls_back_to_yaml_when_flow_def_is_none(self) -> None:
-        """solve() falls back to BlueprintLoader when flow_def is None."""
+    def test_surfaces_exec_error_when_healing_exhausts(self) -> None:
+        """When compose returns a valid blueprint but exec_outputs is None,
+        solve() surfaces exec_error as EngineResult.error without touching
+        the loader."""
         from bricks.benchmark.showcase.engine import BricksEngine
-        from bricks.core.models import ExecutionResult
 
         mock_compose_result = MagicMock()
         mock_compose_result.is_valid = True
-        mock_compose_result.flow_def = None
+        mock_compose_result.flow_def = MagicMock()
         mock_compose_result.blueprint_yaml = "yaml: placeholder"
-        mock_compose_result.total_input_tokens = 10
-        mock_compose_result.total_output_tokens = 5
+        mock_compose_result.total_input_tokens = 30
+        mock_compose_result.total_output_tokens = 12
         mock_compose_result.model = "test-model"
+        mock_compose_result.exec_outputs = None
+        mock_compose_result.exec_error = "all tiers exhausted"
+        mock_compose_result.heal_attempts = [MagicMock(), MagicMock()]
 
         engine = BricksEngine.__new__(BricksEngine)
         engine._composer = MagicMock()
         engine._composer.compose.return_value = mock_compose_result
         engine._engine = MagicMock()
-        engine._engine.run.return_value = ExecutionResult(outputs={"x": 1}, steps=[])
         engine._loader = MagicMock()
         engine._registry = MagicMock()
 
         result = engine.solve("task", "raw data")
 
-        engine._loader.load_string.assert_called_once_with("yaml: placeholder")
-        assert result.outputs == {"x": 1}
+        assert result.outputs == {}
+        assert result.error == "all tiers exhausted"
+        engine._loader.load_string.assert_not_called()

--- a/src/bricks/benchmark/tests/test_smoke_pipeline.py
+++ b/src/bricks/benchmark/tests/test_smoke_pipeline.py
@@ -88,17 +88,17 @@ def count_pipeline(raw_text):
         assert "result" in result, f"Expected 'result' key in outputs, got: {result}"
         assert result["result"] == 5, f"Expected 5 chars in 'hello', got: {result['result']}"
 
-    def test_compose_result_flow_def_survives_to_engine(self) -> None:
-        """Regression: ComposeResult.flow_def must be used by BricksEngine (not BlueprintLoader).
+    def test_compose_result_exec_outputs_survive_to_engine(self) -> None:
+        """Regression: BricksEngine.solve reads ``exec_outputs`` from ComposeResult.
 
-        Asserts that when ComposeResult.flow_def is set, BricksEngine.solve()
-        calls flow_def.execute() and never calls BlueprintLoader.load_string().
-        If this test fails, the YAML-roundtrip regression has been reintroduced.
+        After #27 the composer's HealerChain owns runtime execution; solve()
+        just forwards an executor closure and trusts ``exec_outputs``. This
+        test pins that contract — in particular, the YAML-roundtrip path
+        must never be re-introduced (loader.load_string must not be called).
         """
         from bricks.benchmark.showcase.engine import BricksEngine
 
         mock_flow_def = MagicMock(spec=FlowDefinition)
-        mock_flow_def.execute.return_value = {"active_count": 5}
 
         mock_compose_result = MagicMock(spec=ComposeResult)
         mock_compose_result.is_valid = True
@@ -107,6 +107,9 @@ def count_pipeline(raw_text):
         mock_compose_result.total_input_tokens = 0
         mock_compose_result.total_output_tokens = 0
         mock_compose_result.model = "test-model"
+        mock_compose_result.exec_outputs = {"active_count": 5}
+        mock_compose_result.exec_error = ""
+        mock_compose_result.heal_attempts = []
 
         engine = BricksEngine.__new__(BricksEngine)
         engine._composer = MagicMock()
@@ -117,7 +120,9 @@ def count_pipeline(raw_text):
 
         result = engine.solve("count active customers", '{"data": []}')
 
-        mock_flow_def.execute.assert_called_once()
+        # compose() must have been called with an executor closure.
+        kwargs = engine._composer.compose.call_args.kwargs
+        assert "executor" in kwargs and callable(kwargs["executor"])
         engine._loader.load_string.assert_not_called()
         assert result.outputs == {"active_count": 5}
 

--- a/src/bricks/core/filtering_selector.py
+++ b/src/bricks/core/filtering_selector.py
@@ -1,0 +1,61 @@
+"""FilteringSelector — wraps another selector and excludes named bricks.
+
+Used by the tier-40 :class:`~bricks.ai.healing.FullRecomposeHealer` when
+prior healing attempts identified specific bricks that the LLM keeps
+misusing. By dropping those bricks from the pool before the next compose,
+the LLM is forced to pick an alternative.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from bricks.core.registry import BrickRegistry
+from bricks.core.selector import BrickSelector
+
+
+class FilteringSelector(BrickSelector):
+    """Wrap another :class:`BrickSelector` and drop named bricks from its result.
+
+    The inner selector runs first; this one rebuilds its registry without
+    the excluded names. Registrations are copied via the public registry
+    API (``register``) rather than mutating private state.
+
+    Args:
+        inner: The selector whose pool we post-filter.
+        exclude: Brick names to drop. Missing names are silently ignored —
+            the filter is a superset, not an invariant.
+    """
+
+    def __init__(self, inner: BrickSelector, exclude: Iterable[str]) -> None:
+        """Initialise with an inner selector and a set of names to exclude."""
+        self._inner = inner
+        self._exclude = set(exclude)
+
+    @property
+    def excluded(self) -> frozenset[str]:
+        """Read-only view of the exclusion set — for tests and logs."""
+        return frozenset(self._exclude)
+
+    def select(self, task: str, registry: BrickRegistry) -> BrickRegistry:
+        """Return a registry containing the inner pool minus excluded names.
+
+        Args:
+            task: Natural language task (passed to the inner selector).
+            registry: Full registry to select from.
+
+        Returns:
+            A fresh :class:`BrickRegistry` that omits every excluded name.
+            If nothing is excluded, returns the inner result unchanged.
+        """
+        pool = self._inner.select(task, registry)
+        if not self._exclude:
+            return pool
+
+        filtered = BrickRegistry()
+        for name, meta in pool.list_all():
+            if name in self._exclude:
+                continue
+            callable_, _ = pool.get(name)
+            filtered.register(name, callable_, meta)
+        return filtered

--- a/src/bricks/llm/base.py
+++ b/src/bricks/llm/base.py
@@ -17,6 +17,16 @@ class CompletionResult:
         model: Which model actually responded.
         duration_seconds: Wall-clock time for this call.
         estimated: True if tokens are tiktoken estimates; False if from API.
+        cached_input_tokens: Number of input tokens served from the prompt
+            cache. Unified across providers: Anthropic's
+            ``cache_read_input_tokens`` and OpenAI's
+            ``prompt_tokens_details.cached_tokens`` both populate this.
+            ``0`` when caching is inactive, unsupported, or on a cache miss.
+        cache_creation_input_tokens: Anthropic-only counter for tokens that
+            were written to the ephemeral prompt cache on this call.
+            Surfaces tier-1 cache writes so callers can distinguish first-
+            pay writes from subsequent reads. ``0`` for non-Anthropic
+            providers.
     """
 
     text: str
@@ -25,6 +35,8 @@ class CompletionResult:
     model: str = ""
     duration_seconds: float = 0.0
     estimated: bool = False
+    cached_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
 
 
 class LLMProvider(ABC):

--- a/src/bricks/llm/litellm_provider.py
+++ b/src/bricks/llm/litellm_provider.py
@@ -2,10 +2,69 @@
 
 from __future__ import annotations
 
+import re
 import time
+from typing import Any
 
 from bricks.errors import BricksComposeError, BricksConfigError
 from bricks.llm.base import CompletionResult, LLMProvider
+
+_ANTHROPIC_FAMILY_RE = re.compile(
+    r"^(claude-|openrouter/anthropic/|bedrock/anthropic/|anthropic/)",
+    re.IGNORECASE,
+)
+
+
+def _is_anthropic_family(model: str) -> bool:
+    """Return True for model strings that route through Anthropic.
+
+    Matches direct Anthropic IDs (``claude-haiku-4-5-20251001``) and the
+    pass-through prefixes LiteLLM uses for OpenRouter / Bedrock / explicit
+    ``anthropic/`` routing. OpenAI, Gemini, Ollama, and anything else are
+    handled by LiteLLM's own automatic caching (OpenAI) or left uncached
+    (everything else), so they stay on the plain-string code path below.
+    """
+    return bool(_ANTHROPIC_FAMILY_RE.match(model))
+
+
+def _build_system_content(system: str, model: str) -> str | list[dict[str, Any]]:
+    """Shape the system prompt for the caller's model family.
+
+    Anthropic models use content-block lists with ``cache_control`` set to
+    ``{"type": "ephemeral"}`` so the composer's ~2500-token system prompt
+    hits the prompt cache on every call after the first. Everything else
+    gets the legacy plain-string form.
+    """
+    if not system:
+        return system
+    if _is_anthropic_family(model):
+        return [{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}]
+    return system
+
+
+def _extract_cached_tokens(usage: Any) -> tuple[int, int]:
+    """Return ``(cached_input_tokens, cache_creation_input_tokens)`` from a
+    LiteLLM-normalised ``usage`` object.
+
+    LiteLLM exposes provider-specific fields through attribute access.
+    Anthropic surfaces ``cache_read_input_tokens`` and
+    ``cache_creation_input_tokens``. OpenAI exposes
+    ``prompt_tokens_details.cached_tokens`` (nested object). Missing
+    fields or shapes default to ``0`` so callers can treat them as
+    monotonic counters.
+    """
+    if usage is None:
+        return 0, 0
+
+    cached = int(getattr(usage, "cache_read_input_tokens", 0) or 0)
+    creation = int(getattr(usage, "cache_creation_input_tokens", 0) or 0)
+
+    if cached == 0:
+        details = getattr(usage, "prompt_tokens_details", None)
+        if details is not None:
+            cached = int(getattr(details, "cached_tokens", 0) or 0)
+
+    return cached, creation
 
 
 class LiteLLMProvider(LLMProvider):
@@ -60,7 +119,7 @@ class LiteLLMProvider(LLMProvider):
             response = litellm.completion(
                 model=self._model,
                 messages=[
-                    {"role": "system", "content": system},
+                    {"role": "system", "content": _build_system_content(system, self._model)},
                     {"role": "user", "content": prompt},
                 ],
                 api_key=self._api_key,
@@ -70,6 +129,7 @@ class LiteLLMProvider(LLMProvider):
             usage = getattr(response, "usage", None)
             in_tok = int(getattr(usage, "prompt_tokens", 0) or 0)
             out_tok = int(getattr(usage, "completion_tokens", 0) or 0)
+            cached_in, cache_write = _extract_cached_tokens(usage)
             return CompletionResult(
                 text=text,
                 input_tokens=in_tok,
@@ -77,6 +137,8 @@ class LiteLLMProvider(LLMProvider):
                 model=self._model,
                 duration_seconds=time.monotonic() - t0,
                 estimated=False,
+                cached_input_tokens=cached_in,
+                cache_creation_input_tokens=cache_write,
             )
         except ImportError:
             raise

--- a/tests/ai/test_composer.py
+++ b/tests/ai/test_composer.py
@@ -348,8 +348,8 @@ class TestDSLPromptTemplate:
         )
         assert "every brick returns a dict" in prompt.lower(), "Data flow contract missing from DSL_PROMPT_TEMPLATE"
 
-    def test_prompt_contains_worked_example(self) -> None:
-        """DSL_PROMPT_TEMPLATE includes the worked @flow example."""
+    def test_prompt_contains_worked_examples(self) -> None:
+        """DSL_PROMPT_TEMPLATE includes worked @flow examples A/B/C."""
         from bricks.ai.composer import DSL_PROMPT_TEMPLATE
 
         prompt = DSL_PROMPT_TEMPLATE.format(
@@ -357,5 +357,7 @@ class TestDSLPromptTemplate:
             task="test task",
             input_context="",
         )
-        assert "crm_summary" in prompt, "Worked example missing from DSL_PROMPT_TEMPLATE"
-        assert "do not copy it literally" in prompt, "Example instruction missing"
+        assert "crm_summary" in prompt, "Example A missing from DSL_PROMPT_TEMPLATE"
+        assert "ticket_urgency_report" in prompt, "Example B missing from DSL_PROMPT_TEMPLATE"
+        assert "file_report" in prompt, "Example C missing from DSL_PROMPT_TEMPLATE"
+        assert "do not copy them literally" in prompt, "Example instruction missing"

--- a/tests/ai/test_composer_examples.py
+++ b/tests/ai/test_composer_examples.py
@@ -1,0 +1,114 @@
+"""Regression tests for the worked examples baked into DSL_PROMPT_TEMPLATE.
+
+The examples are part of the system prompt — if they contain invalid DSL the
+LLM will be trained on a broken pattern and cascade the bug into generated
+blueprints. These tests guarantee every `@flow` block in the template parses
+through :func:`bricks.core.validator_dsl.validate_dsl` and exercises its
+stated pattern.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from bricks.ai.composer import DSL_PROMPT_TEMPLATE
+from bricks.core.validator_dsl import validate_dsl
+
+
+def _extract_examples(template: str) -> list[str]:
+    """Return every ``@flow`` function literal found in *template*.
+
+    Splits the template on the ``@flow`` marker, then for each chunk takes
+    lines until the block dedents back to column 0 — giving the full
+    function text including multi-line returns.
+
+    The template uses doubled braces for ``.format`` escaping; the examples
+    themselves contain literal ``{{`` / ``}}`` pairs that must be unescaped
+    before the DSL validator will accept them.
+    """
+    rendered = template.replace("{{", "{").replace("}}", "}")
+    parts = rendered.split("@flow\n")[1:]  # drop preamble
+    examples: list[str] = []
+    for part in parts:
+        lines = part.splitlines()
+        # A real example starts with ``def <name>(...)`` on the very next line.
+        # Rule-body mentions of ``@flow`` (e.g. "decorated with @flow") are
+        # skipped here.
+        if not lines or not lines[0].lstrip().startswith("def "):
+            continue
+        collected = ["@flow"]
+        for line in lines:
+            if not line.strip():
+                break
+            if collected[-1] != "@flow" and not line.startswith((" ", "\t")):
+                break
+            collected.append(line)
+        examples.append("\n".join(collected).rstrip())
+    return examples
+
+
+def _brick_calls(code: str) -> set[str]:
+    """Return the set of ``step.<name>`` and primitive calls in *code*."""
+    tree = ast.parse(code)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name) and node.value.id == "step":
+            names.add(f"step.{node.attr}")
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            names.add(node.func.id)
+    return names
+
+
+def test_template_has_three_examples() -> None:
+    """The prompt must ship exactly three worked examples (A, B, C)."""
+    examples = _extract_examples(DSL_PROMPT_TEMPLATE)
+    assert len(examples) == 3, f"expected 3 examples, found {len(examples)}"
+
+
+@pytest.mark.parametrize("idx", [0, 1, 2])
+def test_each_example_passes_ast_validator(idx: int) -> None:
+    """Each embedded example must satisfy validate_dsl — otherwise we are
+    teaching the LLM to emit code the composer will reject."""
+    examples = _extract_examples(DSL_PROMPT_TEMPLATE)
+    code = examples[idx]
+    result = validate_dsl(code)
+    assert result.valid, f"example #{idx + 1} failed validation: {result.errors}\ncode:\n{code}"
+
+
+def test_example_a_uses_extract_dict_field() -> None:
+    """Example A teaches the unwrap-before-filter pattern (issue #28)."""
+    code = _extract_examples(DSL_PROMPT_TEMPLATE)[0]
+    calls = _brick_calls(code)
+    assert "step.extract_dict_field" in calls, (
+        "example A must demonstrate extract_dict_field unwrap so the LLM "
+        "learns not to pass a wrapper dict directly to filter_dict_list"
+    )
+    assert "step.filter_dict_list" in calls
+
+
+def test_example_b_uses_for_each_and_reduce_sum_list() -> None:
+    """Example B teaches for_each + list-of-Node reduce_sum (issue #28)."""
+    code = _extract_examples(DSL_PROMPT_TEMPLATE)[1]
+    calls = _brick_calls(code)
+    assert "for_each" in calls
+    assert "step.reduce_sum" in calls
+    # reduce_sum must be called with a list kwarg so the pattern is exercised.
+    tree = ast.parse(code)
+    reduce_calls = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute) and n.func.attr == "reduce_sum"
+    ]
+    assert reduce_calls, "reduce_sum call not found"
+    values_kw = next((kw for kw in reduce_calls[0].keywords if kw.arg == "values"), None)
+    assert values_kw is not None, "reduce_sum must be called with values= kwarg"
+    assert isinstance(values_kw.value, ast.List), "values= must be a list literal so the list-of-Node pattern is taught"
+
+
+def test_example_c_uses_branch() -> None:
+    """Example C teaches branch routing (issue #28)."""
+    code = _extract_examples(DSL_PROMPT_TEMPLATE)[2]
+    calls = _brick_calls(code)
+    assert "branch" in calls

--- a/tests/ai/test_composer_runtime_retry.py
+++ b/tests/ai/test_composer_runtime_retry.py
@@ -1,0 +1,272 @@
+"""Integration tests for the composer ↔ HealerChain wiring.
+
+The scaffolding tests in ``test_healing.py`` cover the chain and each
+healer in isolation. This module verifies the composer calls the chain
+correctly when ``executor=`` is supplied, and that ``executor=None``
+preserves today's behavior for existing callers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from bricks.ai.composer import BlueprintComposer
+from bricks.ai.healing import HealAttempt, HealResult
+from bricks.core.brick import BrickMeta
+from bricks.core.exceptions import BrickExecutionError
+from bricks.core.registry import BrickRegistry
+from bricks.llm.base import CompletionResult, LLMProvider
+
+# A DSL snippet the validate_dsl pass accepts and that executes to a simple
+# dict when run through the composer's _parse_dsl_response + a fake executor.
+_WORKING_DSL = "@flow\ndef ok_task(raw_api_response):\n    return step.identity(value=raw_api_response)\n"
+_REPLACEMENT_DSL = "@flow\ndef fixed_task(raw_api_response):\n    return step.identity(value=raw_api_response)\n"
+
+
+def _registry_with_identity() -> BrickRegistry:
+    """Tiny registry — one brick ``identity`` that returns its input."""
+    registry = BrickRegistry()
+
+    def identity(value: Any) -> dict[str, Any]:
+        return {"result": value}
+
+    registry.register("identity", identity, BrickMeta(name="identity", tags=[], category="test"))
+    return registry
+
+
+def _provider_returning(*texts: str) -> MagicMock:
+    """Build a MagicMock LLMProvider that hands out texts in order."""
+    provider = MagicMock(spec=LLMProvider)
+    completions = [
+        CompletionResult(text=t, input_tokens=10, output_tokens=5, model="test", duration_seconds=0.1, estimated=False)
+        for t in texts
+    ]
+    provider.complete.side_effect = completions
+    return provider
+
+
+class TestExecutorNone:
+    """``executor=None`` must preserve today's pre-healing behavior exactly."""
+
+    def test_compose_without_executor_skips_healing(self) -> None:
+        provider = _provider_returning(_WORKING_DSL)
+        composer = BlueprintComposer(provider=provider)
+        registry = _registry_with_identity()
+
+        result = composer.compose(task="just run it", registry=registry, input_keys=["raw_api_response"])
+
+        # Back-compat fields populated.
+        assert result.is_valid is True
+        assert result.flow_def is not None
+        assert result.blueprint_yaml  # non-empty
+        # New fields stay at their defaults when executor is not passed.
+        assert result.exec_outputs is None
+        assert result.exec_error == ""
+        assert result.heal_attempts == []
+        # Only one LLM call — no healing.
+        assert provider.complete.call_count == 1
+
+
+class TestExecutorSuccessFirstTry:
+    """When the first execution succeeds, no healers run."""
+
+    def test_exec_outputs_populated_and_no_heal_attempts(self) -> None:
+        provider = _provider_returning(_WORKING_DSL)
+        composer = BlueprintComposer(provider=provider)
+        registry = _registry_with_identity()
+
+        executor_calls: list[Any] = []
+
+        def _run(flow: Any) -> dict[str, Any]:
+            executor_calls.append(flow)
+            return {"result": "ok"}
+
+        result = composer.compose(
+            task="just run it",
+            registry=registry,
+            input_keys=["raw_api_response"],
+            executor=_run,
+        )
+
+        assert result.exec_outputs == {"result": "ok"}
+        assert result.exec_error == ""
+        assert result.heal_attempts == []
+        assert len(executor_calls) == 1
+        # Still only one LLM call — healers never invoked.
+        assert provider.complete.call_count == 1
+
+
+class TestExecutorFailsThenHealsSucceeds:
+    """Execution fails once, tier-20 LLM retry produces working DSL, retry succeeds."""
+
+    def test_tier_20_llm_retry_unblocks_execution(self) -> None:
+        # LLM returns the original (bad) DSL, then a replacement after healing.
+        provider = _provider_returning(_WORKING_DSL, _REPLACEMENT_DSL)
+        composer = BlueprintComposer(provider=provider)
+        registry = _registry_with_identity()
+
+        call_count = {"n": 0}
+
+        def _run(flow: Any) -> dict[str, Any]:
+            del flow  # executor signature fixed by contract
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise BrickExecutionError("identity", "step_1_identity", RuntimeError("first try bad"))
+            return {"result": "healed"}
+
+        result = composer.compose(
+            task="heal me",
+            registry=registry,
+            input_keys=["raw_api_response"],
+            executor=_run,
+        )
+
+        assert result.exec_outputs == {"result": "healed"}
+        assert result.exec_error == ""
+        # One successful heal attempt, tier 20 (LLMRetryHealer).
+        assert len(result.heal_attempts) == 1
+        attempt = result.heal_attempts[0]
+        assert attempt.tier == 20
+        assert attempt.exec_succeeded is True
+        # Two LLM calls: original compose + one retry prompt.
+        assert provider.complete.call_count == 2
+
+
+class TestHealingExhaustsCleanly:
+    """Every tier fails → exec_error surfaced, no exception escapes compose."""
+
+    def test_exhausted_chain_sets_exec_error(self) -> None:
+        # LLM keeps producing DSL, but executor always raises BrickExecutionError.
+        # Enough replacement texts to cover every tier in the default chain
+        # x max_attempts=4, so StopIteration can't mask the test's intent.
+        provider = _provider_returning(_WORKING_DSL, *([_REPLACEMENT_DSL] * 8))
+        composer = BlueprintComposer(provider=provider)
+        registry = _registry_with_identity()
+
+        def _run(_: Any) -> dict[str, Any]:
+            raise BrickExecutionError("identity", "step_1_identity", RuntimeError("persistent"))
+
+        result = composer.compose(
+            task="cannot heal",
+            registry=registry,
+            input_keys=["raw_api_response"],
+            executor=_run,
+        )
+
+        assert result.exec_outputs is None
+        assert "persistent" in result.exec_error
+        assert len(result.heal_attempts) >= 1
+        assert all(a.exec_succeeded is False for a in result.heal_attempts)
+
+
+class TestFrameworkErrorsPassthrough:
+    """Non-BrickExecutionError errors must NOT be swallowed by the healer chain."""
+
+    def test_non_brick_exec_error_propagates(self) -> None:
+        provider = _provider_returning(_WORKING_DSL)
+        composer = BlueprintComposer(provider=provider)
+        registry = _registry_with_identity()
+
+        def _run(_: Any) -> dict[str, Any]:
+            raise RuntimeError("framework bug — must not be masked")
+
+        try:
+            composer.compose(
+                task="framework crash",
+                registry=registry,
+                input_keys=["raw_api_response"],
+                executor=_run,
+            )
+        except RuntimeError as exc:
+            assert "framework bug" in str(exc)
+        else:
+            raise AssertionError("RuntimeError must propagate unchanged")
+
+
+class TestExplicitEmptyHealerList:
+    """``healers=[]`` opts out of healing entirely but still accepts an executor."""
+
+    def test_empty_healers_surfaces_error_without_retrying(self) -> None:
+        provider = _provider_returning(_WORKING_DSL)
+        composer = BlueprintComposer(provider=provider, healers=[])
+        registry = _registry_with_identity()
+
+        def _run(_: Any) -> dict[str, Any]:
+            raise BrickExecutionError("identity", "step_1_identity", RuntimeError("no healer to catch"))
+
+        result = composer.compose(
+            task="no healing",
+            registry=registry,
+            input_keys=["raw_api_response"],
+            executor=_run,
+        )
+
+        assert result.exec_outputs is None
+        assert "no healer to catch" in result.exec_error
+        assert result.heal_attempts == []
+        # Only the original compose call — no retry happened.
+        assert provider.complete.call_count == 1
+
+
+class TestTokensRollUp:
+    """Tokens spent by healers must appear in ComposeResult totals."""
+
+    def test_heal_tokens_roll_into_total(self) -> None:
+        provider = _provider_returning(_WORKING_DSL, _REPLACEMENT_DSL)
+        composer = BlueprintComposer(provider=provider)
+        registry = _registry_with_identity()
+
+        call_count = {"n": 0}
+
+        def _run(_: Any) -> dict[str, Any]:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise BrickExecutionError("identity", "step_1_identity", RuntimeError("boom"))
+            return {"result": 1}
+
+        result = composer.compose(
+            task="heal tokens",
+            registry=registry,
+            input_keys=["raw_api_response"],
+            executor=_run,
+        )
+
+        # The LLMProvider mock returns 10 in / 5 out per call x 2 calls.
+        assert result.total_input_tokens == 20
+        assert result.total_output_tokens == 10
+        assert result.total_tokens == 30
+
+
+def test_compose_result_back_compat_for_positional_callers() -> None:
+    """Existing callers that ignore the new fields must keep working."""
+    provider = _provider_returning(_WORKING_DSL)
+    composer = BlueprintComposer(provider=provider)
+    registry = _registry_with_identity()
+
+    result = composer.compose(task="compat", registry=registry, input_keys=["raw_api_response"])
+    # Only touch pre-existing fields.
+    assert result.is_valid
+    assert result.flow_def is not None
+    assert result.total_tokens >= 0
+    assert result.api_calls >= 1
+
+
+def test_healer_attempt_dataclass_surface_remains_stable() -> None:
+    """Pin the HealAttempt fields the composer exposes via heal_attempts."""
+    # This is a smoke check that guards downstream consumers like the
+    # showcase engine's logger from silent field renames.
+    attempt = HealAttempt(
+        healer_name="LLMRetryHealer",
+        tier=20,
+        produced_flow=True,
+        exec_succeeded=True,
+    )
+    assert attempt.error_after == ""
+    assert attempt.tokens_in == 0
+
+
+def test_heal_result_produced_something_false_on_empty() -> None:
+    """Smoke test — guards the check composer relies on."""
+    assert HealResult().produced_something is False
+    assert HealResult(new_dsl="nope").produced_something is True

--- a/tests/ai/test_healing.py
+++ b/tests/ai/test_healing.py
@@ -16,12 +16,14 @@ import pytest
 
 from bricks.ai.healing import (
     ChainResult,
+    DictUnwrapHealer,
     FullRecomposeHealer,
     HealAttempt,
     HealContext,
     HealerChain,
     HealResult,
     LLMRetryHealer,
+    ParamNameHealer,
     ShapeAwareLLMHealer,
 )
 from bricks.core.exceptions import BrickExecutionError
@@ -483,3 +485,182 @@ class TestFullRecomposeHealer:
         assert result.tokens_in == 7
         assert result.tokens_out == 3
         assert result.new_dsl.startswith("@flow")
+
+
+# --- ParamNameHealer (tier 10) ----------------------------------------------
+
+
+class _FakeRegistry:
+    """Minimal registry stand-in — only implements the .get method tier 10 needs."""
+
+    def __init__(self, bricks: dict[str, Any]) -> None:
+        self._bricks = bricks
+
+    def get(self, name: str):
+        if name not in self._bricks:
+            raise KeyError(name)
+        return (self._bricks[name], None)
+
+
+class TestParamNameHealer:
+    """Tier-10 deterministic fix for TypeError: unexpected keyword argument."""
+
+    def _dsl(self) -> str:
+        return "@flow\ndef do_it(data):\n    result = step.count_dict_list(item=data)\n    return result\n"
+
+    def _registry_with_count(self) -> _FakeRegistry:
+        def count_dict_list(items: list, *, metadata: Any = None) -> dict:
+            return {"result": len(items)}
+
+        return _FakeRegistry({"count_dict_list": count_dict_list})
+
+    def _ctx(
+        self,
+        cause: Exception,
+        *,
+        dsl: str | None = None,
+        registry: _FakeRegistry | None = None,
+        brick: str = "count_dict_list",
+    ) -> HealContext:
+        return HealContext(
+            task="count the items",
+            failed_flow=_StubFlow(label="orig"),  # type: ignore[arg-type]
+            failed_dsl=dsl or self._dsl(),
+            error=BrickExecutionError(brick, "step_1", cause),
+            attempt=0,
+            prior_attempts=[],
+            registry=registry or self._registry_with_count(),
+        )
+
+    def test_can_heal_only_on_typeerror_with_matching_message(self) -> None:
+        healer = ParamNameHealer()
+        typeerror = self._ctx(TypeError("got an unexpected keyword argument 'item'"))
+        assert healer.can_heal(typeerror) is True
+
+        attr = self._ctx(AttributeError("boom"))
+        assert healer.can_heal(attr) is False
+
+        unrelated_type = self._ctx(TypeError("some other message"))
+        assert healer.can_heal(unrelated_type) is False
+
+    def test_can_heal_false_without_registry(self) -> None:
+        healer = ParamNameHealer()
+        ctx = HealContext(
+            task="x",
+            failed_flow=_StubFlow(label="x"),  # type: ignore[arg-type]
+            failed_dsl="",
+            error=BrickExecutionError("b", "s", TypeError("unexpected keyword argument 'y'")),
+            attempt=0,
+            prior_attempts=[],
+            registry=None,
+        )
+        assert healer.can_heal(ctx) is False
+
+    def test_heal_rewrites_bad_kwarg_to_closest_match(self) -> None:
+        healer = ParamNameHealer()
+        ctx = self._ctx(TypeError("got an unexpected keyword argument 'item'"))
+        result = healer.heal(ctx)
+
+        assert result.produced_something is True
+        assert "items=data" in result.new_dsl
+        assert "item=data" not in result.new_dsl
+        # Deterministic tiers must not spend tokens.
+        assert result.tokens_in == 0
+        assert result.tokens_out == 0
+
+    def test_heal_returns_empty_when_no_close_match(self) -> None:
+        healer = ParamNameHealer()
+        ctx = self._ctx(TypeError("got an unexpected keyword argument 'xyzabc'"))
+        result = healer.heal(ctx)
+        assert result.produced_something is False
+
+    def test_heal_wont_loop_if_prior_attempt_failed_with_same_rewrite(self) -> None:
+        healer = ParamNameHealer()
+        ctx = self._ctx(TypeError("got an unexpected keyword argument 'item'"))
+        ctx.prior_attempts = [
+            HealAttempt(
+                healer_name=ParamNameHealer.name,
+                tier=10,
+                produced_flow=True,
+                exec_succeeded=False,
+                error_after="the kwarg 'item' still wrong",
+            )
+        ]
+        result = healer.heal(ctx)
+        assert result.produced_something is False
+
+
+# --- DictUnwrapHealer (tier 15) ---------------------------------------------
+
+
+class TestDictUnwrapHealer:
+    """Tier-15 deterministic fix for the wrapper-dict mistake."""
+
+    _TICKET_DSL = (
+        "@flow\n"
+        "def ticket_counts(raw_api_response):\n"
+        "    parsed = step.extract_json_from_str(text=raw_api_response)\n"
+        "    high = step.filter_dict_list(items=parsed.output, key='priority', value='high')\n"
+        "    return step.count_dict_list(items=high.output)\n"
+    )
+
+    _TASK_WITH_KEY = "Parse the JSON. The dict has key 'tickets' with the list of items."
+    _TASK_WITHOUT_KEY = "Just parse some JSON and count things."
+
+    def _ctx(
+        self,
+        cause: Exception,
+        *,
+        task: str = _TASK_WITH_KEY,
+        brick: str = "filter_dict_list",
+    ) -> HealContext:
+        return HealContext(
+            task=task,
+            failed_flow=_StubFlow(label="orig"),  # type: ignore[arg-type]
+            failed_dsl=self._TICKET_DSL,
+            error=BrickExecutionError(brick, "step_2", cause),
+            attempt=0,
+            prior_attempts=[],
+        )
+
+    def test_can_heal_requires_attribute_error_shape(self) -> None:
+        healer = DictUnwrapHealer()
+        assert healer.can_heal(self._ctx(AttributeError("'str' object has no attribute 'get'"))) is True
+        assert healer.can_heal(self._ctx(TypeError("nope"))) is False
+        assert healer.can_heal(self._ctx(AttributeError("some other attribute error"))) is False
+
+    def test_can_heal_declines_after_prior_same_healer_failed(self) -> None:
+        healer = DictUnwrapHealer()
+        ctx = self._ctx(AttributeError("'str' object has no attribute 'get'"))
+        ctx.prior_attempts = [
+            HealAttempt(
+                healer_name=DictUnwrapHealer.name,
+                tier=15,
+                produced_flow=True,
+                exec_succeeded=False,
+                error_after="still broken",
+            )
+        ]
+        assert healer.can_heal(ctx) is False
+
+    def test_heal_inserts_extract_dict_field_before_failing_step(self) -> None:
+        healer = DictUnwrapHealer()
+        ctx = self._ctx(AttributeError("'str' object has no attribute 'get'"))
+        result = healer.heal(ctx)
+
+        assert result.produced_something is True
+        assert "step.extract_dict_field" in result.new_dsl
+        assert "field='tickets'" in result.new_dsl or 'field="tickets"' in result.new_dsl
+        # The consumer must now reference the unwrapped step.
+        assert "items=parsed_items.output" in result.new_dsl
+        # Deterministic — no tokens.
+        assert result.tokens_in == 0
+
+    def test_heal_declines_when_task_has_no_key_hint(self) -> None:
+        healer = DictUnwrapHealer()
+        ctx = self._ctx(
+            AttributeError("'str' object has no attribute 'get'"),
+            task=self._TASK_WITHOUT_KEY,
+        )
+        result = healer.heal(ctx)
+        assert result.produced_something is False

--- a/tests/ai/test_healing.py
+++ b/tests/ai/test_healing.py
@@ -10,17 +10,22 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 from bricks.ai.healing import (
     ChainResult,
+    FullRecomposeHealer,
     HealAttempt,
     HealContext,
     HealerChain,
     HealResult,
+    LLMRetryHealer,
+    ShapeAwareLLMHealer,
 )
 from bricks.core.exceptions import BrickExecutionError
+from bricks.llm.base import CompletionResult, LLMProvider
 
 # --- test doubles -----------------------------------------------------------
 
@@ -285,3 +290,196 @@ def test_chain_result_defaults() -> None:
     assert result.attempts == []
     assert result.total_tokens_in == 0
     assert result.total_tokens_out == 0
+
+
+# --- LLMRetryHealer (tier 20) -----------------------------------------------
+
+
+class TestLLMRetryHealer:
+    """Tier-20 LLM retry — fires on any BrickExecutionError."""
+
+    def _provider_returning(self, text: str, tokens_in: int = 42, tokens_out: int = 17) -> MagicMock:
+        provider = MagicMock(spec=LLMProvider)
+        provider.complete.return_value = CompletionResult(
+            text=text,
+            input_tokens=tokens_in,
+            output_tokens=tokens_out,
+            model="test",
+            duration_seconds=0.1,
+            estimated=False,
+        )
+        return provider
+
+    def test_can_heal_accepts_any_brick_execution_error(self) -> None:
+        healer = LLMRetryHealer(provider=MagicMock(spec=LLMProvider), system_prompt="SYS")
+        assert healer.can_heal(_make_ctx()) is True
+
+    def test_heal_prompts_with_brick_step_cause_and_strips_fences(self) -> None:
+        provider = self._provider_returning("```python\n@flow\ndef fixed():\n    return 1\n```")
+        healer = LLMRetryHealer(provider=provider, system_prompt="SYSTEM-PROMPT")
+
+        ctx = _make_ctx("missing columns")
+        result = healer.heal(ctx)
+
+        assert result.new_dsl.startswith("@flow"), "fences must be stripped"
+        assert "```" not in result.new_dsl
+        assert result.tokens_in == 42
+        assert result.tokens_out == 17
+
+        # The call must carry the system prompt and reference the failing step.
+        provider.complete.assert_called_once()
+        call = provider.complete.call_args
+        assert call.kwargs["system"] == "SYSTEM-PROMPT"
+        prompt = call.kwargs["prompt"]
+        assert "brick_x" in prompt, "retry prompt must include the failing brick name"
+        assert "step_1_brick_x" in prompt, "retry prompt must include the failing step name"
+        assert "missing columns" in prompt, "retry prompt must include the cause message"
+
+    def test_heal_passes_through_empty_dsl_if_llm_returns_empty(self) -> None:
+        provider = self._provider_returning("")
+        healer = LLMRetryHealer(provider=provider, system_prompt="SYS")
+        result = healer.heal(_make_ctx())
+        assert result.new_dsl == ""
+        assert result.produced_something is False
+
+
+# --- ShapeAwareLLMHealer (tier 30) ------------------------------------------
+
+
+class TestShapeAwareLLMHealer:
+    """Tier-30 shape-aware retry — only fires after tier 20 failed."""
+
+    def _provider(self, text: str = "@flow\ndef v2():\n    return 1\n") -> MagicMock:
+        provider = MagicMock(spec=LLMProvider)
+        provider.complete.return_value = CompletionResult(
+            text=text, input_tokens=100, output_tokens=50, model="test", duration_seconds=0.1, estimated=False
+        )
+        return provider
+
+    def test_can_heal_false_without_trace_executor(self) -> None:
+        healer = ShapeAwareLLMHealer(provider=self._provider(), system_prompt="SYS", trace_executor=None)
+        ctx = _make_ctx()
+        # Even with a prior tier-20 failure, no trace_executor → cannot heal.
+        ctx.prior_attempts = [
+            HealAttempt(
+                healer_name=LLMRetryHealer.name,
+                tier=20,
+                produced_flow=True,
+                exec_succeeded=False,
+                error_after="x",
+            )
+        ]
+        assert healer.can_heal(ctx) is False
+
+    def test_can_heal_false_on_first_attempt(self) -> None:
+        """Without a prior tier-20 failure, tier-30 must stand down."""
+        healer = ShapeAwareLLMHealer(provider=self._provider(), system_prompt="SYS", trace_executor=lambda _: {})
+        ctx = _make_ctx()
+        ctx.prior_attempts = []
+        assert healer.can_heal(ctx) is False
+
+    def test_can_heal_true_after_tier_20_failed(self) -> None:
+        healer = ShapeAwareLLMHealer(provider=self._provider(), system_prompt="SYS", trace_executor=lambda _: {})
+        ctx = _make_ctx()
+        ctx.prior_attempts = [
+            HealAttempt(
+                healer_name=LLMRetryHealer.name,
+                tier=20,
+                produced_flow=True,
+                exec_succeeded=False,
+                error_after="x",
+            )
+        ]
+        assert healer.can_heal(ctx) is True
+
+    def test_heal_includes_observed_shapes_in_prompt(self) -> None:
+        trace_result = {"step_1_parse": "dict<keys=['customers']>", "step_2_filter": "str"}
+
+        def _trace_exec(_: Any) -> dict[str, Any]:
+            return trace_result
+
+        provider = self._provider()
+        healer = ShapeAwareLLMHealer(provider=provider, system_prompt="SYS", trace_executor=_trace_exec)
+        result = healer.heal(_make_ctx())
+
+        prompt = provider.complete.call_args.kwargs["prompt"]
+        for step_name, shape in trace_result.items():
+            assert step_name in prompt
+            assert shape in prompt
+
+        assert result.tokens_in == 100
+        assert result.tokens_out == 50
+
+    def test_heal_tolerates_trace_executor_raising(self) -> None:
+        """A crashing trace_executor must not crash the healer."""
+
+        def _bad_trace(_: Any) -> dict[str, Any]:
+            raise RuntimeError("tracer broke")
+
+        provider = self._provider()
+        healer = ShapeAwareLLMHealer(provider=provider, system_prompt="SYS", trace_executor=_bad_trace)
+        result = healer.heal(_make_ctx())
+
+        prompt = provider.complete.call_args.kwargs["prompt"]
+        assert "(no shape info available)" in prompt
+        assert result.produced_something is True
+
+
+# --- FullRecomposeHealer (tier 40) ------------------------------------------
+
+
+class TestFullRecomposeHealer:
+    """Tier-40 full recompose — only fires after 3 prior attempts failed."""
+
+    def test_can_heal_requires_three_prior_attempts(self) -> None:
+        healer = FullRecomposeHealer(fresh_compose=lambda task, excluded: HealResult())
+        ctx = _make_ctx()
+        ctx.prior_attempts = []
+        assert healer.can_heal(ctx) is False
+        ctx.prior_attempts = [HealAttempt(healer_name="a", tier=10, produced_flow=False, exec_succeeded=None)] * 2
+        assert healer.can_heal(ctx) is False
+        ctx.prior_attempts = [HealAttempt(healer_name="a", tier=10, produced_flow=False, exec_succeeded=None)] * 3
+        assert healer.can_heal(ctx) is True
+
+    def test_heal_extracts_failed_brick_names_and_delegates(self) -> None:
+        called: dict[str, Any] = {}
+
+        def _fresh(task: str, excluded: list[str]) -> HealResult:
+            called["task"] = task
+            called["excluded"] = excluded
+            return HealResult(new_dsl="@flow\ndef fresh():\n    return 1\n", tokens_in=7, tokens_out=3)
+
+        healer = FullRecomposeHealer(fresh_compose=_fresh)
+        ctx = _make_ctx()
+        ctx.prior_attempts = [
+            HealAttempt(
+                healer_name="t20",
+                tier=20,
+                produced_flow=True,
+                exec_succeeded=False,
+                error_after="Brick 'filter_dict_list' failed at step 'step_2': oops",
+            ),
+            HealAttempt(
+                healer_name="t30",
+                tier=30,
+                produced_flow=True,
+                exec_succeeded=False,
+                error_after="Brick 'filter_dict_list' failed at step 'step_3': oops",
+            ),
+            HealAttempt(
+                healer_name="t20",
+                tier=20,
+                produced_flow=True,
+                exec_succeeded=False,
+                error_after="Brick 'map_values' failed at step 'step_1': boom",
+            ),
+        ]
+
+        result = healer.heal(ctx)
+
+        assert called["task"] == ctx.task
+        # Exclusions dedupe, preserve first-seen order, and include current error's brick.
+        assert called["excluded"] == ["filter_dict_list", "map_values", "brick_x"]
+        assert result.tokens_in == 7
+        assert result.tokens_out == 3
+        assert result.new_dsl.startswith("@flow")

--- a/tests/ai/test_healing.py
+++ b/tests/ai/test_healing.py
@@ -1,0 +1,287 @@
+"""Tests for the ``HealerChain`` orchestrator and related dataclasses.
+
+Concrete healer tiers (10/15/20/30/40) have their own test modules; this
+file only exercises the chain mechanics: tier ordering, max_attempts cap,
+the BrickExecutionError-only retry contract, and the trace produced in
+:class:`ChainResult`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from bricks.ai.healing import (
+    ChainResult,
+    HealAttempt,
+    HealContext,
+    HealerChain,
+    HealResult,
+)
+from bricks.core.exceptions import BrickExecutionError
+
+# --- test doubles -----------------------------------------------------------
+
+
+@dataclass
+class _StubFlow:
+    """Stand-in for a FlowDefinition — the chain only treats it as an opaque
+    handle the executor receives. Carries an identifier so tests can assert
+    which flow reached the executor."""
+
+    label: str
+
+
+@dataclass
+class _FakeHealer:
+    """Configurable healer for chain-mechanics tests.
+
+    Records every ``can_heal`` / ``heal`` invocation so assertions can
+    inspect the sequence.
+    """
+
+    tier: int
+    name: str
+    produces_dsl: str = ""
+    produces_flow: _StubFlow | None = None
+    accept: bool = True
+    tokens_in: int = 0
+    tokens_out: int = 0
+    heal_calls: list[HealContext] = field(default_factory=list)
+    can_heal_calls: list[HealContext] = field(default_factory=list)
+
+    def can_heal(self, ctx: HealContext) -> bool:
+        self.can_heal_calls.append(ctx)
+        return self.accept
+
+    def heal(self, ctx: HealContext) -> HealResult:
+        self.heal_calls.append(ctx)
+        return HealResult(
+            new_dsl=self.produces_dsl,
+            new_flow=self.produces_flow,
+            tokens_in=self.tokens_in,
+            tokens_out=self.tokens_out,
+        )
+
+
+def _make_ctx(error_message: str = "simulated failure") -> HealContext:
+    """Build a minimal HealContext. The failed_flow is a stub — the chain
+    never introspects it in scaffolding-level tests."""
+    return HealContext(
+        task="pretend task",
+        failed_flow=_StubFlow(label="original"),  # type: ignore[arg-type]
+        failed_dsl="@flow\ndef pretend(): return 1\n",
+        error=BrickExecutionError("brick_x", "step_1_brick_x", RuntimeError(error_message)),
+        attempt=0,
+        prior_attempts=[],
+    )
+
+
+def _ok_executor(outputs: dict[str, Any]):
+    """Return an executor that always returns *outputs*."""
+
+    def _run(_: Any) -> dict[str, Any]:
+        return outputs
+
+    return _run
+
+
+def _failing_executor(message: str = "still broken"):
+    """Return an executor that always raises BrickExecutionError."""
+
+    def _run(_: Any) -> dict[str, Any]:
+        raise BrickExecutionError("brick_x", "step_1_brick_x", RuntimeError(message))
+
+    return _run
+
+
+def _noop_parser(_: str) -> _StubFlow:
+    """Return a stub flow. The chain only needs the executor to accept it."""
+    return _StubFlow(label="parsed")
+
+
+# --- tests ------------------------------------------------------------------
+
+
+class TestHealerChainOrdering:
+    """Chain must sort healers by tier ascending and pick the first match."""
+
+    def test_healers_sorted_ascending_on_construction(self) -> None:
+        high = _FakeHealer(tier=40, name="t40")
+        mid = _FakeHealer(tier=20, name="t20")
+        low = _FakeHealer(tier=10, name="t10")
+        chain = HealerChain(healers=[high, low, mid])
+        assert [h.tier for h in chain.healers] == [10, 20, 40]
+
+    def test_lowest_tier_with_can_heal_true_wins(self) -> None:
+        declines = _FakeHealer(tier=10, name="t10", accept=False)
+        winner = _FakeHealer(tier=20, name="t20", produces_dsl="@flow\ndef x():\n    return 1\n")
+        loser_later = _FakeHealer(tier=30, name="t30", produces_dsl="should_not_run")
+        chain = HealerChain(healers=[loser_later, declines, winner], max_attempts=1)
+
+        result = chain.heal(
+            _make_ctx(),
+            executor=_ok_executor({"result": 42}),
+            parser=_noop_parser,
+        )
+
+        assert result.success is True
+        assert declines.heal_calls == [], "declining healer must not be invoked"
+        assert len(winner.heal_calls) == 1, "tier 20 should run"
+        assert loser_later.heal_calls == [], "tier 30 must not run after tier 20 succeeds"
+
+
+class TestMaxAttempts:
+    """Chain must stop after max_attempts iterations even if healers keep
+    proposing flows."""
+
+    def test_caps_iterations(self) -> None:
+        always_fails = _FakeHealer(tier=20, name="t20", produces_dsl="@flow\ndef x():\n    return 1\n")
+        chain = HealerChain(healers=[always_fails], max_attempts=2)
+
+        result = chain.heal(
+            _make_ctx(),
+            executor=_failing_executor("still broken"),
+            parser=_noop_parser,
+        )
+
+        assert result.success is False
+        assert len(result.attempts) == 2
+        assert all(a.exec_succeeded is False for a in result.attempts)
+        assert result.final_error, "final_error must describe the last failure"
+
+    def test_single_attempt_default(self) -> None:
+        # max_attempts=2 is the class default — exercise that without
+        # overriding it.
+        healer = _FakeHealer(tier=20, name="t20", produces_dsl="@flow\ndef x():\n    return 1\n")
+        chain = HealerChain(healers=[healer])
+        assert chain._max_attempts == 2
+
+
+class TestHealerDeclining:
+    """When no healer's can_heal returns True, chain stops immediately
+    with an empty-attempts ChainResult."""
+
+    def test_all_decline_short_circuits(self) -> None:
+        mute = _FakeHealer(tier=10, name="t10", accept=False)
+        chain = HealerChain(healers=[mute], max_attempts=3)
+
+        result = chain.heal(
+            _make_ctx("original error"),
+            executor=_ok_executor({"should": "not run"}),
+            parser=_noop_parser,
+        )
+
+        assert result.success is False
+        assert result.attempts == []
+        assert "original error" in result.final_error
+
+
+class TestProducedNothing:
+    """A healer that returns HealResult with no DSL and no flow must be
+    recorded as an attempt but not trigger an executor call."""
+
+    def test_empty_result_still_records_attempt(self) -> None:
+        shrugs = _FakeHealer(tier=10, name="t10")  # produces_dsl="" by default
+        chain = HealerChain(healers=[shrugs], max_attempts=1)
+
+        executor_calls: list[Any] = []
+
+        def _exec(flow: Any) -> dict[str, Any]:
+            executor_calls.append(flow)
+            return {}
+
+        result = chain.heal(_make_ctx(), executor=_exec, parser=_noop_parser)
+
+        assert executor_calls == [], "executor must not run when healer produced nothing"
+        assert len(result.attempts) == 1
+        assert result.attempts[0].produced_flow is False
+        assert result.attempts[0].exec_succeeded is None
+
+
+class TestErrorPassthrough:
+    """Non-BrickExecutionError exceptions from the executor must propagate
+    unchanged — we do not want to mask framework bugs."""
+
+    def test_non_brick_exception_propagates(self) -> None:
+        healer = _FakeHealer(tier=20, name="t20", produces_dsl="@flow\ndef x():\n    return 1\n")
+        chain = HealerChain(healers=[healer], max_attempts=3)
+
+        def _explode(_: Any) -> dict[str, Any]:
+            raise RuntimeError("framework bug — do not retry")
+
+        with pytest.raises(RuntimeError, match="framework bug"):
+            chain.heal(_make_ctx(), executor=_explode, parser=_noop_parser)
+
+
+class TestSuccessfulHealTrace:
+    """ChainResult.attempts must record an exec_succeeded=True entry for
+    the winning attempt and carry tokens through."""
+
+    def test_success_carries_tokens_and_outputs(self) -> None:
+        healer = _FakeHealer(
+            tier=20,
+            name="t20",
+            produces_dsl="@flow\ndef ok():\n    return 1\n",
+            tokens_in=100,
+            tokens_out=40,
+        )
+        chain = HealerChain(healers=[healer], max_attempts=2)
+
+        result = chain.heal(
+            _make_ctx(),
+            executor=_ok_executor({"answer": 42}),
+            parser=_noop_parser,
+        )
+
+        assert result.success is True
+        assert result.outputs == {"answer": 42}
+        assert result.total_tokens_in == 100
+        assert result.total_tokens_out == 40
+        assert len(result.attempts) == 1
+        assert result.attempts[0].exec_succeeded is True
+        assert result.attempts[0].healer_name == "t20"
+
+    def test_healer_returning_prebuilt_flow_skips_parser(self) -> None:
+        prebuilt = _StubFlow(label="prebuilt")
+        healer = _FakeHealer(tier=20, name="t20", produces_flow=prebuilt)
+        chain = HealerChain(healers=[healer], max_attempts=1)
+
+        executed: list[Any] = []
+
+        def _exec(flow: Any) -> dict[str, Any]:
+            executed.append(flow)
+            return {}
+
+        parser_calls: list[str] = []
+
+        def _parser(dsl: str) -> _StubFlow:
+            parser_calls.append(dsl)
+            return _StubFlow(label="fallback-parsed")
+
+        chain.heal(_make_ctx(), executor=_exec, parser=_parser)
+
+        assert executed == [prebuilt], "prebuilt flow must reach executor verbatim"
+        assert parser_calls == [], "parser must not be called when new_flow is already set"
+
+
+def test_heal_attempt_defaults() -> None:
+    """Smoke test the HealAttempt dataclass defaults so later refactors do
+    not silently break assumptions used by other tests."""
+    att = HealAttempt(healer_name="x", tier=10, produced_flow=False, exec_succeeded=None)
+    assert att.error_after == ""
+    assert att.tokens_in == 0
+    assert att.tokens_out == 0
+
+
+def test_chain_result_defaults() -> None:
+    """Smoke test the ChainResult dataclass defaults."""
+    result = ChainResult(success=False)
+    assert result.outputs is None
+    assert result.final_flow is None
+    assert result.final_dsl == ""
+    assert result.attempts == []
+    assert result.total_tokens_in == 0
+    assert result.total_tokens_out == 0

--- a/tests/core/test_filtering_selector.py
+++ b/tests/core/test_filtering_selector.py
@@ -1,0 +1,77 @@
+"""Tests for ``FilteringSelector`` — wraps another selector and excludes names."""
+
+from __future__ import annotations
+
+from bricks.core.brick import BrickMeta
+from bricks.core.filtering_selector import FilteringSelector
+from bricks.core.registry import BrickRegistry
+from bricks.core.selector import AllBricksSelector
+
+
+def _registry_with(*names: str) -> BrickRegistry:
+    """Build a registry with placeholder bricks for each name."""
+    registry = BrickRegistry()
+
+    def _noop() -> dict:  # pragma: no cover - placeholder callable
+        return {"result": None}
+
+    for name in names:
+        registry.register(name, _noop, BrickMeta(name=name, tags=[], category="test"))
+    return registry
+
+
+class TestFilteringSelector:
+    """Verify inner-selector delegation + exclusion semantics."""
+
+    def test_excludes_named_bricks(self) -> None:
+        inner = AllBricksSelector()
+        registry = _registry_with("filter_dict_list", "map_values", "count_dict_list")
+
+        selector = FilteringSelector(inner=inner, exclude=["filter_dict_list"])
+        result = selector.select(task="whatever", registry=registry)
+
+        names = [name for name, _ in result.list_all()]
+        assert "filter_dict_list" not in names
+        assert "map_values" in names
+        assert "count_dict_list" in names
+
+    def test_missing_excluded_name_is_ignored(self) -> None:
+        inner = AllBricksSelector()
+        registry = _registry_with("a", "b")
+
+        selector = FilteringSelector(inner=inner, exclude=["does_not_exist"])
+        result = selector.select(task="", registry=registry)
+
+        assert {n for n, _ in result.list_all()} == {"a", "b"}
+
+    def test_empty_exclusion_returns_inner_unchanged(self) -> None:
+        """With no exclusions, FilteringSelector must not rebuild the pool."""
+        inner = AllBricksSelector()
+        registry = _registry_with("a", "b")
+
+        selector = FilteringSelector(inner=inner, exclude=[])
+        result = selector.select(task="", registry=registry)
+
+        # Same object, not a rebuild.
+        assert result is registry
+
+    def test_excluded_property_exposes_frozenset(self) -> None:
+        selector = FilteringSelector(inner=AllBricksSelector(), exclude=["x", "y"])
+        excluded = selector.excluded
+        assert excluded == frozenset({"x", "y"})
+        assert isinstance(excluded, frozenset)
+
+    def test_inner_selector_runs_before_filter(self) -> None:
+        """FilteringSelector must not bypass its inner selector — it
+        post-filters whatever inner returns."""
+
+        calls: list[str] = []
+
+        class RecordingSelector(AllBricksSelector):
+            def select(self, task, registry):  # type: ignore[override]
+                calls.append(task)
+                return super().select(task, registry)
+
+        selector = FilteringSelector(inner=RecordingSelector(), exclude=["x"])
+        selector.select(task="hello", registry=_registry_with("x", "y"))
+        assert calls == ["hello"]

--- a/tests/llm/test_litellm_caching.py
+++ b/tests/llm/test_litellm_caching.py
@@ -1,0 +1,188 @@
+"""Tests for LiteLLMProvider prompt-cache wiring.
+
+The provider must:
+
+1. Send the system prompt as a content-block list with
+   ``cache_control: {"type": "ephemeral"}`` for Anthropic-family models,
+   so Anthropic charges cached rates on the byte-identical system prompt
+   composer reuses across every compose call.
+2. Send the system prompt as a plain string for everything else — OpenAI
+   caches automatically via prefix matching, and Gemini / Ollama don't
+   use the same mechanism.
+3. Read cache-usage fields back into :class:`CompletionResult`:
+   - Anthropic: ``usage.cache_read_input_tokens`` /
+     ``cache_creation_input_tokens``.
+   - OpenAI: ``usage.prompt_tokens_details.cached_tokens``.
+
+These tests patch ``litellm.completion`` so they don't hit the network.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bricks.llm.litellm_provider import LiteLLMProvider, _is_anthropic_family
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-haiku-4-5-20251001",
+        "claude-sonnet-4-5",
+        "openrouter/anthropic/claude-opus-4-7",
+        "bedrock/anthropic/claude-haiku-4-5",
+        "anthropic/claude-haiku-4-5",
+    ],
+)
+def test_is_anthropic_family_true(model: str) -> None:
+    assert _is_anthropic_family(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-4o-mini",
+        "gpt-5",
+        "o4-mini",
+        "gemini/gemini-2.0-flash",
+        "ollama/llama3",
+        "mistral/large",
+        "",  # empty = non-Anthropic default
+    ],
+)
+def test_is_anthropic_family_false(model: str) -> None:
+    assert _is_anthropic_family(model) is False
+
+
+def _build_response(
+    text: str = "ok",
+    in_tok: int = 100,
+    out_tok: int = 5,
+    cache_read: int = 0,
+    cache_create: int = 0,
+    openai_cached_tokens: int | None = None,
+) -> MagicMock:
+    """Build a mock litellm.completion response with configurable usage fields."""
+    msg = MagicMock()
+    msg.content = text
+    choice = MagicMock()
+    choice.message = msg
+
+    usage = MagicMock(spec=["prompt_tokens", "completion_tokens"])
+    usage.prompt_tokens = in_tok
+    usage.completion_tokens = out_tok
+    if cache_read:
+        usage.cache_read_input_tokens = cache_read
+    if cache_create:
+        usage.cache_creation_input_tokens = cache_create
+    if openai_cached_tokens is not None:
+        details = MagicMock(spec=["cached_tokens"])
+        details.cached_tokens = openai_cached_tokens
+        usage.prompt_tokens_details = details
+
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.usage = usage
+    return resp
+
+
+class TestAnthropicFamilyUsesContentBlocks:
+    """Anthropic models must get content-block system with cache_control."""
+
+    def test_claude_model_sends_content_block_with_cache_control(self) -> None:
+        provider = LiteLLMProvider(model="claude-haiku-4-5-20251001", api_key="test-key")
+        with patch("litellm.completion", return_value=_build_response()) as mock_completion:
+            provider.complete(prompt="user text", system="SYSTEM_TEXT")
+
+        call = mock_completion.call_args
+        messages = call.kwargs["messages"]
+        system_msg = messages[0]
+        assert system_msg["role"] == "system"
+        assert isinstance(system_msg["content"], list), "Anthropic must get content-block list"
+        block = system_msg["content"][0]
+        assert block["type"] == "text"
+        assert block["text"] == "SYSTEM_TEXT"
+        assert block["cache_control"] == {"type": "ephemeral"}
+
+    def test_empty_system_stays_empty_string(self) -> None:
+        """An empty system prompt is still an empty string — cache_control only wraps real content."""
+        provider = LiteLLMProvider(model="claude-haiku-4-5", api_key="test-key")
+        with patch("litellm.completion", return_value=_build_response()) as mock_completion:
+            provider.complete(prompt="user text", system="")
+
+        system_msg = mock_completion.call_args.kwargs["messages"][0]
+        assert system_msg["content"] == "", "empty system must remain the empty string"
+
+    @pytest.mark.parametrize(
+        "model",
+        ["openrouter/anthropic/claude-opus-4-7", "bedrock/anthropic/claude-haiku-4-5"],
+    )
+    def test_pass_through_anthropic_routes_get_cache_control(self, model: str) -> None:
+        provider = LiteLLMProvider(model=model, api_key="test-key")
+        with patch("litellm.completion", return_value=_build_response()) as mock_completion:
+            provider.complete(prompt="x", system="SYS")
+
+        system_msg = mock_completion.call_args.kwargs["messages"][0]
+        assert isinstance(system_msg["content"], list)
+        assert system_msg["content"][0]["cache_control"] == {"type": "ephemeral"}
+
+
+class TestNonAnthropicUsesPlainString:
+    """OpenAI / Gemini / Ollama keep the legacy plain-string format."""
+
+    @pytest.mark.parametrize(
+        "model",
+        ["gpt-4o-mini", "gpt-5", "o4-mini", "gemini/gemini-2.0-flash", "ollama/llama3"],
+    )
+    def test_non_anthropic_plain_string_system(self, model: str) -> None:
+        provider = LiteLLMProvider(model=model, api_key="test-key")
+        with patch("litellm.completion", return_value=_build_response()) as mock_completion:
+            provider.complete(prompt="x", system="SYS")
+
+        system_msg = mock_completion.call_args.kwargs["messages"][0]
+        assert system_msg["content"] == "SYS", f"{model} must send plain string"
+
+
+class TestCacheUsageExtraction:
+    """Cache-read / cache-creation counters flow into CompletionResult."""
+
+    def test_anthropic_cache_read_and_create_populate(self) -> None:
+        provider = LiteLLMProvider(model="claude-haiku-4-5", api_key="test-key")
+        response = _build_response(cache_read=2400, cache_create=0)
+        with patch("litellm.completion", return_value=response):
+            result = provider.complete(prompt="x", system="SYS")
+
+        assert result.cached_input_tokens == 2400
+        assert result.cache_creation_input_tokens == 0
+
+    def test_anthropic_cache_creation_populates_on_first_write(self) -> None:
+        provider = LiteLLMProvider(model="claude-haiku-4-5", api_key="test-key")
+        response = _build_response(cache_read=0, cache_create=2400)
+        with patch("litellm.completion", return_value=response):
+            result = provider.complete(prompt="x", system="SYS")
+
+        assert result.cache_creation_input_tokens == 2400
+        assert result.cached_input_tokens == 0
+
+    def test_openai_cached_tokens_surface_as_cached_input_tokens(self) -> None:
+        provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
+        response = _build_response(openai_cached_tokens=1800)
+        with patch("litellm.completion", return_value=response):
+            result = provider.complete(prompt="x", system="SYS")
+
+        assert result.cached_input_tokens == 1800
+        # Cache creation only applies to Anthropic.
+        assert result.cache_creation_input_tokens == 0
+
+    def test_missing_usage_fields_default_to_zero(self) -> None:
+        """Providers that don't surface cache fields must not blow up the provider."""
+        provider = LiteLLMProvider(model="claude-haiku-4-5", api_key="test-key")
+        # Plain response with just prompt/completion tokens.
+        response = _build_response()
+        with patch("litellm.completion", return_value=response):
+            result = provider.complete(prompt="x", system="SYS")
+
+        assert result.cached_input_tokens == 0
+        assert result.cache_creation_input_tokens == 0


### PR DESCRIPTION
## Summary

- **P0 (fix)** — Correct the broken `crm_summary` example in the DSL prompt (was passing a wrapper dict to `filter_dict_list`, which would crash at runtime and which the LLM sometimes copied verbatim — this killed TICKET-pipeline). Add two more worked examples covering `for_each` + list-of-Node `reduce_sum` and `branch` routing.
- **P1 (feat)** — Ship a tiered `HealerChain` self-heal mechanism, wired into the composer via an optional `executor=` callable:
  - Tier 10 `ParamNameHealer` — deterministic fix for `TypeError: unexpected keyword argument`.
  - Tier 15 `DictUnwrapHealer` — deterministic fix for wrapper-dict-reached-list-consumer shape.
  - Tier 20 `LLMRetryHealer` — LLM re-prompt with error context.
  - Tier 30 `ShapeAwareLLMHealer` — LLM re-prompt with observed runtime shapes.
  - Tier 40 `FullRecomposeHealer` — fresh compose with `FilteringSelector` excluding failed bricks.
- **P2 (feat)** — Prompt caching for Anthropic-family models in `LiteLLMProvider` (saves ~90% on the ~2500-token system prompt after the first call). OpenAI caches automatically; Gemini is out of scope.

## Issues

Closes #27
Part of #28, #29, #30, #31, #32

## Commit map

| # | Commit | Addresses |
|---|---|---|
| 1 | `fix(ai): correct crm_summary example and add two worked examples` | P0 — #28 |
| 2 | `feat(ai): Healer protocol, HealContext, HealerChain` | P1 — #29 |
| 3 | `feat(ai): LLMRetryHealer, ShapeAwareLLMHealer, FullRecomposeHealer` | P1 — #31 |
| 4 | `feat(ai): ParamNameHealer, DictUnwrapHealer` | P1 — #30 |
| 5 | `feat(ai): wire composer to HealerChain via optional executor` | P1 wiring |
| 6 | `feat(llm): prompt caching for Anthropic-family models via LiteLLM` | P2 — #32 |

## Test plan

- [x] `pytest tests/ai tests/llm` — 113 pass
- [x] `pytest tests/core/test_filtering_selector.py` — 5 pass
- [x] `pytest tests/core/test_dag.py` — 25 pass (existing + PR #26 regression tests)
- [x] `ruff check` + `ruff format --check` on all edited/new files
- [ ] CI green on 3.10 / 3.11 / 3.12
- [ ] Re-run `python -m bricks.benchmark.showcase.run --live --model claudecode --scenario TICKET-pipeline` end-to-end and confirm: no `RepresenterError`, no `'str' object has no attribute 'get'`; if the LLM still emits bad DSL, a tier-15 or tier-20 heal attempt corrects it and the scenario completes.

## Breaking changes

**None.** Everything is additive with safe defaults:
- `BlueprintComposer.__init__` gains `healers=None` — `None` means "build the sensible default chain lazily at compose time."
- `BlueprintComposer.compose` gains `executor=None` — `None` preserves today's pre-execution behavior for existing callers.
- `CompletionResult` gains two `int = 0` fields.
- `CallDetail` / `ComposeResult` gain `int = 0` / `str = ""` / `list = []` defaults.
- `BricksEngine.solve` now reads `compose_result.exec_outputs` / `exec_error` / `heal_attempts`; callers see the same `EngineResult` contract.

## Out of scope

- **Gemini caching** — different API (`CachedContent` with storage billing), bigger lift, separate issue.
- **Embedding-tier selector** — mentioned in the umbrella discussion but not bundled here.
- **Structured failure logging** — the `heal_attempts` trace inside `ComposeResult` is the hook; surfacing it to disk per-scenario will land in a follow-up.
- **Tier 40 in the default chain** — it recursively invokes compose and needs a caller-supplied `fresh_compose`; opt in via `BlueprintComposer(healers=[..., FullRecomposeHealer(fresh_compose=...)])`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)