### PR TITLE
feat(providers): parse --output-format json in ClaudeCodeProvider (#47)

### DIFF
--- a/src/bricks/llm/base.py
+++ b/src/bricks/llm/base.py
@@ -27,6 +27,9 @@ class CompletionResult:
             Surfaces tier-1 cache writes so callers can distinguish first-
             pay writes from subsequent reads. ``0`` for non-Anthropic
             providers.
+        cost_usd: Actual dollar cost reported by the provider for this call.
+            ``0.0`` when the provider doesn't report cost or tokens were
+            estimated rather than measured.
     """
 
     text: str
@@ -37,6 +40,7 @@ class CompletionResult:
     estimated: bool = False
     cached_input_tokens: int = 0
     cache_creation_input_tokens: int = 0
+    cost_usd: float = 0.0
 
 
 class LLMProvider(ABC):

--- a/src/bricks/providers/claudecode/provider.py
+++ b/src/bricks/providers/claudecode/provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import subprocess
@@ -43,13 +44,17 @@ class ClaudeCodeProvider(LLMProvider):
         response = provider.complete("Say hello", system="You are helpful.")
     """
 
-    def __init__(self, timeout: int = 120) -> None:
+    def __init__(self, timeout: int = 120, model: str | None = None) -> None:
         """Initialise provider.
 
         Args:
             timeout: Maximum seconds to wait for a ``claude -p`` response.
+            model: Optional model alias to pass as ``--model`` (e.g.
+                ``"sonnet"``, ``"opus"``, ``"haiku"``). ``None`` lets
+                Claude Code pick its default.
         """
         self.timeout = timeout
+        self.model = model
 
     def _estimate_tokens(self, text: str) -> int:
         """Estimate token count using tiktoken, fallback to char/4.
@@ -71,18 +76,21 @@ class ClaudeCodeProvider(LLMProvider):
     def complete(self, prompt: str, system: str = "") -> CompletionResult:
         """Send a prompt through ``claude -p`` and return a CompletionResult.
 
-        The full prompt is passed via stdin to avoid OS argument-length limits.
-        Token counts are estimated (tiktoken if available, else char/4).
+        Invokes ``claude -p --output-format json`` and parses the structured
+        response to report real token usage and cost. Falls back to tiktoken
+        estimation if the CLI ever returns non-JSON output.
 
         Args:
             prompt: The user message to send.
             system: Optional system prompt prepended before the user message.
 
         Returns:
-            CompletionResult with response text and estimated token counts.
+            CompletionResult with response text, real token counts, and cost
+            when the CLI returns JSON; estimated counts otherwise.
 
         Raises:
-            RuntimeError: If the ``claude`` process exits with a non-zero code.
+            RuntimeError: If the ``claude`` process exits with a non-zero code
+                or the parsed response has ``is_error: true``.
             subprocess.TimeoutExpired: If the process exceeds ``self.timeout``.
         """
         full_prompt = f"{system}\n\n{prompt}" if system else prompt
@@ -95,13 +103,17 @@ class ClaudeCodeProvider(LLMProvider):
             if git_bash:
                 env["CLAUDE_CODE_GIT_BASH_PATH"] = git_bash
 
+        cmd = ["claude", "-p", "--output-format", "json"]
+        if self.model:
+            cmd.extend(["--model", self.model])
+
         logger.info("Sending prompt to claude -p (%d chars, timeout=%ds)", len(full_prompt), self.timeout)
         logger.debug("Full prompt:\n%s", full_prompt)
 
         t0 = time.monotonic()
         try:
-            result = subprocess.run(
-                ["claude", "-p"],  # noqa: S607
+            result = subprocess.run(  # noqa: S603
+                cmd,
                 input=full_prompt,
                 capture_output=True,
                 text=True,
@@ -120,11 +132,35 @@ class ClaudeCodeProvider(LLMProvider):
 
         logger.info("claude -p responded (%d chars, %.1fs)", len(result.stdout), elapsed)
         logger.debug("Raw response:\n%s", result.stdout)
+
+        try:
+            parsed = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            logger.warning("claude -p returned non-JSON; falling back to tiktoken estimate")
+            return CompletionResult(
+                text=result.stdout.strip(),
+                input_tokens=self._estimate_tokens(full_prompt),
+                output_tokens=self._estimate_tokens(result.stdout),
+                model=self.model or "claude-code",
+                duration_seconds=elapsed,
+                estimated=True,
+            )
+
+        if parsed.get("is_error"):
+            raise RuntimeError(parsed.get("result", "unknown error"))
+
+        usage = parsed.get("usage", {})
+        model_usage = parsed.get("modelUsage", {})
+        model_name = next(iter(model_usage), self.model or "claude-code")
+
         return CompletionResult(
-            text=result.stdout.strip(),
-            input_tokens=self._estimate_tokens(full_prompt),
-            output_tokens=self._estimate_tokens(result.stdout),
-            model="claude-code",
+            text=parsed.get("result", "").strip(),
+            input_tokens=usage.get("input_tokens", 0),
+            output_tokens=usage.get("output_tokens", 0),
+            model=model_name,
             duration_seconds=elapsed,
-            estimated=True,
+            estimated=False,
+            cached_input_tokens=usage.get("cache_read_input_tokens", 0),
+            cache_creation_input_tokens=usage.get("cache_creation_input_tokens", 0),
+            cost_usd=parsed.get("total_cost_usd", 0.0),
         )

--- a/tests/providers/claudecode/test_provider.py
+++ b/tests/providers/claudecode/test_provider.py
@@ -2,13 +2,185 @@
 
 from __future__ import annotations
 
+import json
 import shutil
+import subprocess
+from typing import Any
+from unittest.mock import patch
 
 import pytest
 
 from bricks.providers.claudecode import ClaudeCodeProvider
 
 _CLAUDE_AVAILABLE = shutil.which("claude") is not None
+
+_SAMPLE_JSON = {
+    "type": "result",
+    "subtype": "success",
+    "is_error": False,
+    "duration_ms": 2411,
+    "duration_api_ms": 1779,
+    "num_turns": 1,
+    "result": "hello",
+    "session_id": "abc-123",
+    "total_cost_usd": 0.161,
+    "usage": {
+        "input_tokens": 3,
+        "cache_creation_input_tokens": 25743,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 4,
+    },
+    "modelUsage": {
+        "claude-sonnet-4-6": {
+            "inputTokens": 3,
+            "outputTokens": 4,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 25743,
+            "costUSD": 0.161,
+            "contextWindow": 200000,
+            "maxOutputTokens": 32000,
+        }
+    },
+}
+
+
+def _mock_run(stdout: str, returncode: int = 0) -> Any:
+    """Return a CompletedProcess stand-in with the given stdout."""
+    return subprocess.CompletedProcess(
+        args=["claude", "-p", "--output-format", "json"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr="",
+    )
+
+
+def test_json_output_populates_all_fields() -> None:
+    """JSON response maps to real tokens, cost, cache counters."""
+    provider = ClaudeCodeProvider()
+    with patch(
+        "bricks.providers.claudecode.provider.subprocess.run",
+        return_value=_mock_run(json.dumps(_SAMPLE_JSON)),
+    ):
+        response = provider.complete("hi")
+
+    assert response.text == "hello"
+    assert response.input_tokens == 3
+    assert response.output_tokens == 4
+    assert response.cached_input_tokens == 0
+    assert response.cache_creation_input_tokens == 25743
+    assert response.cost_usd == 0.161
+    assert response.model == "claude-sonnet-4-6"
+    assert response.estimated is False
+
+
+def test_is_error_true_raises_runtime_error() -> None:
+    """`is_error: true` raises RuntimeError with the error text."""
+    payload = {"is_error": True, "result": "boom"}
+    provider = ClaudeCodeProvider()
+    with (
+        patch(
+            "bricks.providers.claudecode.provider.subprocess.run",
+            return_value=_mock_run(json.dumps(payload)),
+        ),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        provider.complete("hi")
+
+
+def test_malformed_json_falls_back_to_estimate() -> None:
+    """Non-JSON output falls back to tiktoken/char estimation."""
+    provider = ClaudeCodeProvider()
+    with patch(
+        "bricks.providers.claudecode.provider.subprocess.run",
+        return_value=_mock_run("not-json"),
+    ):
+        response = provider.complete("hello world")
+
+    assert response.estimated is True
+    assert response.text == "not-json"
+    assert response.input_tokens > 0
+    assert response.output_tokens > 0
+    assert response.cost_usd == 0.0
+    assert response.model == "claude-code"
+
+
+def test_malformed_json_fallback_preserves_model_alias() -> None:
+    """Fallback uses the configured model alias when set."""
+    provider = ClaudeCodeProvider(model="opus")
+    with patch(
+        "bricks.providers.claudecode.provider.subprocess.run",
+        return_value=_mock_run("not-json"),
+    ):
+        response = provider.complete("hi")
+
+    assert response.estimated is True
+    assert response.model == "opus"
+
+
+def test_model_param_appears_in_command() -> None:
+    """`model=` adds `--model <alias>` to the subprocess argv."""
+    provider = ClaudeCodeProvider(model="opus")
+    with patch(
+        "bricks.providers.claudecode.provider.subprocess.run",
+        return_value=_mock_run(json.dumps(_SAMPLE_JSON)),
+    ) as mock_run:
+        provider.complete("hi")
+
+    cmd = mock_run.call_args.args[0]
+    assert cmd == ["claude", "-p", "--output-format", "json", "--model", "opus"]
+
+
+def test_model_param_absent_when_not_set() -> None:
+    """Default provider does not pass `--model`."""
+    provider = ClaudeCodeProvider()
+    with patch(
+        "bricks.providers.claudecode.provider.subprocess.run",
+        return_value=_mock_run(json.dumps(_SAMPLE_JSON)),
+    ) as mock_run:
+        provider.complete("hi")
+
+    cmd = mock_run.call_args.args[0]
+    assert "--model" not in cmd
+    assert cmd == ["claude", "-p", "--output-format", "json"]
+
+
+@pytest.mark.parametrize(
+    "model_key",
+    ["claude-sonnet-4-6", "claude-opus-4-7", "claude-haiku-4-5"],
+)
+def test_per_model_variants(model_key: str) -> None:
+    """`result.model` matches whatever key `modelUsage` reports."""
+    payload = {
+        **_SAMPLE_JSON,
+        "modelUsage": {model_key: _SAMPLE_JSON["modelUsage"]["claude-sonnet-4-6"]},
+    }
+    provider = ClaudeCodeProvider()
+    with patch(
+        "bricks.providers.claudecode.provider.subprocess.run",
+        return_value=_mock_run(json.dumps(payload)),
+    ):
+        response = provider.complete("hi")
+
+    assert response.model == model_key
+
+
+def test_nonzero_returncode_raises() -> None:
+    """Non-zero CLI exit still raises RuntimeError (pre-JSON-parse path)."""
+    provider = ClaudeCodeProvider()
+    failed = subprocess.CompletedProcess(
+        args=["claude", "-p"],
+        returncode=1,
+        stdout="",
+        stderr="cli crashed",
+    )
+    with (
+        patch(
+            "bricks.providers.claudecode.provider.subprocess.run",
+            return_value=failed,
+        ),
+        pytest.raises(RuntimeError, match="cli crashed"),
+    ):
+        provider.complete("hi")
 
 
 @pytest.mark.skipif(not _CLAUDE_AVAILABLE, reason="claude CLI not available")
@@ -20,8 +192,8 @@ def test_simple_completion_returns_result() -> None:
     assert len(response.text) > 0
     assert response.input_tokens > 0
     assert response.output_tokens > 0
-    assert response.estimated is True
-    assert response.model == "claude-code"
+    assert response.estimated is False
+    assert response.model != ""
 
 
 @pytest.mark.skipif(not _CLAUDE_AVAILABLE, reason="claude CLI not available")


### PR DESCRIPTION
Closes #47.

## Summary
- Add `cost_usd: float = 0.0` to `CompletionResult` (additive, doesn't break existing callers)
- Accept optional `model: str | None = None` on `ClaudeCodeProvider`; passes through as `--model <alias>`
- Invoke `claude -p --output-format json`, parse `usage` / `total_cost_usd` / `modelUsage` into the result
- Raise `RuntimeError` when the payload has `is_error: true`
- On `json.JSONDecodeError`, log a warning and fall back to the old tiktoken estimation path so transient CLI changes don't break Bricks

## Test plan
- [x] Mocked unit tests cover success, `is_error:true`, malformed JSON fallback, `--model` argv presence/absence, per-model `modelUsage` keys, and the non-zero-returncode path — all pass without a live `claude` CLI.
- [x] Live smoke tests (3 existing, gated by `shutil.which("claude")`) now assert `estimated is False` and confirm real CLI still returns parseable JSON.
- [x] Full suite: `pytest` → 1168 passed, 18 skipped locally.
- [x] `ruff check src tests` clean; `ruff format --check` clean.
- [x] `mypy src` clean.
- [ ] CI matrix (3.10 / 3.11 / 3.12) green.

## Notes
- Target branch per the issue is `feat/playground-backend`, but that branch isn't on origin — per your direction this PR targets `main`.
- Non-goals preserved: no budget cap, no streaming, no `litellm_provider.py` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)