### PR TITLE
feat(playground): drop v2 mockup into web/static/index.html (#42)

### DIFF
--- a/src/bricks/playground/web/static/index.html
+++ b/src/bricks/playground/web/static/index.html
@@ -1,950 +1,1291 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Bricks Benchmark</title>
-  <style>
-    :root {
-      --bg: #FAF9F7;
-      --surface: #FFFFFF;
-      --border: #E8E4DF;
-      --text: #1A1915;
-      --text-muted: #9B9590;
-      --primary: #D97706;
-      --primary-hover: #B45309;
-      --green: #059669;
-      --red: #DC2626;
-      --purple: #7C3AED;
-      --card-shadow: 0 1px 3px rgba(0,0,0,0.06);
-      --radius: 12px;
-    }
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      background: var(--bg);
-      color: var(--text);
-      min-height: 100vh;
-    }
-    /* ── Top bar ── */
-    .topbar {
-      background: var(--surface);
-      border-bottom: 1px solid var(--border);
-      padding: 0 32px;
-      display: flex;
-      align-items: center;
-      gap: 24px;
-      height: 56px;
-      position: sticky;
-      top: 0;
-      z-index: 100;
-    }
-    .topbar-logo { font-weight: 700; font-size: 18px; color: var(--primary); letter-spacing: -0.5px; }
-    .topbar-logo span { color: var(--text-muted); font-weight: 400; }
-    .step-indicator {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      margin-left: auto;
-    }
-    .step-dot {
-      width: 28px; height: 28px;
-      border-radius: 50%;
-      display: flex; align-items: center; justify-content: center;
-      font-size: 12px; font-weight: 600;
-      background: var(--border);
-      color: var(--text-muted);
-      transition: all 0.2s;
-    }
-    .step-dot.active { background: var(--primary); color: #fff; }
-    .step-dot.done { background: var(--green); color: #fff; }
-    .step-line { width: 32px; height: 2px; background: var(--border); border-radius: 2px; }
-    /* ── Layout ── */
-    .main { max-width: 960px; margin: 0 auto; padding: 32px 24px; }
-    /* ── Cards ── */
-    .card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
-      box-shadow: var(--card-shadow);
-      padding: 24px;
-      margin-bottom: 20px;
-    }
-    .card h2 { font-size: 18px; font-weight: 600; margin-bottom: 4px; }
-    .card .subtitle { color: var(--text-muted); font-size: 14px; margin-bottom: 20px; }
-    /* ── Dataset cards ── */
-    .dataset-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 12px; }
-    .dataset-card {
-      border: 2px solid var(--border);
-      border-radius: 10px;
-      padding: 16px;
-      cursor: pointer;
-      transition: border-color 0.15s, box-shadow 0.15s;
-    }
-    .dataset-card:hover { border-color: var(--primary); }
-    .dataset-card.selected { border-color: var(--primary); background: #FEF3C7; }
-    .dataset-card h3 { font-size: 15px; font-weight: 600; margin-bottom: 4px; }
-    .dataset-card .ds-desc { font-size: 13px; color: var(--text-muted); margin-bottom: 8px; }
-    .ds-meta { display: flex; gap: 8px; flex-wrap: wrap; font-size: 12px; color: var(--text-muted); }
-    .ds-tag { background: var(--bg); border: 1px solid var(--border); border-radius: 4px; padding: 2px 6px; }
-    .ds-preview-btn {
-      background: none; border: 1px solid var(--border); border-radius: 6px;
-      padding: 4px 10px; font-size: 12px; cursor: pointer; margin-top: 10px;
-      color: var(--text-muted);
-    }
-    .ds-preview-btn:hover { background: var(--bg); }
-    .ds-preview { display: none; margin-top: 10px; overflow-x: auto; }
-    .ds-preview.open { display: block; }
-    .mini-table { border-collapse: collapse; font-size: 12px; width: 100%; }
-    .mini-table th, .mini-table td { border: 1px solid var(--border); padding: 4px 8px; text-align: left; white-space: nowrap; }
-    .mini-table th { background: var(--bg); color: var(--text-muted); font-weight: 600; }
-    /* ── Custom data ── */
-    .custom-zone {
-      border: 2px dashed var(--border);
-      border-radius: 10px;
-      padding: 20px;
-      text-align: center;
-      transition: border-color 0.15s;
-      cursor: pointer;
-    }
-    .custom-zone.selected { border-color: var(--primary); background: #FEF3C7; }
-    .custom-zone.has-data { text-align: left; cursor: default; }
-    .custom-textarea {
-      width: 100%; min-height: 120px;
-      font-family: 'SF Mono', 'Fira Code', monospace;
-      font-size: 13px;
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      padding: 10px;
-      background: var(--bg);
-      color: var(--text);
-      resize: vertical;
-      margin-top: 10px;
-    }
-    .custom-textarea:focus { outline: none; border-color: var(--primary); }
-    /* ── Task textarea ── */
-    .task-textarea {
-      width: 100%; min-height: 100px;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      font-size: 14px;
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      padding: 12px;
-      color: var(--text);
-      resize: vertical;
-    }
-    .task-textarea:focus { outline: none; border-color: var(--primary); }
-    /* ── Optional settings ── */
-    .settings-toggle {
-      background: none; border: none; cursor: pointer;
-      color: var(--text-muted); font-size: 14px;
-      display: flex; align-items: center; gap: 6px; padding: 4px 0;
-    }
-    .settings-toggle:hover { color: var(--text); }
-    .settings-body { display: none; margin-top: 16px; }
-    .settings-body.open { display: block; }
-    .settings-label { font-size: 13px; font-weight: 600; color: var(--text-muted); margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.5px; }
-    .settings-section { margin-bottom: 16px; }
-    /* ── Brick chips ── */
-    .brick-chips { display: flex; flex-wrap: wrap; gap: 6px; max-height: 160px; overflow-y: auto; }
-    .brick-chip {
-      border: 1px solid var(--border); border-radius: 20px;
-      padding: 3px 10px; font-size: 12px; cursor: pointer;
-      background: var(--bg); color: var(--text-muted);
-      transition: all 0.15s;
-    }
-    .brick-chip:hover { border-color: var(--primary); color: var(--primary); }
-    .brick-chip.selected { background: var(--primary); color: #fff; border-color: var(--primary); }
-    /* ── Model pills ── */
-    .model-pills { display: flex; gap: 8px; flex-wrap: wrap; }
-    .model-pill {
-      border: 2px solid var(--border); border-radius: 20px;
-      padding: 6px 14px; font-size: 13px; cursor: pointer;
-      background: var(--surface); color: var(--text-muted);
-      transition: all 0.15s;
-    }
-    .model-pill:hover { border-color: var(--primary); }
-    .model-pill.selected { border-color: var(--primary); color: var(--primary); background: #FEF3C7; }
-    /* ── Preset select ── */
-    .preset-select {
-      font-size: 14px; border: 1px solid var(--border); border-radius: 8px;
-      padding: 8px 12px; background: var(--surface); color: var(--text); cursor: pointer;
-      width: 100%;
-    }
-    .preset-select:focus { outline: none; border-color: var(--primary); }
-    /* ── Buttons ── */
-    .btn-row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-top: 8px; }
-    .btn {
-      padding: 10px 20px; font-size: 14px; font-weight: 600; border-radius: 8px;
-      border: none; cursor: pointer; transition: all 0.15s;
-    }
-    .btn-primary { background: var(--primary); color: #fff; }
-    .btn-primary:hover { background: var(--primary-hover); }
-    .btn-primary:disabled { background: var(--border); color: var(--text-muted); cursor: not-allowed; }
-    .btn-outline { background: none; border: 2px solid var(--border); color: var(--text); }
-    .btn-outline:hover { border-color: var(--primary); color: var(--primary); }
-    .error-msg { color: var(--red); font-size: 13px; padding: 4px 0; }
-    /* ── Step 2 ── */
-    #step2 { text-align: center; padding: 48px 0; }
-    .spinner {
-      width: 48px; height: 48px; border: 4px solid var(--border);
-      border-top-color: var(--primary); border-radius: 50%;
-      animation: spin 0.9s linear infinite; margin: 0 auto 24px;
-    }
-    @keyframes spin { to { transform: rotate(360deg); } }
-    .progress-steps { list-style: none; text-align: left; max-width: 340px; margin: 24px auto; }
-    .progress-steps li { padding: 8px 0; font-size: 14px; color: var(--text-muted); display: flex; align-items: center; gap: 10px; }
-    .progress-steps li.done { color: var(--green); }
-    .progress-steps li.active { color: var(--text); }
-    .step-icon { font-size: 16px; width: 20px; text-align: center; }
-    /* ── Step 3 ── */
-    .winner-banner {
-      border-radius: var(--radius);
-      padding: 28px 32px;
-      margin-bottom: 20px;
-      background: linear-gradient(135deg, #F0FDF4 0%, #ECFDF5 100%);
-      border: 1px solid var(--green);
-    }
-    .winner-banner.tie { background: linear-gradient(135deg, #EFF6FF 0%, #F0F9FF 100%); border-color: #60A5FA; }
-    .winner-banner.no-expected { background: var(--surface); border-color: var(--border); }
-    .winner-trophy { font-size: 36px; margin-bottom: 8px; }
-    .winner-title { font-size: 22px; font-weight: 700; margin-bottom: 6px; }
-    .winner-sub { color: var(--text-muted); font-size: 15px; margin-bottom: 12px; }
-    .savings-big { font-size: 32px; font-weight: 800; color: var(--purple); }
-    .engine-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 20px; }
-    .engine-card {
-      border: 2px solid var(--border);
-      border-radius: var(--radius);
-      padding: 20px;
-      background: var(--surface);
-    }
-    .engine-card.correct { border-color: var(--green); }
-    .engine-card.wrong { border-color: var(--red); }
-    .engine-card h3 { font-size: 16px; font-weight: 700; margin-bottom: 4px; }
-    .engine-card .method { font-size: 12px; color: var(--text-muted); margin-bottom: 14px; font-style: italic; }
-    .engine-stat { display: flex; justify-content: space-between; font-size: 13px; padding: 4px 0; border-bottom: 1px solid var(--bg); }
-    .engine-stat:last-child { border: none; }
-    .stat-label { color: var(--text-muted); }
-    .stat-val { font-weight: 600; font-family: 'SF Mono', monospace; font-size: 12px; }
-    .correct-badge { display: inline-block; padding: 2px 8px; border-radius: 20px; font-size: 12px; font-weight: 600; margin-top: 8px; }
-    .correct-badge.yes { background: #D1FAE5; color: var(--green); }
-    .correct-badge.no { background: #FEE2E2; color: var(--red); }
-    .correct-badge.na { background: var(--bg); color: var(--text-muted); }
-    .explain-card { margin-bottom: 20px; }
-    .savings-strip {
-      border-radius: var(--radius);
-      background: linear-gradient(135deg, #4C1D95 0%, #7C3AED 100%);
-      color: #fff;
-      padding: 24px 28px;
-      margin-bottom: 20px;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-    }
-    .savings-strip .pct { font-size: 36px; font-weight: 800; }
-    .savings-strip .detail { font-size: 14px; opacity: 0.8; margin-top: 4px; }
-    .savings-strip .desc { font-size: 13px; opacity: 0.7; max-width: 340px; }
-    .comparison-table { width: 100%; border-collapse: collapse; font-size: 13px; margin-top: 12px; }
-    .comparison-table th { background: var(--bg); padding: 8px 12px; text-align: left; font-weight: 600; color: var(--text-muted); border-bottom: 2px solid var(--border); }
-    .comparison-table td { padding: 8px 12px; border-bottom: 1px solid var(--border); font-family: 'SF Mono', 'Fira Code', monospace; }
-    .comparison-table tr:last-child td { border: none; }
-    .match { color: var(--green); }
-    .mismatch { color: var(--red); }
-    .blueprint-block {
-      background: #1A1915;
-      border-radius: var(--radius);
-      padding: 20px;
-      overflow-x: auto;
-      font-family: 'SF Mono', 'Fira Code', monospace;
-      font-size: 13px;
-      line-height: 1.6;
-      color: #E5E5E0;
-    }
-    .yaml-key { color: #F59E0B; }
-    .yaml-val { color: #86EFAC; }
-    .yaml-comment { color: #6B7280; }
-    .footer-actions { display: flex; gap: 12px; flex-wrap: wrap; padding-top: 8px; }
-    /* ── Helpers ── */
-    .hidden { display: none !important; }
-    .divider { height: 1px; background: var(--border); margin: 16px 0; }
-    .section-header { font-size: 13px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 12px; }
-    .or-divider { text-align: center; color: var(--text-muted); font-size: 13px; margin: 12px 0; }
-  </style>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Bricks Playground</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    /* warm paper palette — adjacent to Claude but its own */
+    --paper:  #F7F4EC;
+    --paper-2:#F0ECE0;
+    --paper-3:#E8E3D4;
+    --ink:    #1C1A16;
+    --ink-2:  #3A3731;
+    --muted:  #8A8578;
+    --faint:  #B5B0A1;
+    --rule:   #E0DBCC;
+    --rule-2: #D0CAB8;
+
+    --accent:       #3F6356;   /* muted deep sage — calmer, paper-friendly */
+    --accent-ink:   #2A4A40;
+    --accent-soft:  #D6E2DC;
+    --accent-bg:    #E5ECE6;
+
+    --ok:   #3F6356;
+    --err:  #B24A3A;
+    --info: #4A6C8F;
+
+    --sans:  'Inter', ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --serif: 'Instrument Serif', 'Tiempos Text', Georgia, serif;
+    --mono:  'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 14px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+  button, input, select, textarea { font-family: inherit; color: inherit; }
+  input:focus, textarea:focus, select:focus { outline: none; }
+
+  /* ===== top bar ===== */
+  .topbar {
+    display: flex; align-items: center; gap: 14px;
+    height: 54px; padding: 0 22px;
+    border-bottom: 1px solid var(--rule);
+    background: var(--paper);
+  }
+  .brand { display: flex; align-items: center; gap: 10px; font-weight: 500; letter-spacing: -0.01em; }
+  .brand-mark {
+    width: 16px; height: 16px;
+    display: grid; grid-template: 1fr 1fr / 1fr 1fr; gap: 2px;
+  }
+  .brand-mark i { background: var(--ink); border-radius: 1px; }
+  .brand-mark i:nth-child(1) { background: var(--accent); }
+  .brand-sub {
+    font-family: var(--mono);
+    font-size: 11px; color: var(--muted);
+    padding-left: 10px; margin-left: 2px;
+    border-left: 1px solid var(--rule);
+  }
+  .spacer { flex: 1; }
+
+  .byok {
+    display: flex; align-items: center;
+    background: #fff;
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+    height: 32px;
+    overflow: hidden;
+  }
+  .byok select {
+    background: transparent; border: none;
+    color: var(--muted);
+    font-family: var(--mono); font-size: 11px;
+    padding: 0 22px 0 10px; height: 100%;
+    cursor: pointer;
+    appearance: none; -webkit-appearance: none;
+    border-right: 1px solid var(--rule);
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='8' height='5' viewBox='0 0 8 5'><path d='M0 0l4 5 4-5z' fill='%238a8578'/></svg>");
+    background-repeat: no-repeat; background-position: right 8px center;
+  }
+  .byok input {
+    background: transparent; border: none;
+    font-family: var(--mono); font-size: 12px;
+    padding: 0 10px; height: 100%; width: 180px;
+    color: var(--ink);
+  }
+  .byok input::placeholder { color: var(--faint); }
+  .byok-dot {
+    padding: 0 10px; height: 100%;
+    display: flex; align-items: center; gap: 6px;
+    font-family: var(--mono); font-size: 10.5px; color: var(--muted);
+    letter-spacing: 0.06em; text-transform: uppercase;
+    border-left: 1px solid var(--rule);
+  }
+  .byok-dot i { width: 6px; height: 6px; border-radius: 50%; background: var(--ok); }
+
+  .tb-btn {
+    height: 32px; padding: 0 14px;
+    background: transparent;
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+    font-size: 12.5px; font-weight: 500;
+    color: var(--ink-2);
+    cursor: pointer;
+    display: inline-flex; align-items: center; gap: 8px;
+    transition: border-color .15s, color .15s;
+  }
+  .tb-btn:hover { border-color: var(--accent); color: var(--accent-ink); }
+  .tb-btn.primary {
+    background: var(--accent); border-color: var(--accent);
+    color: #FFF6EE; font-weight: 600;
+  }
+  .tb-btn.primary:hover { background: var(--accent-ink); border-color: var(--accent-ink); color:#FFF6EE; }
+  .kbd {
+    font-family: var(--mono); font-size: 10px;
+    padding: 1px 5px; border-radius: 3px;
+    background: rgba(0,0,0,0.08);
+  }
+
+  /* ===== views ===== */
+  .view { display: none; }
+  .view.on { display: block; }
+
+  /* ===== setup view ===== */
+  .setup {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 56px 32px 96px;
+  }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 14px;
+  }
+  h1 {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: 44px;
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+    margin: 0 0 14px;
+  }
+  h1 em { font-style: italic; color: var(--accent); }
+  .lede {
+    color: var(--ink-2);
+    font-size: 15px;
+    max-width: 520px;
+    margin: 0 0 40px;
+  }
+
+  .block { margin-bottom: 28px; }
+  .block-label {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 10px;
+  }
+  .block-label .l {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .block-label .r {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--faint);
+  }
+
+  /* scenario select */
+  .scen-select {
+    width: 100%;
+    height: 46px;
+    padding: 0 40px 0 14px;
+    background: #fff;
+    border: 1px solid var(--rule-2);
+    border-radius: 10px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--ink);
+    appearance: none; -webkit-appearance: none;
+    cursor: pointer;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M0 0l5 6 5-6z' fill='%238a8578'/></svg>");
+    background-repeat: no-repeat; background-position: right 14px center;
+    transition: border-color .15s;
+  }
+  .scen-select:hover { border-color: var(--accent); }
+
+  /* task box */
+  .task-box {
+    width: 100%;
+    background: #fff;
+    border: 1px solid var(--rule-2);
+    border-radius: 10px;
+    padding: 14px 16px;
+    font-family: var(--sans);
+    font-size: 14px;
+    color: var(--ink);
+    resize: vertical;
+    min-height: 72px;
+    line-height: 1.5;
+    transition: border-color .15s;
+  }
+  .task-box:focus { border-color: var(--accent); }
+  .task-box::placeholder { color: var(--faint); }
+
+  /* data box */
+  .data-wrap {
+    background: #fff;
+    border: 1px solid var(--rule-2);
+    border-radius: 10px;
+    overflow: hidden;
+  }
+  .data-wrap.drag { border-color: var(--accent); background: var(--accent-bg); }
+  .data-head {
+    display: flex; align-items: center; gap: 10px;
+    padding: 9px 12px;
+    border-bottom: 1px solid var(--rule);
+    background: var(--paper-2);
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--muted);
+  }
+  .data-head .fname {
+    color: var(--ink-2);
+    display: flex; align-items: center; gap: 6px;
+  }
+  .data-head .fsize { color: var(--faint); }
+  .data-head .push { flex: 1; }
+  .upload-mini {
+    background: transparent;
+    border: 1px dashed var(--rule-2);
+    color: var(--muted);
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 11px;
+    cursor: pointer;
+    display: inline-flex; align-items: center; gap: 6px;
+  }
+  .upload-mini:hover { color: var(--accent-ink); border-color: var(--accent); }
+  .data-body {
+    max-height: 260px;
+    overflow: auto;
+    font-family: var(--mono);
+    font-size: 12.5px;
+    line-height: 1.6;
+    padding: 12px 16px;
+    color: var(--ink-2);
+    white-space: pre;
+  }
+  .data-body::-webkit-scrollbar { width: 8px; height: 8px; }
+  .data-body::-webkit-scrollbar-thumb { background: var(--rule-2); border-radius: 4px; }
+
+  /* json colors */
+  .j-key  { color: var(--accent-ink); }
+  .j-str  { color: var(--ok); }
+  .j-num  { color: #A35D1C; }
+  .j-bool { color: var(--info); }
+  .j-null { color: var(--faint); }
+
+  /* row with toggle */
+  .row {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 14px 16px;
+    background: #fff;
+    border: 1px solid var(--rule-2);
+    border-radius: 10px;
+    margin-bottom: 20px;
+  }
+  .row .l b { font-size: 13px; font-weight: 600; display: block; }
+  .row .l span { font-family: var(--mono); font-size: 11px; color: var(--muted); }
+  .toggle {
+    position: relative;
+    width: 38px; height: 22px;
+    background: var(--paper-3);
+    border: 1px solid var(--rule-2);
+    border-radius: 999px;
+    cursor: pointer;
+    transition: all .15s;
+  }
+  .toggle::after {
+    content: "";
+    position: absolute; top: 2px; left: 2px;
+    width: 16px; height: 16px; border-radius: 50%;
+    background: var(--muted);
+    transition: all .18s ease;
+  }
+  .toggle.on { background: var(--accent-soft); border-color: var(--accent); }
+  .toggle.on::after { left: 18px; background: var(--accent); }
+
+  /* run */
+  .actions {
+    display: flex; gap: 10px; align-items: center;
+    margin-top: 32px;
+  }
+  .run-big {
+    background: var(--accent);
+    border: none;
+    color: #FFF6EE;
+    padding: 13px 24px;
+    border-radius: 10px;
+    font-size: 14.5px;
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-flex; align-items: center; gap: 10px;
+    transition: background .15s;
+  }
+  .run-big:hover { background: var(--accent-ink); }
+  .ghost {
+    background: transparent;
+    border: 1px solid var(--rule);
+    color: var(--ink-2);
+    padding: 12px 18px;
+    border-radius: 10px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .ghost:hover { border-color: var(--accent); color: var(--accent-ink); }
+
+  /* ===== running view ===== */
+  .running {
+    max-width: 480px;
+    margin: 0 auto;
+    padding: 120px 32px;
+    text-align: center;
+  }
+  .spinner {
+    width: 40px; height: 40px;
+    margin: 0 auto 28px;
+    border: 2px solid var(--rule);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 0.9s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .running h2 {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: 28px;
+    letter-spacing: -0.01em;
+    margin: 0 0 6px;
+  }
+  .running p { color: var(--muted); font-size: 13px; margin: 0 0 32px; }
+
+  .steps {
+    list-style: none;
+    text-align: left;
+    max-width: 340px;
+    margin: 0 auto;
+    padding: 0;
+  }
+  .steps li {
+    padding: 10px 0;
+    font-family: var(--mono);
+    font-size: 12.5px;
+    color: var(--faint);
+    display: flex; align-items: center; gap: 12px;
+    border-top: 1px solid var(--rule);
+  }
+  .steps li:first-child { border-top: none; }
+  .steps li .mark {
+    width: 16px; height: 16px; border-radius: 50%;
+    border: 1px solid var(--rule-2);
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 10px; color: var(--faint);
+  }
+  .steps li.active { color: var(--ink); }
+  .steps li.active .mark { border-color: var(--accent); color: var(--accent); }
+  .steps li.done { color: var(--ok); }
+  .steps li.done .mark { background: var(--ok); border-color: var(--ok); color: #fff; }
+  .steps li.done .mark::before { content: "✓"; }
+
+  /* ===== results view ===== */
+  .results {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 48px 32px 96px;
+  }
+  .res-top {
+    display: flex; align-items: flex-end; justify-content: space-between;
+    margin-bottom: 32px;
+    gap: 24px;
+  }
+  .res-top .back {
+    background: transparent;
+    border: none;
+    color: var(--muted);
+    font-size: 13px;
+    cursor: pointer;
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 0; margin-bottom: 10px;
+  }
+  .res-top .back:hover { color: var(--accent-ink); }
+
+  .verdict {
+    background: #fff;
+    border: 1px solid var(--rule);
+    border-radius: 14px;
+    padding: 40px 44px 36px;
+    margin-bottom: 24px;
+    position: relative;
+    overflow: hidden;
+  }
+  .verdict h2 {
+    font-family: var(--verdict-font, var(--sans));
+    font-weight: var(--verdict-weight, 600);
+    font-size: var(--verdict-size, 26px);
+    line-height: var(--verdict-lh, 1.35);
+    letter-spacing: var(--verdict-tracking, -0.015em);
+    margin: 0 0 32px;
+    max-width: 560px;
+    position: relative;
+    color: var(--ink);
+    text-wrap: balance;
+  }
+  .verdict h2 em {
+    font-style: var(--verdict-em-style, normal);
+    font-weight: var(--verdict-em-weight, 500);
+    color: var(--muted);
+    display: block;
+    margin-top: 4px;
+    font-size: 0.82em;
+    letter-spacing: -0.01em;
+  }
+  .verdict h2.with-dot::before {
+    content: "";
+    display: inline-block;
+    width: 7px; height: 7px; border-radius: 50%;
+    background: var(--accent);
+    margin-right: 12px; vertical-align: middle;
+    transform: translateY(-4px);
+  }
+
+  .score-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 32px;
+    position: relative;
+  }
+  .score-grid.dual { grid-template-columns: 1fr 1fr; }
+  .scol .who {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--muted);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .scol .who i { width: 6px; height: 6px; border-radius: 50%; background: var(--muted); }
+  .scol.win .who i { background: var(--accent); }
+  .scol.loss .who i { background: var(--err); }
+  .scol .num {
+    font-family: var(--serif);
+    font-size: 52px;
+    line-height: 1;
+    letter-spacing: -0.03em;
+    color: var(--ink);
+  }
+  .scol .num .of { color: var(--faint); font-size: 26px; margin-left: 2px; }
+  .scol.win .num { color: var(--accent); }
+  .scol.loss .num { color: var(--err); opacity: 0.9; }
+  .scol .meta {
+    font-family: var(--mono);
+    font-size: 11.5px;
+    color: var(--muted);
+    margin-top: 10px;
+    letter-spacing: 0.01em;
+  }
+
+  /* metric strip */
+  .metrics {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    background: #fff;
+    border: 1px solid var(--rule-2);
+    border-radius: 12px;
+    overflow: hidden;
+    margin-bottom: 40px;
+  }
+  .metrics.dual { grid-template-columns: repeat(4, 1fr); }
+  .metric {
+    padding: 20px 24px;
+    border-right: 1px solid var(--rule);
+  }
+  .metric:last-child { border-right: none; }
+  .metric .k {
+    font-family: var(--mono);
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 10px;
+  }
+  .metric .v {
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: 22px;
+    letter-spacing: -0.02em;
+    color: var(--ink);
+  }
+  .metric .sub {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--muted);
+    margin-top: 6px;
+  }
+
+  /* section */
+  .res-sec { margin-bottom: 32px; }
+  .res-sec-head {
+    display: flex; align-items: baseline; justify-content: space-between;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--rule);
+    margin-bottom: 18px;
+  }
+  .res-sec-head h3 {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-size: 22px;
+    letter-spacing: -0.01em;
+    margin: 0;
+  }
+  .res-sec-head .num {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--muted);
+    letter-spacing: 0.1em;
+  }
+
+  /* compare table */
+  .cmp {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: var(--mono);
+    font-size: 13.5px;
+  }
+  .cmp th {
+    text-align: right;
+    font-size: 10.5px;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted);
+    padding: 0 16px 14px;
+    border-bottom: 1px solid var(--rule-2);
+  }
+  .cmp th:first-child { text-align: left; padding-left: 2px; }
+  .cmp td {
+    padding: 16px;
+    border-bottom: 1px solid var(--rule);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: var(--ink-2);
+  }
+  .cmp tr:last-child td { border-bottom: none; }
+  .cmp td:first-child { text-align: left; padding-left: 2px; font-weight: 500; color: var(--ink); }
+  .cmp .exp { color: var(--muted); }
+  .cmp .pass { color: var(--ok); font-weight: 600; position: relative; }
+  .cmp .pass::after { content: ""; display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: var(--ok); margin-left: 8px; vertical-align: middle; transform: translateY(-1px); }
+  .cmp .fail { color: var(--err); font-weight: 600; }
+  .cmp .fail::after { content: " ✗"; }
+  .cmp .fail .s { text-decoration: line-through; text-decoration-color: rgba(178,74,58,.35); }
+
+  /* collapsed details */
+  details.drawer {
+    background: #fff;
+    border: 1px solid var(--rule-2);
+    border-radius: 10px;
+    overflow: hidden;
+  }
+  details.drawer + details.drawer { margin-top: 10px; }
+  details.drawer summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 14px 18px;
+    display: flex; align-items: center; justify-content: space-between;
+    user-select: none;
+  }
+  details.drawer summary::-webkit-details-marker { display: none; }
+  .drw-l {
+    display: flex; align-items: baseline; gap: 12px;
+  }
+  .drw-t { font-family: var(--mono); font-size: 13px; font-weight: 500; }
+  .drw-s { font-family: var(--mono); font-size: 11px; color: var(--muted); }
+  .chev { width: 14px; height: 14px; color: var(--muted); transition: transform .2s; }
+  details.drawer[open] .chev { transform: rotate(180deg); }
+
+  pre.yaml {
+    margin: 0;
+    padding: 16px 20px;
+    background: var(--paper-2);
+    border-top: 1px solid var(--rule);
+    font-family: var(--mono);
+    font-size: 12px;
+    line-height: 1.65;
+    color: var(--ink-2);
+    white-space: pre;
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+  .y-key { color: var(--accent-ink); }
+  .y-str { color: var(--ok); }
+  .y-num { color: #A35D1C; }
+  .y-ref { color: var(--accent); }
+  .y-dash { color: var(--muted); }
+
+  .bricks-used {
+    padding: 16px 20px;
+    background: var(--paper-2);
+    border-top: 1px solid var(--rule);
+    display: flex; flex-wrap: wrap; gap: 6px;
+  }
+  .brick-pill {
+    font-family: var(--mono);
+    font-size: 11px;
+    padding: 4px 10px;
+    background: #fff;
+    border: 1px solid var(--rule-2);
+    border-radius: 999px;
+    color: var(--ink-2);
+  }
+  .brick-pill em {
+    font-style: normal;
+    color: var(--faint);
+    margin-left: 6px;
+  }
+  .brick-pill .pill-count {
+    font-style: normal;
+    font-weight: 500;
+    margin-left: 8px;
+    padding: 1px 6px;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent-ink);
+    font-size: 10px;
+  }
+
+  /* res footer */
+  .res-foot {
+    margin-top: 40px;
+    padding-top: 20px;
+    border-top: 1px solid var(--rule);
+    display: flex; justify-content: space-between; flex-wrap: wrap; gap: 12px;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--muted);
+  }
+  .res-foot b { color: var(--ink-2); font-weight: 500; margin-right: 5px; }
+
+  @media (max-width: 720px) {
+    h1 { font-size: 32px; }
+    .verdict h2 { font-size: 26px; }
+    .metrics, .metrics.dual { grid-template-columns: 1fr 1fr; }
+    .metric { border-right: none; border-bottom: 1px solid var(--rule); }
+    .byok input { width: 100px; }
+  }
+</style>
 </head>
 <body>
 
-<!-- TOP BAR -->
+<!-- ====== TOP BAR ====== -->
 <nav class="topbar">
-  <div class="topbar-logo">⚡ Bricks <span>Benchmark</span></div>
-  <div class="step-indicator">
-    <div class="step-dot active" id="dot1">1</div>
-    <div class="step-line"></div>
-    <div class="step-dot" id="dot2">2</div>
-    <div class="step-line"></div>
-    <div class="step-dot" id="dot3">3</div>
+  <div class="brand">
+    <div class="brand-mark"><i></i><i></i><i></i><i></i></div>
+    <span>bricks</span>
+    <span class="brand-sub">playground</span>
+  </div>
+  <div class="spacer"></div>
+  <div class="byok" title="Model">
+    <select id="modelSel" style="padding-right: 24px;">
+      <option>Haiku 4.5</option>
+      <option>Sonnet 4.5</option>
+      <option>GPT-4o Mini</option>
+      <option>Llama3 local</option>
+    </select>
+  </div>
+  <div class="byok" title="Bring your own key">
+    <select>
+      <option>Anthropic</option>
+      <option>OpenAI</option>
+    </select>
+    <input type="password" placeholder="sk-ant-•••••••••" value="sk-ant-api03-xXxXxXx" />
+    <div class="byok-dot"><i></i>connected</div>
   </div>
 </nav>
 
-<!-- STEP 1: SETUP -->
-<div class="main" id="step1">
-  <div class="card">
-    <h2>What would you like to benchmark?</h2>
-    <p class="subtitle">Choose a dataset, describe your task, and compare BricksEngine vs LLM.</p>
+<!-- ====== VIEW 1 — SETUP ====== -->
+<main class="view on" id="view-setup">
+  <div class="setup">
 
-    <!-- Presets -->
-    <div class="settings-section">
-      <div class="section-header">Quick Start — Load a Preset</div>
-      <select class="preset-select" id="presetSelect">
-        <option value="">Select a preset scenario…</option>
+    <div class="eyebrow">Playground</div>
+    <h1>Compose a task. <em>Run it both ways.</em></h1>
+    <p class="lede">Deterministic pipelines beat raw LLM reasoning on structured data. Try it on a sample or your own.</p>
+
+    <!-- SCENARIO SELECT -->
+    <div class="block">
+      <div class="block-label">
+        <span class="l">01 · Scenario</span>
+        <span class="r">presets + your own</span>
+      </div>
+      <select class="scen-select" id="scenSelect">
+        <option value="crm-pipeline">CRM · customer aggregates</option>
+        <option value="crm-hallucination">CRM · consistency at scale</option>
+        <option value="crm-reuse">CRM · reuse across a batch</option>
+        <option value="support">Support · ticket triage</option>
+        <option value="orders">Orders · revenue by plan</option>
+        <option value="custom">Blank · start from scratch</option>
       </select>
     </div>
 
-    <div class="divider"></div>
-
-    <!-- Section A: Data -->
-    <div class="section-header">Section A — Choose Your Data</div>
-    <div class="dataset-grid" id="datasetGrid">
-      <div style="color:var(--text-muted);font-size:13px;">Loading datasets…</div>
+    <!-- TASK -->
+    <div class="block">
+      <div class="block-label">
+        <span class="l">02 · Task</span>
+        <span class="r">what should the pipeline produce?</span>
+      </div>
+      <textarea class="task-box" id="taskInput" placeholder="Describe the task in plain English…">Parse the customer JSON, filter to active customers, and return: active_count, total_active_revenue, avg_active_revenue (rounded to 2 decimals).</textarea>
     </div>
 
-    <div class="or-divider">— or paste your own —</div>
-
-    <div class="custom-zone" id="customZone">
-      <div id="customZonePrompt">
-        <div style="font-size:24px;margin-bottom:8px;">📋</div>
-        <div style="font-weight:600;margin-bottom:4px;">Paste JSON data</div>
-        <div style="font-size:13px;color:var(--text-muted);">Click to expand and paste your own JSON array or object</div>
+    <!-- DATA -->
+    <div class="block">
+      <div class="block-label">
+        <span class="l">03 · Data</span>
+        <span class="r">drag a file or edit inline</span>
       </div>
-      <div id="customZoneInput" class="hidden">
-        <div style="font-size:13px;font-weight:600;margin-bottom:6px;">Your JSON data:</div>
-        <textarea class="custom-textarea" id="customDataInput" placeholder='[{"id": 1, "name": "Alice", ...}, ...]'></textarea>
-      </div>
-    </div>
-
-    <div class="divider"></div>
-
-    <!-- Section B: Task -->
-    <div class="section-header">Section B — Describe Your Task</div>
-    <textarea class="task-textarea" id="taskInput" placeholder="Describe what you want to compute from the data…"></textarea>
-
-    <div class="divider"></div>
-
-    <!-- Section C: Optional settings -->
-    <button class="settings-toggle" id="settingsToggle">
-      <span id="settingsArrow">▶</span> Optional Settings (expected outputs, brick hints, model)
-    </button>
-    <div class="settings-body" id="settingsBody">
-      <div class="settings-section">
-        <div class="settings-label">Expected Outputs (JSON)</div>
-        <p style="font-size:12px;color:var(--text-muted);margin-bottom:6px;">Know the correct answers? Enter them to check accuracy.</p>
-        <textarea class="custom-textarea" id="expectedInput" style="min-height:80px;" placeholder='{"active_count": 9, "total_revenue": 1524.0}'></textarea>
-      </div>
-      <div class="settings-section">
-        <div class="settings-label">Brick Hints</div>
-        <div class="brick-chips" id="brickChips">
-          <div style="color:var(--text-muted);font-size:13px;">Loading bricks…</div>
+      <div class="data-wrap" id="dropzone">
+        <div class="data-head">
+          <span class="fname">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+            customers.json
+          </span>
+          <span class="fsize">24 rows · 3.2 KB</span>
+          <span class="push"></span>
+          <button class="upload-mini">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+            Upload CSV / JSON
+          </button>
         </div>
-      </div>
-      <div class="settings-section">
-        <div class="settings-label">Model</div>
-        <div class="model-pills" id="modelPills">
-          <div class="model-pill selected" data-model="claudecode">Claude Code</div>
-          <div class="model-pill" data-model="claude-haiku-4-5-20251001">Haiku 4.5</div>
-          <div class="model-pill" data-model="gpt-4o-mini">GPT-4o Mini</div>
-          <div class="model-pill" data-model="ollama/llama3">Llama3 (local)</div>
-        </div>
+        <div class="data-body" id="dataBody"></div>
       </div>
     </div>
 
-    <div class="divider"></div>
-
-    <div id="setupError" class="error-msg hidden"></div>
-    <div class="btn-row">
-      <button class="btn btn-primary" id="runBtn">Run Benchmark →</button>
-      <button class="btn btn-outline" id="saveYamlBtn">Save as YAML</button>
-      <button class="btn btn-outline" id="clearBtn">Clear</button>
+    <!-- EXPECTED OUTPUT (optional) -->
+    <div class="block">
+      <div class="block-label">
+        <span class="l">04 · Expected output <span style="color:var(--faint); text-transform:none; letter-spacing:0; font-size:10.5px; margin-left:6px;">optional</span></span>
+        <span class="r">for pass/fail comparison</span>
+      </div>
+      <textarea class="task-box" id="expectedInput" style="font-family: var(--mono); font-size: 12.5px; min-height: 88px;" placeholder='{"active_count": 18, "total_active_revenue": 3447.50}'>{
+  "active_count": 18,
+  "total_active_revenue": 3447.50,
+  "avg_active_revenue": 191.53
+}</textarea>
     </div>
+
+    <!-- COMPARE -->
+    <div class="row">
+      <div class="l">
+        <b>Compare to raw LLM</b>
+        <span>Run the same task with a plain prompt — side-by-side results.</span>
+      </div>
+      <div class="toggle" id="cmpToggle" role="switch" aria-checked="false"></div>
+    </div>
+
+    <!-- ACTIONS -->
+    <div class="actions">
+      <button class="run-big" id="runBtn">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+        Run
+        <span class="kbd">⌘↵</span>
+      </button>
+      <button class="ghost">Save as YAML</button>
+    </div>
+
   </div>
-</div>
+</main>
 
-<!-- STEP 2: RUNNING -->
-<div class="main hidden" id="step2">
-  <div style="text-align:center;padding:60px 0;">
+<!-- ====== VIEW 2 — RUNNING ====== -->
+<main class="view" id="view-running">
+  <div class="running">
     <div class="spinner"></div>
-    <h2 style="font-size:22px;margin-bottom:8px;">Running your benchmark…</h2>
-    <p style="color:var(--text-muted);font-size:14px;">Both engines are processing the same data with the same model.</p>
-    <ul class="progress-steps" id="progressSteps">
-      <li data-step="0"><span class="step-icon">○</span> Parsing input data</li>
-      <li data-step="1"><span class="step-icon">○</span> BricksEngine — composing blueprint</li>
-      <li data-step="2"><span class="step-icon">○</span> BricksEngine — executing pipeline</li>
-      <li data-step="3"><span class="step-icon">○</span> RawLLMEngine — sending prompt</li>
-      <li data-step="4"><span class="step-icon">○</span> Comparing results</li>
-    </ul>
+    <h2 id="runHeadline">Running your pipeline…</h2>
+    <p id="runSub">Bricks composing a blueprint, then executing deterministically.</p>
+    <ol class="steps" id="steps">
+      <li data-s="0"><span class="mark">1</span>Parsing input data</li>
+      <li data-s="1"><span class="mark">2</span>Bricks — composing blueprint</li>
+      <li data-s="2"><span class="mark">3</span>Bricks — executing pipeline</li>
+      <li data-s="3" class="hide-if-solo"><span class="mark">4</span>Raw LLM — sending full prompt</li>
+      <li data-s="4"><span class="mark">5</span>Checking outputs</li>
+    </ol>
   </div>
-</div>
+</main>
 
-<!-- STEP 3: RESULTS -->
-<div class="main hidden" id="step3">
+<!-- ====== VIEW 3 — RESULTS ====== -->
+<main class="view" id="view-results">
+  <div class="results">
 
-  <!-- Winner banner -->
-  <div id="winnerBanner" class="winner-banner">
-    <div class="winner-trophy" id="winnerTrophy">🏆</div>
-    <div class="winner-title" id="winnerTitle">BricksEngine wins</div>
-    <div class="winner-sub" id="winnerSub">100% accurate with 74% fewer tokens</div>
-    <div class="savings-big" id="savingsBig">3.9x more efficient</div>
-  </div>
-
-  <!-- Engine cards -->
-  <div class="engine-cards">
-    <div class="engine-card" id="bricksCard">
-      <h3>⚡ BricksEngine</h3>
-      <div class="method">YAML Blueprint → Deterministic execution</div>
-      <div class="engine-stat"><span class="stat-label">Tokens in</span><span class="stat-val" id="b-tokens-in">—</span></div>
-      <div class="engine-stat"><span class="stat-label">Tokens out</span><span class="stat-val" id="b-tokens-out">—</span></div>
-      <div class="engine-stat"><span class="stat-label">Duration</span><span class="stat-val" id="b-duration">—</span></div>
-      <div class="engine-stat"><span class="stat-label">Model</span><span class="stat-val" id="b-model">—</span></div>
-      <div class="engine-stat"><span class="stat-label">Error</span><span class="stat-val" id="b-error" style="color:var(--red);">—</span></div>
-      <span class="correct-badge na" id="b-correct-badge">N/A</span>
+    <div class="res-top">
+      <div>
+        <div class="eyebrow">Results</div>
+      </div>
+      <div style="font-family: var(--mono); font-size: 11px; color: var(--muted);">
+        run · 2026-04-20 · seed 42
+      </div>
     </div>
-    <div class="engine-card" id="llmCard">
-      <h3>🤖 RawLLMEngine</h3>
-      <div class="method">Full data in prompt → LLM computes everything</div>
-      <div class="engine-stat"><span class="stat-label">Tokens in</span><span class="stat-val" id="l-tokens-in">—</span></div>
-      <div class="engine-stat"><span class="stat-label">Tokens out</span><span class="stat-val" id="l-tokens-out">—</span></div>
-      <div class="engine-stat"><span class="stat-label">Duration</span><span class="stat-val" id="l-duration">—</span></div>
-      <div class="engine-stat"><span class="stat-label">Model</span><span class="stat-val" id="l-model">—</span></div>
-      <div class="engine-stat"><span class="stat-label">Error</span><span class="stat-val" id="l-error" style="color:var(--red);">—</span></div>
-      <span class="correct-badge na" id="l-correct-badge">N/A</span>
+
+    <!-- verdict -->
+    <div class="verdict">
+      <h2 id="verdictTitle">Bricks ran deterministically.</h2>
+      <div class="score-grid" id="scoreGrid">
+        <div class="scol win">
+          <div class="who"><i></i>Bricks</div>
+          <div class="num">3<span class="of">/3</span></div>
+          <div class="meta">100% · 2,400 tokens · $0.0012</div>
+        </div>
+      </div>
     </div>
-  </div>
 
-  <!-- What happened -->
-  <div class="card explain-card">
-    <h2>What Happened?</h2>
-    <div id="explainText" style="font-size:14px;line-height:1.7;margin-top:12px;"></div>
-  </div>
-
-  <!-- Token savings strip -->
-  <div class="savings-strip">
-    <div>
-      <div class="pct" id="savingsPct">—</div>
-      <div class="detail" id="savingsDetail">— vs — tokens</div>
+    <!-- metrics -->
+    <div class="metrics" id="metrics">
+      <div class="metric"><div class="k">Tokens</div><div class="v">2,400</div><div class="sub">composed once</div></div>
+      <div class="metric"><div class="k">Cost</div><div class="v">$0.0012</div><div class="sub">claude-haiku-4-5</div></div>
+      <div class="metric"><div class="k">Duration</div><div class="v">6.2s</div><div class="sub">wall clock</div></div>
     </div>
-    <div class="desc">Bricks used the LLM only for blueprint composition, not data processing. Raw LLM sent all your data in every prompt.</div>
-  </div>
 
-  <!-- Output comparison -->
-  <div class="card hidden" id="comparisonCard">
-    <h2>Output Comparison</h2>
-    <table class="comparison-table">
-      <thead><tr><th>Key</th><th>Expected</th><th>BricksEngine</th><th>RawLLMEngine</th></tr></thead>
-      <tbody id="comparisonBody"></tbody>
-    </table>
-  </div>
+    <!-- output comparison -->
+    <div class="res-sec">
+      <div class="res-sec-head">
+        <h3>Outputs</h3>
+        <span class="num">key · expected · got</span>
+      </div>
+      <table class="cmp" id="cmpTable">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Expected</th>
+            <th>Bricks</th>
+            <th class="raw-col" style="display:none;">Raw LLM</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>active_count</td>
+            <td class="exp">18</td>
+            <td class="pass">18</td>
+            <td class="raw-col fail" style="display:none;"><span class="s">17</span></td>
+          </tr>
+          <tr>
+            <td>total_active_revenue</td>
+            <td class="exp">3,447.50</td>
+            <td class="pass">3,447.50</td>
+            <td class="raw-col fail" style="display:none;"><span class="s">3,200.00</span></td>
+          </tr>
+          <tr>
+            <td>avg_active_revenue</td>
+            <td class="exp">191.53</td>
+            <td class="pass">191.53</td>
+            <td class="raw-col fail" style="display:none;"><span class="s">188.24</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
-  <!-- Blueprint -->
-  <div class="card" id="blueprintCard">
-    <h2>Generated Blueprint</h2>
-    <p style="font-size:13px;color:var(--text-muted);margin:8px 0 16px;">The YAML blueprint composed by BricksEngine — data was NOT sent to the LLM during execution.</p>
-    <div class="blueprint-block" id="blueprintBlock"></div>
-  </div>
+    <!-- details (collapsed) -->
+    <div class="res-sec">
+      <div class="res-sec-head">
+        <h3>Details</h3>
+        <span class="num">optional</span>
+      </div>
 
-  <!-- Footer actions -->
-  <div class="footer-actions">
-    <button class="btn btn-outline" id="newBenchmarkBtn">← New Benchmark</button>
-    <button class="btn btn-outline" id="exportBtn">Export Results</button>
-    <button class="btn btn-outline" id="runAgainBtn">Run Again with Different Data →</button>
+      <details class="drawer">
+        <summary>
+          <div class="drw-l">
+            <span class="drw-t">Blueprint</span>
+            <span class="drw-s">6 steps · YAML · reusable</span>
+          </div>
+          <svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+        </summary>
+        <pre class="yaml" id="yamlCode"></pre>
+      </details>
+
+      <details class="drawer">
+        <summary>
+          <div class="drw-l">
+            <span class="drw-t">Bricks used</span>
+            <span class="drw-s">5 unique · 6 calls · deterministic</span>
+          </div>
+          <svg class="chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+        </summary>
+        <div class="bricks-used">
+          <span class="brick-pill">extract_markdown_fences<em>str</em></span>
+          <span class="brick-pill">extract_json_from_str<em>str</em></span>
+          <span class="brick-pill">filter_dict_list<em>list</em></span>
+          <span class="brick-pill">count_dict_list<em>list</em></span>
+          <span class="brick-pill">calculate_aggregates<em>math</em><b class="pill-count">×2</b></span>
+        </div>
+      </details>
+    </div>
+
+    <div class="res-foot">
+      <span><b>model</b>claude-haiku-4-5</span>
+      <span><b>seed</b>42</span>
+      <span><b>version</b>0.4.26</span>
+    </div>
+
+    <div class="actions" style="justify-content:flex-start; margin-top:40px;">
+      <button class="run-big" id="backBtn">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+        New run
+      </button>
+      <button class="ghost" id="copyYamlBtn">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:6px; vertical-align:-2px;"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+        <span id="copyYamlLabel">Copy YAML</span>
+      </button>
+      <button class="ghost">Share results</button>
+    </div>
+
   </div>
-</div>
+</main>
 
 <script>
-// ── State ──────────────────────────────────────────────────────────────────
-const state = {
-  datasets: [],
-  bricks: [],
-  presets: [],
-  selectedDatasetId: null,
-  customData: null,
-  selectedBricks: new Set(),
-  selectedModel: 'claudecode',
-  lastResults: null,
-};
-
-const PLACEHOLDERS = {
-  'crm-customers': 'Example: Filter to active customers, count them, sum their monthly_revenue, compute average revenue…',
-  'support-tickets': 'Example: Find all high-priority open tickets, count them by category (billing, technical, general)…',
-  'orders-customers': 'Example: Join orders to customers, filter completed orders, sum revenue by customer plan type…',
-};
-
-// ── Step navigation ────────────────────────────────────────────────────────
-function showStep(n) {
-  document.getElementById('step1').classList.toggle('hidden', n !== 1);
-  document.getElementById('step2').classList.toggle('hidden', n !== 2);
-  document.getElementById('step3').classList.toggle('hidden', n !== 3);
-  [1, 2, 3].forEach(i => {
-    const dot = document.getElementById('dot' + i);
-    dot.className = 'step-dot' + (i === n ? ' active' : i < n ? ' done' : '');
-  });
-}
-
-// ── Load datasets ──────────────────────────────────────────────────────────
-async function loadDatasets() {
-  try {
-    const res = await fetch('/api/datasets');
-    state.datasets = await res.json();
-    renderDatasets();
-  } catch (e) {
-    document.getElementById('datasetGrid').innerHTML = '<div style="color:var(--red);font-size:13px;">Failed to load datasets</div>';
-  }
-}
-
-function renderDatasets() {
-  const grid = document.getElementById('datasetGrid');
-  grid.innerHTML = state.datasets.map(ds => `
-    <div class="dataset-card" data-id="${ds.id}" onclick="selectDataset('${ds.id}')">
-      <h3>${ds.name}</h3>
-      <div class="ds-desc">${ds.description}</div>
-      <div class="ds-meta">
-        <span class="ds-tag">${ds.row_count} rows</span>
-        ${ds.fields.slice(0, 3).map(f => `<span class="ds-tag">${f}</span>`).join('')}
-      </div>
-      <button class="ds-preview-btn" onclick="togglePreview(event,'${ds.id}')">Preview ▾</button>
-      <div class="ds-preview" id="preview-${ds.id}">
-        ${renderMiniTable(ds.preview)}
-      </div>
-    </div>
-  `).join('');
-}
-
-function renderMiniTable(rows) {
-  if (!rows || rows.length === 0) return '<em>No preview</em>';
-  const keys = Object.keys(rows[0]).slice(0, 5);
-  const thead = `<tr>${keys.map(k => `<th>${k}</th>`).join('')}</tr>`;
-  const tbody = rows.map(r => `<tr>${keys.map(k => `<td>${r[k] ?? ''}</td>`).join('')}</tr>`).join('');
-  return `<table class="mini-table"><thead>${thead}</thead><tbody>${tbody}</tbody></table>`;
-}
-
-function togglePreview(e, id) {
-  e.stopPropagation();
-  const el = document.getElementById('preview-' + id);
-  el.classList.toggle('open');
-  e.target.textContent = el.classList.contains('open') ? 'Preview ▴' : 'Preview ▾';
-}
-
-function selectDataset(id) {
-  state.selectedDatasetId = id;
-  state.customData = null;
-  document.querySelectorAll('.dataset-card').forEach(c => c.classList.remove('selected'));
-  document.querySelector(`.dataset-card[data-id="${id}"]`).classList.add('selected');
-  document.getElementById('customZone').classList.remove('selected');
-  document.getElementById('customDataInput').value = '';
-  document.getElementById('customZoneInput').classList.add('hidden');
-  document.getElementById('customZonePrompt').classList.remove('hidden');
-  updateTaskPlaceholder(id);
-}
-
-function updateTaskPlaceholder(id) {
-  const ph = PLACEHOLDERS[id] || 'Describe what you want to compute from this data…';
-  document.getElementById('taskInput').placeholder = ph;
-}
-
-// ── Custom data ────────────────────────────────────────────────────────────
-document.getElementById('customZone').addEventListener('click', function(e) {
-  if (e.target.closest('#customZoneInput')) return;
-  document.getElementById('customZoneInput').classList.remove('hidden');
-  document.getElementById('customZonePrompt').classList.add('hidden');
-});
-
-document.getElementById('customDataInput').addEventListener('input', function() {
-  const v = this.value.trim();
-  if (v) {
-    state.customData = v;
-    state.selectedDatasetId = null;
-    document.querySelectorAll('.dataset-card').forEach(c => c.classList.remove('selected'));
-    document.getElementById('customZone').classList.add('selected');
-    document.getElementById('taskInput').placeholder = 'Describe what you want to compute from this data…';
-  } else {
-    state.customData = null;
-    document.getElementById('customZone').classList.remove('selected');
-  }
-});
-
-// ── Load bricks ────────────────────────────────────────────────────────────
-async function loadBricks() {
-  try {
-    const res = await fetch('/api/bricks');
-    state.bricks = await res.json();
-    renderBrickChips();
-  } catch (e) { /* ignore */ }
-}
-
-function renderBrickChips() {
-  const container = document.getElementById('brickChips');
-  container.innerHTML = state.bricks.map(b => `
-    <div class="brick-chip" data-name="${b.name}" onclick="toggleBrick('${b.name}')" title="${b.description}">${b.name}</div>
-  `).join('');
-}
-
-function toggleBrick(name) {
-  if (state.selectedBricks.has(name)) {
-    state.selectedBricks.delete(name);
-  } else {
-    state.selectedBricks.add(name);
-  }
-  document.querySelector(`.brick-chip[data-name="${name}"]`).classList.toggle('selected', state.selectedBricks.has(name));
-}
-
-// ── Load presets ────────────────────────────────────────────────────────────
-async function loadPresets() {
-  try {
-    const res = await fetch('/api/presets');
-    state.presets = await res.json();
-    renderPresets();
-  } catch (e) { /* ignore */ }
-}
-
-function renderPresets() {
-  const sel = document.getElementById('presetSelect');
-  state.presets.forEach(p => {
-    const opt = document.createElement('option');
-    opt.value = p.name;
-    opt.textContent = p.name;
-    sel.appendChild(opt);
-  });
-}
-
-document.getElementById('presetSelect').addEventListener('change', function() {
-  const preset = state.presets.find(p => p.name === this.value);
-  if (!preset) return;
-  if (preset.dataset_id) selectDataset(preset.dataset_id);
-  if (preset.task_text) document.getElementById('taskInput').value = preset.task_text;
-  if (preset.expected_outputs) {
-    document.getElementById('settingsBody').classList.add('open');
-    document.getElementById('settingsArrow').textContent = '▼';
-    document.getElementById('expectedInput').value = JSON.stringify(preset.expected_outputs, null, 2);
-  }
-});
-
-// ── Model pills ─────────────────────────────────────────────────────────────
-document.getElementById('modelPills').addEventListener('click', function(e) {
-  const pill = e.target.closest('.model-pill');
-  if (!pill) return;
-  document.querySelectorAll('.model-pill').forEach(p => p.classList.remove('selected'));
-  pill.classList.add('selected');
-  state.selectedModel = pill.dataset.model;
-});
-
-// ── Settings toggle ──────────────────────────────────────────────────────────
-document.getElementById('settingsToggle').addEventListener('click', function() {
-  const body = document.getElementById('settingsBody');
-  const arrow = document.getElementById('settingsArrow');
-  body.classList.toggle('open');
-  arrow.textContent = body.classList.contains('open') ? '▼' : '▶';
-});
-
-// ── Clear ────────────────────────────────────────────────────────────────────
-document.getElementById('clearBtn').addEventListener('click', function() {
-  state.selectedDatasetId = null;
-  state.customData = null;
-  state.selectedBricks.clear();
-  document.querySelectorAll('.dataset-card').forEach(c => c.classList.remove('selected'));
-  document.getElementById('customZone').classList.remove('selected');
-  document.getElementById('customDataInput').value = '';
-  document.getElementById('customZoneInput').classList.add('hidden');
-  document.getElementById('customZonePrompt').classList.remove('hidden');
-  document.getElementById('taskInput').value = '';
-  document.getElementById('expectedInput').value = '';
-  document.getElementById('presetSelect').value = '';
-  document.querySelectorAll('.brick-chip').forEach(c => c.classList.remove('selected'));
-  document.getElementById('setupError').classList.add('hidden');
-  document.getElementById('taskInput').placeholder = 'Describe what you want to compute from the data…';
-});
-
-// ── Save as YAML (stub) ──────────────────────────────────────────────────────
-document.getElementById('saveYamlBtn').addEventListener('click', function() {
-  alert('Save as YAML will be available in a future update (Mission 068).');
-});
-
-// ── Run benchmark ────────────────────────────────────────────────────────────
-document.getElementById('runBtn').addEventListener('click', runBenchmark);
-
-async function runBenchmark() {
-  const errEl = document.getElementById('setupError');
-  errEl.classList.add('hidden');
-
-  const taskText = document.getElementById('taskInput').value.trim();
-  if (!taskText) {
-    errEl.textContent = 'Please describe your task.';
-    errEl.classList.remove('hidden');
-    return;
-  }
-
-  let rawData = '';
-  if (state.selectedDatasetId) {
-    const ds = state.datasets.find(d => d.id === state.selectedDatasetId);
-    rawData = ds ? ds.full_data : '';
-  } else if (state.customData) {
-    rawData = state.customData;
-  } else {
-    errEl.textContent = 'Please select a dataset or paste your own data.';
-    errEl.classList.remove('hidden');
-    return;
-  }
-
-  let expectedOutputs = null;
-  const expRaw = document.getElementById('expectedInput').value.trim();
-  if (expRaw) {
-    try { expectedOutputs = JSON.parse(expRaw); }
-    catch { expectedOutputs = null; }
-  }
-
-  const requiredBricks = state.selectedBricks.size > 0 ? [...state.selectedBricks] : null;
-
-  showStep(2);
-  animateProgress();
-
-  const body = {
-    task_text: taskText,
-    raw_data: rawData,
-    expected_outputs: expectedOutputs,
-    required_bricks: requiredBricks,
-    model: state.selectedModel,
+  // ---- sample customers (hardcoded) ----
+  const customers = {
+    customers: [
+      { id: 1,  name: "Acme Corp",         status: "active",   monthly_revenue: 245.00, plan: "pro" },
+      { id: 2,  name: "Globex Ltd",        status: "active",   monthly_revenue: 189.50, plan: "pro" },
+      { id: 3,  name: "Initech",           status: "inactive", monthly_revenue: 0,      plan: "free" },
+      { id: 4,  name: "Umbrella Inc",      status: "active",   monthly_revenue: 312.00, plan: "enterprise" },
+      { id: 5,  name: "Soylent Co",        status: "active",   monthly_revenue: 145.75, plan: "pro" },
+      { id: 6,  name: "Stark Industries",  status: "active",   monthly_revenue: 498.00, plan: "enterprise" },
+      { id: 7,  name: "Wayne Enterprises", status: "active",   monthly_revenue: 421.25, plan: "enterprise" },
+      { id: 8,  name: "Oscorp",            status: "inactive", monthly_revenue: 0,      plan: "free" },
+      { id: 9,  name: "Tyrell Corp",       status: "active",   monthly_revenue: 158.00, plan: "pro" },
+      { id: 10, name: "Cyberdyne Sys",     status: "active",   monthly_revenue: 267.50, plan: "pro" }
+    ]
   };
 
-  try {
-    const res = await fetch('/api/run', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-    if (!res.ok) {
-      const err = await res.json();
-      throw new Error(err.detail || 'Server error');
-    }
-    const results = await res.json();
-    state.lastResults = results;
-    completeProgress(results);
-  } catch (e) {
-    showStep(1);
-    errEl.textContent = 'Benchmark failed: ' + e.message;
-    errEl.classList.remove('hidden');
+  function esc(s){ return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+  function hlJson(obj){
+    const s = JSON.stringify(obj, null, 2);
+    return esc(s)
+      .replace(/"([^"\\]*)"(\s*:)/g, '<span class="j-key">"$1"</span>$2')
+      .replace(/:\s*"([^"\\]*)"/g, ': <span class="j-str">"$1"</span>')
+      .replace(/:\s*(-?\d+(?:\.\d+)?)/g, ': <span class="j-num">$1</span>')
+      .replace(/:\s*(true|false)/g, ': <span class="j-bool">$1</span>')
+      .replace(/:\s*null/g, ': <span class="j-null">null</span>');
   }
-}
+  document.getElementById('dataBody').innerHTML = hlJson(customers);
 
-// ── Progress animation ──────────────────────────────────────────────────────
-let progressTimer = null;
-function animateProgress() {
-  const steps = document.querySelectorAll('#progressSteps li');
-  steps.forEach(s => {
-    s.className = '';
-    s.querySelector('.step-icon').textContent = '○';
+  // ---- yaml highlight ----
+  const yamlRaw = `name: parse_and_analyze_customers
+inputs:
+  raw_api_response: ""
+steps:
+  - name: extract_json
+    brick: extract_markdown_fences
+    params:
+      text: "\${inputs.raw_api_response}"
+    save_as: json_fenced
+  - name: parse_json
+    brick: extract_json_from_str
+    params:
+      text: "\${json_fenced.result}"
+    save_as: parsed_data
+  - name: filter_active
+    brick: filter_dict_list
+    params:
+      items: "\${parsed_data.data.customers}"
+      key: "status"
+      value: "active"
+    save_as: active_customers
+  - name: active_count
+    brick: count_dict_list
+    params:
+      items: "\${active_customers.result}"
+    save_as: count_result
+  - name: total_active_revenue
+    brick: calculate_aggregates
+    params:
+      items: "\${active_customers.result}"
+      field: "monthly_revenue"
+      operation: "sum"
+    save_as: total_revenue
+  - name: avg_active_revenue
+    brick: calculate_aggregates
+    params:
+      items: "\${active_customers.result}"
+      field: "monthly_revenue"
+      operation: "avg"
+    save_as: avg_revenue
+outputs_map:
+  active_count: "\${count_result.result}"
+  total_active_revenue: "\${total_revenue.result}"
+  avg_active_revenue: "\${avg_revenue.result}"`;
+
+  function hlYaml(src){
+    return src.split('\n').map(line => {
+      const m = line.match(/^(\s*)(- )?([A-Za-z_][A-Za-z0-9_]*)(:)(\s*)(.*)$/);
+      if (!m) return esc(line);
+      const [, ind, dash, key, colon, sp, val] = m;
+      let v = '';
+      if (val === '') v = '';
+      else if (val.startsWith('"') && val.endsWith('"')) {
+        const inner = esc(val.slice(1,-1)).replace(/\$\{[^}]+\}/g, x=>`<span class="y-ref">${x}</span>`);
+        v = `<span class="y-str">"${inner}"</span>`;
+      } else if (/^-?\d+(\.\d+)?$/.test(val)) v = `<span class="y-num">${esc(val)}</span>`;
+      else v = esc(val);
+      const d = dash ? `<span class="y-dash">- </span>` : '';
+      return `${ind}${d}<span class="y-key">${esc(key)}</span><span class="y-dash">${colon}</span>${sp}${v}`;
+    }).join('\n');
+  }
+  document.getElementById('yamlCode').innerHTML = hlYaml(yamlRaw);
+
+  // ---- view switching ----
+  function showView(id) {
+    document.querySelectorAll('.view').forEach(v => v.classList.remove('on'));
+    document.getElementById(id).classList.add('on');
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  }
+
+  // ---- compare toggle ----
+  const toggle = document.getElementById('cmpToggle');
+  let compareOn = false;
+  toggle.addEventListener('click', () => {
+    compareOn = !compareOn;
+    window.compareOn = compareOn;
+    toggle.classList.toggle('on', compareOn);
+    toggle.setAttribute('aria-checked', String(compareOn));
   });
-  let i = 0;
-  function tick() {
-    if (i < steps.length) {
+
+  // ---- run flow ----
+  const runBtn = document.getElementById('runBtn');
+  const steps = document.querySelectorAll('#steps li');
+  const runHeadline = document.getElementById('runHeadline');
+  const runSub = document.getElementById('runSub');
+
+  runBtn.addEventListener('click', startRun);
+  document.addEventListener('keydown', e => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') startRun();
+  });
+
+  function startRun() {
+    // configure steps
+    const rawStep = document.querySelector('#steps li[data-s="3"]');
+    rawStep.style.display = compareOn ? '' : 'none';
+    steps.forEach(s => s.classList.remove('active', 'done'));
+    runHeadline.textContent = compareOn ? 'Running both pipelines…' : 'Running your pipeline…';
+    runSub.textContent = compareOn
+      ? 'Bricks composing + executing, raw LLM doing it in one shot.'
+      : 'Bricks composing a blueprint, then executing deterministically.';
+
+    showView('view-running');
+
+    const sequence = compareOn ? [0, 1, 2, 3, 4] : [0, 1, 2, 4];
+    let i = 0;
+    const tick = () => {
       if (i > 0) {
-        steps[i - 1].className = 'done';
-        steps[i - 1].querySelector('.step-icon').textContent = '✅';
+        const prev = document.querySelector(`#steps li[data-s="${sequence[i-1]}"]`);
+        prev.classList.remove('active'); prev.classList.add('done');
       }
-      steps[i].className = 'active';
-      steps[i].querySelector('.step-icon').textContent = '⏳';
-      i++;
-      progressTimer = setTimeout(tick, 200);
-    }
+      if (i < sequence.length) {
+        const cur = document.querySelector(`#steps li[data-s="${sequence[i]}"]`);
+        cur.classList.add('active');
+        i++;
+        setTimeout(tick, 520 + Math.random() * 300);
+      } else {
+        setTimeout(showResults, 450);
+      }
+    };
+    tick();
   }
-  tick();
-}
 
-function completeProgress(results) {
-  clearTimeout(progressTimer);
-  const steps = document.querySelectorAll('#progressSteps li');
-  steps.forEach(s => {
-    s.className = 'done';
-    s.querySelector('.step-icon').textContent = '✅';
+  // ---- results ----
+  function showResults() {
+    const verdictTitle = document.getElementById('verdictTitle');
+    const scoreGrid = document.getElementById('scoreGrid');
+    const metrics = document.getElementById('metrics');
+    const cmpTable = document.getElementById('cmpTable');
+
+    if (compareOn) {
+      verdictTitle.innerHTML = 'Bricks beat raw LLM';
+      scoreGrid.className = 'score-grid dual';
+      scoreGrid.innerHTML = `
+        <div class="scol win">
+          <div class="who"><i></i>Bricks</div>
+          <div class="num">3<span class="of">/3</span></div>
+          <div class="meta">deterministic · 2,400 tok · $0.0012</div>
+        </div>
+        <div class="scol loss">
+          <div class="who"><i></i>Raw LLM</div>
+          <div class="num">0<span class="of">/3</span></div>
+          <div class="meta">drifted · 9,730 tok · $0.0049</div>
+        </div>`;
+      metrics.className = 'metrics dual';
+      metrics.innerHTML = `
+        <div class="metric"><div class="k">Accuracy</div><div class="v">+100%</div><div class="sub">vs raw LLM</div></div>
+        <div class="metric"><div class="k">Tokens</div><div class="v">4× less</div><div class="sub">2,400 vs 9,730</div></div>
+        <div class="metric"><div class="k">Cost</div><div class="v">−75%</div><div class="sub">$0.0012 vs $0.0049</div></div>
+        <div class="metric"><div class="k">Duration</div><div class="v">6.2s</div><div class="sub">vs 4.9s</div></div>`;
+      cmpTable.querySelectorAll('.raw-col').forEach(el => el.style.display = '');
+    } else {
+      verdictTitle.innerHTML = 'Bricks ran deterministically.';
+      scoreGrid.className = 'score-grid';
+      scoreGrid.innerHTML = `
+        <div class="scol win">
+          <div class="who"><i></i>Bricks</div>
+          <div class="num">3<span class="of">/3</span></div>
+          <div class="meta">100% · 2,400 tokens · $0.0012</div>
+        </div>`;
+      metrics.className = 'metrics';
+      metrics.innerHTML = `
+        <div class="metric"><div class="k">Tokens</div><div class="v">2,400</div><div class="sub">composed once</div></div>
+        <div class="metric"><div class="k">Cost</div><div class="v">$0.0012</div><div class="sub">claude-haiku-4-5</div></div>
+        <div class="metric"><div class="k">Duration</div><div class="v">6.2s</div><div class="sub">wall clock</div></div>`;
+      cmpTable.querySelectorAll('.raw-col').forEach(el => el.style.display = 'none');
+    }
+
+    if (typeof applyTweaks === 'function') applyTweaks();
+    showView('view-results');
+  }
+
+  // ---- back ----
+  document.getElementById('backBtn').addEventListener('click', () => showView('view-setup'));
+
+  // ---- drag & drop ----
+  const dz = document.getElementById('dropzone');
+  ['dragenter','dragover'].forEach(ev => dz.addEventListener(ev, e => {
+    e.preventDefault(); dz.classList.add('drag');
+  }));
+  ['dragleave','drop'].forEach(ev => dz.addEventListener(ev, e => {
+    e.preventDefault(); dz.classList.remove('drag');
+  }));
+
+  // ---- copy yaml ----
+  const copyYamlBtn = document.getElementById('copyYamlBtn');
+  if (copyYamlBtn) {
+    const label = document.getElementById('copyYamlLabel');
+    copyYamlBtn.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(yamlRaw);
+        label.textContent = 'Copied ✓';
+        setTimeout(() => { label.textContent = 'Copy YAML'; }, 1600);
+      } catch (err) {
+        label.textContent = 'Copy failed';
+        setTimeout(() => { label.textContent = 'Copy YAML'; }, 1600);
+      }
+    });
+  }
+
+  /* ================= TWEAKS ================= */
+  const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+    "verdictFont": "Instrument Serif",
+    "verdictSize": 36,
+    "verdictItalicEm": false,
+    "verdictDot": true,
+    "verdictCopy": "Bricks ran deterministically."
+  }/*EDITMODE-END*/;
+
+  const FONT_PRESETS = {
+    "Inter Semibold":    { family: "'Inter', sans-serif",             weight: 600, tracking: "-0.02em", lh: 1.18 },
+    "Inter Bold":        { family: "'Inter', sans-serif",             weight: 700, tracking: "-0.025em", lh: 1.15 },
+    "Space Grotesk":     { family: "'Space Grotesk', sans-serif",     weight: 600, tracking: "-0.02em", lh: 1.15 },
+    "Fraunces":          { family: "'Fraunces', serif",               weight: 500, tracking: "-0.015em", lh: 1.12 },
+    "Playfair Display":  { family: "'Playfair Display', serif",       weight: 600, tracking: "-0.01em",  lh: 1.12 },
+    "Instrument Serif":  { family: "'Instrument Serif', serif",       weight: 400, tracking: "-0.01em",  lh: 1.1  },
+    "JetBrains Mono":    { family: "'JetBrains Mono', monospace",     weight: 500, tracking: "-0.02em",  lh: 1.2  },
+  };
+
+  const state = { ...TWEAK_DEFAULTS };
+
+  function applyTweaks(){
+    const preset = FONT_PRESETS[state.verdictFont] || FONT_PRESETS["Inter Semibold"];
+    const root = document.documentElement.style;
+    root.setProperty('--verdict-font', preset.family);
+    root.setProperty('--verdict-weight', preset.weight);
+    root.setProperty('--verdict-size', state.verdictSize + 'px');
+    root.setProperty('--verdict-tracking', preset.tracking);
+    root.setProperty('--verdict-lh', preset.lh);
+    root.setProperty('--verdict-em-style', state.verdictItalicEm ? 'italic' : 'normal');
+    root.setProperty('--verdict-em-weight', state.verdictItalicEm ? '400' : 'inherit');
+
+    // re-render verdict copy (non-compare view only)
+    const el = document.getElementById('verdictTitle');
+    if (el && !window.compareOn) {
+      const html = (state.verdictCopy || '')
+        .replace(/\{em\}/g, '<em>')
+        .replace(/\{\/em\}/g, '</em>');
+      el.innerHTML = html;
+    }
+    if (el) el.classList.toggle('with-dot', !!state.verdictDot);
+  }
+
+  function persist(patch){
+    Object.assign(state, patch);
+    applyTweaks();
+    try { window.parent.postMessage({ type: '__edit_mode_set_keys', edits: patch }, '*'); } catch(e){}
+  }
+
+  // ---- tweaks panel DOM ----
+  const tweaks = document.createElement('div');
+  tweaks.id = 'tweaks-panel';
+  tweaks.style.cssText = `
+    position: fixed; right: 20px; bottom: 20px;
+    width: 280px; background: #fff;
+    border: 1px solid var(--rule-2); border-radius: 14px;
+    box-shadow: 0 12px 40px rgba(28,26,22,.14), 0 2px 6px rgba(28,26,22,.06);
+    padding: 18px 18px 16px; z-index: 9999;
+    font-family: var(--sans); color: var(--ink);
+    display: none;
+  `;
+  tweaks.innerHTML = `
+    <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:14px;">
+      <div style="font-family:var(--mono); font-size:10.5px; letter-spacing:.12em; text-transform:uppercase; color:var(--muted);">Tweaks</div>
+      <button id="tw-close" style="background:none; border:none; color:var(--muted); cursor:pointer; padding:2px 6px; font-size:16px; line-height:1;">×</button>
+    </div>
+
+    <div style="font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; margin-bottom:6px;">Verdict font</div>
+    <select id="tw-font" style="width:100%; padding:8px 10px; border:1px solid var(--rule-2); border-radius:8px; background:var(--paper); margin-bottom:14px; font-size:13px;"></select>
+
+    <div style="font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; margin-bottom:6px; display:flex; justify-content:space-between;">
+      <span>Size</span><span id="tw-size-val" style="font-family:var(--mono); text-transform:none; letter-spacing:0;"></span>
+    </div>
+    <input type="range" id="tw-size" min="20" max="56" step="1" style="width:100%; margin-bottom:14px; accent-color:var(--accent);">
+
+    <label style="display:flex; align-items:center; gap:8px; font-size:13px; margin-bottom:10px; cursor:pointer;">
+      <input type="checkbox" id="tw-italic" style="accent-color:var(--accent);">
+      Italicize accent phrase
+    </label>
+    <label style="display:flex; align-items:center; gap:8px; font-size:13px; margin-bottom:14px; cursor:pointer;">
+      <input type="checkbox" id="tw-dot" style="accent-color:var(--accent);">
+      Leading status dot
+    </label>
+
+    <div style="font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; margin-bottom:6px;">Copy <span style="text-transform:none; letter-spacing:0; color:var(--faint);">— wrap accent in {em}…{/em}</span></div>
+    <textarea id="tw-copy" rows="3" style="width:100%; padding:8px 10px; border:1px solid var(--rule-2); border-radius:8px; font-family:var(--sans); font-size:12.5px; resize:vertical; background:var(--paper);"></textarea>
+  `;
+  document.body.appendChild(tweaks);
+
+  // populate font dropdown
+  const fontSel = tweaks.querySelector('#tw-font');
+  Object.keys(FONT_PRESETS).forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name; opt.textContent = name;
+    fontSel.appendChild(opt);
   });
-  setTimeout(() => renderResults(results), 300);
-}
 
-// ── Render results ──────────────────────────────────────────────────────────
-function renderResults(r) {
-  const b = r.bricks_result;
-  const l = r.llm_result;
-  const hasExpected = b.correct !== null;
-
-  // Winner banner
-  const banner = document.getElementById('winnerBanner');
-  const trophy = document.getElementById('winnerTrophy');
-  const title = document.getElementById('winnerTitle');
-  const sub = document.getElementById('winnerSub');
-  const big = document.getElementById('savingsBig');
-
-  if (!hasExpected) {
-    banner.className = 'winner-banner no-expected';
-    trophy.textContent = '📊';
-    title.textContent = 'Both engines completed';
-    sub.textContent = 'No expected outputs provided — run again with expected values to check accuracy.';
-    big.textContent = r.savings_ratio.toFixed(1) + 'x token ratio';
-  } else if (b.correct && !l.correct) {
-    banner.className = 'winner-banner';
-    trophy.textContent = '🏆';
-    title.textContent = 'BricksEngine wins';
-    sub.textContent = `100% accurate with ${r.savings_percent.toFixed(0)}% fewer tokens`;
-    big.textContent = r.savings_ratio.toFixed(1) + 'x more efficient';
-  } else if (!b.correct && l.correct) {
-    banner.className = 'winner-banner tie';
-    trophy.textContent = '🤖';
-    title.textContent = 'RawLLMEngine wins this round';
-    sub.textContent = 'LLM got the correct answer; Bricks composition may need refinement.';
-    big.textContent = r.savings_ratio.toFixed(1) + 'x token ratio';
-  } else if (b.correct && l.correct) {
-    banner.className = 'winner-banner tie';
-    trophy.textContent = '🤝';
-    title.textContent = 'Tie — both correct';
-    sub.textContent = `Bricks used ${r.savings_percent.toFixed(0)}% fewer tokens for the same result`;
-    big.textContent = r.savings_ratio.toFixed(1) + 'x more efficient';
-  } else {
-    banner.className = 'winner-banner no-expected';
-    trophy.textContent = '⚠️';
-    title.textContent = 'Neither engine got it right';
-    sub.textContent = 'Both engines returned incorrect outputs. Consider refining the task.';
-    big.textContent = r.savings_ratio.toFixed(1) + 'x token ratio';
+  function syncTweakUI(){
+    fontSel.value = state.verdictFont;
+    tweaks.querySelector('#tw-size').value = state.verdictSize;
+    tweaks.querySelector('#tw-size-val').textContent = state.verdictSize + 'px';
+    tweaks.querySelector('#tw-italic').checked = !!state.verdictItalicEm;
+    tweaks.querySelector('#tw-dot').checked = !!state.verdictDot;
+    tweaks.querySelector('#tw-copy').value = state.verdictCopy;
   }
 
-  // Engine cards
-  const bCard = document.getElementById('bricksCard');
-  const lCard = document.getElementById('llmCard');
-  bCard.className = 'engine-card' + (hasExpected ? (b.correct ? ' correct' : ' wrong') : '');
-  lCard.className = 'engine-card' + (hasExpected ? (l.correct ? ' correct' : ' wrong') : '');
+  fontSel.addEventListener('change', e => persist({ verdictFont: e.target.value }));
+  tweaks.querySelector('#tw-size').addEventListener('input', e => {
+    tweaks.querySelector('#tw-size-val').textContent = e.target.value + 'px';
+    persist({ verdictSize: parseInt(e.target.value, 10) });
+  });
+  tweaks.querySelector('#tw-italic').addEventListener('change', e => persist({ verdictItalicEm: e.target.checked }));
+  tweaks.querySelector('#tw-dot').addEventListener('change', e => persist({ verdictDot: e.target.checked }));
+  tweaks.querySelector('#tw-copy').addEventListener('input', e => persist({ verdictCopy: e.target.value }));
+  tweaks.querySelector('#tw-close').addEventListener('click', () => { tweaks.style.display = 'none'; });
 
-  document.getElementById('b-tokens-in').textContent = b.tokens_in.toLocaleString();
-  document.getElementById('b-tokens-out').textContent = b.tokens_out.toLocaleString();
-  document.getElementById('b-duration').textContent = b.duration_seconds.toFixed(1) + 's';
-  document.getElementById('b-model').textContent = b.model || '—';
-  document.getElementById('b-error').textContent = b.error || 'none';
-  document.getElementById('l-tokens-in').textContent = l.tokens_in.toLocaleString();
-  document.getElementById('l-tokens-out').textContent = l.tokens_out.toLocaleString();
-  document.getElementById('l-duration').textContent = l.duration_seconds.toFixed(1) + 's';
-  document.getElementById('l-model').textContent = l.model || '—';
-  document.getElementById('l-error').textContent = l.error || 'none';
+  // host protocol
+  window.addEventListener('message', ev => {
+    const d = ev.data || {};
+    if (d.type === '__activate_edit_mode') { syncTweakUI(); tweaks.style.display = 'block'; }
+    if (d.type === '__deactivate_edit_mode') { tweaks.style.display = 'none'; }
+  });
+  try { window.parent.postMessage({ type: '__edit_mode_available' }, '*'); } catch(e){}
 
-  const bBadge = document.getElementById('b-correct-badge');
-  const lBadge = document.getElementById('l-correct-badge');
-  if (!hasExpected) {
-    bBadge.className = 'correct-badge na'; bBadge.textContent = 'N/A';
-    lBadge.className = 'correct-badge na'; lBadge.textContent = 'N/A';
-  } else {
-    bBadge.className = 'correct-badge ' + (b.correct ? 'yes' : 'no');
-    bBadge.textContent = b.correct ? '✓ Correct' : '✗ Wrong';
-    lBadge.className = 'correct-badge ' + (l.correct ? 'yes' : 'no');
-    lBadge.textContent = l.correct ? '✓ Correct' : '✗ Wrong';
-  }
-
-  // Explain
-  const bricks_tok = b.tokens_in + b.tokens_out;
-  const llm_tok = l.tokens_in + l.tokens_out;
-  const explainEl = document.getElementById('explainText');
-  let explain = `<p><strong>BricksEngine</strong> composed a YAML blueprint from your task description — the LLM only saw brick function signatures, <em>not</em> your data. The blueprint was then executed deterministically. `;
-  if (b.error) explain += `<span style="color:var(--red)">It failed with: ${b.error}</span>`;
-  else explain += `It used <strong>${bricks_tok.toLocaleString()} tokens</strong> total.`;
-  explain += `</p><br>`;
-  explain += `<p><strong>RawLLMEngine</strong> sent your <em>entire dataset</em> directly in the prompt and asked the LLM to compute the answer. `;
-  if (l.error) explain += `<span style="color:var(--red)">It failed with: ${l.error}</span>`;
-  else if (!l.correct && hasExpected) explain += `It used <strong>${llm_tok.toLocaleString()} tokens</strong> but returned incorrect values. LLMs often struggle with precise filtering and aggregation over structured data.`;
-  else explain += `It used <strong>${llm_tok.toLocaleString()} tokens</strong>.`;
-  explain += `</p>`;
-  explainEl.innerHTML = explain;
-
-  // Savings strip
-  document.getElementById('savingsPct').textContent = r.savings_percent.toFixed(0) + '% savings';
-  document.getElementById('savingsDetail').textContent = `${bricks_tok.toLocaleString()} vs ${llm_tok.toLocaleString()} tokens`;
-
-  // Comparison table
-  const compCard = document.getElementById('comparisonCard');
-  if (hasExpected && b.correct !== null) {
-    const expected = JSON.parse(document.getElementById('expectedInput').value || '{}');
-    const keys = Object.keys(expected);
-    if (keys.length > 0) {
-      compCard.classList.remove('hidden');
-      const tbody = document.getElementById('comparisonBody');
-      tbody.innerHTML = keys.map(k => {
-        const exp = expected[k];
-        const bv = b.outputs[k];
-        const lv = l.outputs[k];
-        const bMatch = bv !== undefined && Math.abs(Number(bv) - Number(exp)) < 0.01;
-        const lMatch = lv !== undefined && Math.abs(Number(lv) - Number(exp)) < 0.01;
-        return `<tr>
-          <td>${k}</td>
-          <td>${exp}</td>
-          <td class="${bMatch ? 'match' : 'mismatch'}">${bv !== undefined ? bv : '—'} ${bMatch ? '✓' : '✗'}</td>
-          <td class="${lMatch ? 'match' : 'mismatch'}">${lv !== undefined ? lv : '—'} ${lMatch ? '✓' : '✗'}</td>
-        </tr>`;
-      }).join('');
-    }
-  } else {
-    compCard.classList.add('hidden');
-  }
-
-  // Blueprint
-  const blueprintEl = document.getElementById('blueprintBlock');
-  const blueprintCard = document.getElementById('blueprintCard');
-  if (b.raw_response) {
-    blueprintCard.classList.remove('hidden');
-    blueprintEl.innerHTML = highlightYaml(escapeHtml(b.raw_response));
-  } else {
-    blueprintCard.classList.add('hidden');
-  }
-
-  showStep(3);
-}
-
-function escapeHtml(s) {
-  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-}
-
-function highlightYaml(s) {
-  return s.split('\n').map(line => {
-    if (line.trim().startsWith('#')) return `<span class="yaml-comment">${line}</span>`;
-    const colonIdx = line.indexOf(':');
-    if (colonIdx > 0) {
-      const key = line.slice(0, colonIdx + 1);
-      const val = line.slice(colonIdx + 1);
-      return `<span class="yaml-key">${key}</span><span class="yaml-val">${val}</span>`;
-    }
-    return line;
-  }).join('\n');
-}
-
-// ── Footer actions ────────────────────────────────────────────────────────────
-document.getElementById('newBenchmarkBtn').addEventListener('click', function() {
-  document.getElementById('clearBtn').click();
-  showStep(1);
-});
-
-document.getElementById('runAgainBtn').addEventListener('click', function() {
-  state.selectedDatasetId = null;
-  state.customData = null;
-  document.querySelectorAll('.dataset-card').forEach(c => c.classList.remove('selected'));
-  document.getElementById('customZone').classList.remove('selected');
-  document.getElementById('customDataInput').value = '';
-  document.getElementById('customZoneInput').classList.add('hidden');
-  document.getElementById('customZonePrompt').classList.remove('hidden');
-  showStep(1);
-});
-
-document.getElementById('exportBtn').addEventListener('click', function() {
-  if (!state.lastResults) return;
-  const blob = new Blob([JSON.stringify(state.lastResults, null, 2)], { type: 'application/json' });
-  const a = document.createElement('a');
-  a.href = URL.createObjectURL(blob);
-  a.download = 'benchmark_results.json';
-  a.click();
-  URL.revokeObjectURL(a.href);
-});
-
-// ── Init ──────────────────────────────────────────────────────────────────────
-loadDatasets();
-loadBricks();
-loadPresets();
+  // initial paint
+  applyTweaks();
 </script>
 </body>
 </html>

--- a/tests/playground/test_static_html.py
+++ b/tests/playground/test_static_html.py
@@ -1,0 +1,35 @@
+"""Snapshot-ish checks for the v2 Playground frontend drop-in."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_INDEX = Path(__file__).resolve().parents[2] / "src" / "bricks" / "playground" / "web" / "static" / "index.html"
+
+
+def test_index_html_exists() -> None:
+    """The v2 mockup must be copied into the web static dir."""
+    assert _INDEX.is_file(), f"expected {_INDEX} to exist"
+
+
+def test_index_html_has_title() -> None:
+    """The Playground page keeps its <title>."""
+    html = _INDEX.read_text(encoding="utf-8")
+    assert "<title>Bricks Playground</title>" in html
+
+
+def test_font_link_keeps_only_allowed_families() -> None:
+    """Google Fonts <link> should import only Inter, Instrument Serif, JetBrains Mono."""
+    html = _INDEX.read_text(encoding="utf-8")
+    link_start = html.find('<link href="https://fonts.googleapis.com/css2?')
+    assert link_start != -1, "missing Google Fonts <link>"
+    link_end = html.find(">", link_start)
+    link = html[link_start : link_end + 1]
+
+    # Allowed families — all three must be present.
+    for family in ("Instrument+Serif", "Inter", "JetBrains+Mono"):
+        assert family in link, f"expected {family} in font link"
+
+    # Stripped families — none may appear in the <link> tag.
+    for family in ("Fraunces", "Space+Grotesk", "Playfair+Display"):
+        assert family not in link, f"{family} should have been stripped from the font link"


### PR DESCRIPTION
Closes #42. Second PR of the Playground v0.5.0 stack (#41 merged ✓).

## Summary
- Copy [docs/playground/mockup_v2.html](docs/playground/mockup_v2.html) → `src/bricks/playground/web/static/index.html` (1,291 lines)
- Strip unused Google Fonts families from the `<link>` tag: `Fraunces`, `Space+Grotesk`, `Playfair+Display`. Keep `Inter`, `Instrument+Serif`, `JetBrains+Mono`.
- Add `tests/playground/test_static_html.py` — three snapshot-ish checks that `index.html` exists, keeps its `<title>`, and that the font link only imports the allowed families.

## Left in place (per issue)
- Hardcoded mock JS data (`customers`, scenario list, run flow). Wired to real endpoints in #43.
- Three stripped font names still appear in the internal `FONT_PRESETS` dev-only font-preview table; picking them falls back to system fonts. Sweep optional in #46.

## Test plan
- [x] `pytest tests/playground -v` — 3/3 pass
- [x] Full suite: `pytest` green locally
- [x] `ruff check` + `ruff format --check` + `mypy src` clean
- [x] `cog --check README.md` clean
- [ ] CI matrix green on 3.10 / 3.11 / 3.12 + lint + links

🤖 Generated with [Claude Code](https://claude.com/claude-code)