### PR TITLE
feat(playground): /playground endpoints + real frontend fetches (#43)

### DIFF
--- a/src/bricks/playground/web/routes.py
+++ b/src/bricks/playground/web/routes.py
@@ -1,186 +1,263 @@
-"""API route handlers for the Bricks Benchmark web server."""
+"""API route handlers for the Bricks Playground web server.
+
+All routes live under the ``/playground`` prefix per design.md §6.
+"""
 
 from __future__ import annotations
 
+import csv
+import io
+import json
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+import yaml  # type: ignore[import-untyped]
+from fastapi import APIRouter, File, HTTPException, UploadFile
 
-from bricks.playground.web.datasets import DatasetLoader
-from bricks.playground.web.schemas import BenchmarkRequest, BenchmarkResponse, EngineResultResponse
+from bricks import __version__ as _bricks_version
+from bricks.llm.base import LLMProvider
+from bricks.playground.web.schemas import (
+    EngineResult,
+    RunMetadata,
+    RunRequest,
+    RunResponse,
+    ScenarioDetail,
+    ScenarioSummary,
+    TokenBreakdown,
+    UploadResponse,
+)
 
-router = APIRouter()
+router = APIRouter(prefix="/playground")
 
-_loader = DatasetLoader()
 _PRESETS_DIR = Path(__file__).parent / "presets"
-
-_CLAUDECODE_MODEL = "claudecode"
-
-
-def _build_provider(model: str) -> Any:
-    """Return an LLMProvider for the given model string.
-
-    ``'claudecode'`` routes through ClaudeCodeProvider. Any other string is
-    passed to LiteLLMProvider.
-
-    Args:
-        model: Model string — ``'claudecode'`` or a LiteLLM model string.
-
-    Returns:
-        An LLMProvider instance.
-    """
-    if model == _CLAUDECODE_MODEL:
-        from bricks.providers.claudecode import ClaudeCodeProvider
-
-        return ClaudeCodeProvider(timeout=300)
-
-    from bricks.llm.litellm_provider import LiteLLMProvider
-
-    return LiteLLMProvider(model=model)
+_UPLOAD_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
 
 
-# ── /api/run ────────────────────────────────────────────────────────────────
+def _build_provider(provider: str, model: str, api_key: str | None) -> LLMProvider:
+    """Return an LLMProvider for the given ``provider`` / ``model`` pair.
 
-
-@router.post("/api/run", response_model=BenchmarkResponse)
-async def run_benchmark(req: BenchmarkRequest) -> BenchmarkResponse:
-    """Run both BricksEngine and RawLLMEngine on the same task, return comparison.
+    Only ``claude_code`` is fully wired in this PR. Anthropic, OpenAI, and
+    Ollama routes are implemented in #44 and raise 501 here.
 
     Args:
-        req: Benchmark request with task text, raw data, and optional settings.
+        provider: One of ``anthropic`` / ``openai`` / ``claude_code`` / ``ollama``.
+        model: Provider-specific model identifier.
+        api_key: BYOK key (required for anthropic / openai, ignored otherwise).
 
     Returns:
-        BenchmarkResponse with results from both engines and token savings stats.
+        An ``LLMProvider`` instance.
 
     Raises:
-        HTTPException: If engine construction fails (e.g. missing API key).
+        HTTPException: 400 if BYOK is required but missing; 501 until #44 lands.
     """
-    from bricks.playground.showcase.engine import BricksEngine, RawLLMEngine
-    from bricks.playground.showcase.result_writer import check_correctness
+    if provider == "claude_code":
+        from bricks.providers.claudecode import ClaudeCodeProvider
 
-    try:
-        provider = _build_provider(req.model)
-    except Exception as exc:
-        raise HTTPException(status_code=400, detail=f"Failed to build provider: {exc}") from exc
+        return ClaudeCodeProvider(model=model or None)
 
-    bricks_engine = BricksEngine(provider=provider)
-    llm_engine = RawLLMEngine(provider=provider)
+    if provider in {"anthropic", "openai"} and not api_key:
+        raise HTTPException(status_code=400, detail=f"{provider} requires an api_key in the request body (BYOK)")
 
-    # Engines expect data wrapped in markdown JSON fences (extract_markdown_fences brick).
-    # Guard against double-fencing if the data is already wrapped.
-    raw = req.raw_data
-    fenced_data = raw if raw.strip().startswith("```") else f"```json\n{raw}\n```"
-
-    bricks_raw = bricks_engine.solve(req.task_text, fenced_data)
-    llm_raw = llm_engine.solve(req.task_text, fenced_data)
-
-    bricks_correct: bool | None = None
-    llm_correct: bool | None = None
-    if req.expected_outputs is not None:
-        bricks_correct = check_correctness(bricks_raw.outputs, req.expected_outputs)
-        llm_correct = check_correctness(llm_raw.outputs, req.expected_outputs)
-
-    bricks_tokens = bricks_raw.tokens_in + bricks_raw.tokens_out
-    llm_tokens = llm_raw.tokens_in + llm_raw.tokens_out
-
-    savings_ratio = (llm_tokens / bricks_tokens) if bricks_tokens > 0 else 1.0
-    savings_percent = ((1 - bricks_tokens / llm_tokens) * 100) if llm_tokens > 0 else 0.0
-
-    return BenchmarkResponse(
-        bricks_result=EngineResultResponse(
-            engine_name="BricksEngine",
-            outputs=bricks_raw.outputs,
-            correct=bricks_correct,
-            tokens_in=bricks_raw.tokens_in,
-            tokens_out=bricks_raw.tokens_out,
-            duration_seconds=bricks_raw.duration_seconds,
-            model=bricks_raw.model,
-            raw_response=bricks_raw.raw_response,
-            error=bricks_raw.error,
-        ),
-        llm_result=EngineResultResponse(
-            engine_name="RawLLMEngine",
-            outputs=llm_raw.outputs,
-            correct=llm_correct,
-            tokens_in=llm_raw.tokens_in,
-            tokens_out=llm_raw.tokens_out,
-            duration_seconds=llm_raw.duration_seconds,
-            model=llm_raw.model,
-            raw_response=llm_raw.raw_response,
-            error=llm_raw.error,
-        ),
-        savings_ratio=round(savings_ratio, 2),
-        savings_percent=round(savings_percent, 1),
+    raise HTTPException(
+        status_code=501,
+        detail=f"Provider {provider!r} is not implemented in this build. See issue #44.",
     )
 
 
-# ── /api/datasets ────────────────────────────────────────────────────────────
+def _preset_path(scenario_id: str) -> Path | None:
+    """Resolve ``scenario_id`` to a YAML file inside ``presets/``.
 
-
-@router.get("/api/datasets")
-async def list_datasets() -> list[dict[str, Any]]:
-    """Return all built-in datasets with metadata, preview, and full data.
-
-    Returns:
-        List of dataset dicts with id, name, description, row_count, fields,
-        preview (first 3 rows), and full_data (JSON string).
+    Accepts both ``crm-pipeline`` (dashes) and ``crm_pipeline`` (underscores).
+    Returns ``None`` if no match exists.
     """
-    return _loader.list_datasets()
+    for sep in (scenario_id, scenario_id.replace("-", "_"), scenario_id.replace("_", "-")):
+        candidate = _PRESETS_DIR / f"{sep}.yaml"
+        if candidate.is_file():
+            return candidate
+    return None
 
 
-# ── /api/bricks ──────────────────────────────────────────────────────────────
+def _load_preset_dict(path: Path) -> dict[str, Any]:
+    """Parse a preset YAML file into a dict; raise 500 on malformed YAML."""
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise HTTPException(status_code=500, detail=f"Malformed preset {path.name!r}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=500, detail=f"Preset {path.name!r} did not parse to a mapping")
+    return data
 
 
-@router.get("/api/bricks")
-async def list_bricks() -> list[dict[str, Any]]:
-    """Return all registered stdlib bricks with name, description, and category.
-
-    Returns:
-        List of dicts with ``name``, ``description``, and ``category`` for each brick.
-    """
-    from bricks.core.registry import BrickRegistry
-
-    registry = BrickRegistry.from_stdlib()
-    return [
-        {
-            "name": name,
-            "description": meta.description,
-            "category": meta.category,
-        }
-        for name, meta in registry.list_all()
-    ]
+# ── GET /playground/scenarios ────────────────────────────────────────────────
 
 
-# ── /api/presets ─────────────────────────────────────────────────────────────
-
-
-@router.get("/api/presets")
-async def list_presets() -> list[dict[str, Any]]:
-    """Return preset benchmark scenarios from the presets directory.
-
-    Returns:
-        List of preset dicts with name, dataset_id, task_text, and expected_outputs.
-    """
-    import yaml
-
-    presets: list[dict[str, Any]] = []
-    if not _PRESETS_DIR.exists():
-        return presets
-
+@router.get("/scenarios", response_model=list[ScenarioSummary])
+async def list_scenarios() -> list[ScenarioSummary]:
+    """Return the list of available preset scenarios."""
+    out: list[ScenarioSummary] = []
+    if not _PRESETS_DIR.is_dir():
+        return out
     for path in sorted(_PRESETS_DIR.glob("*.yaml")):
-        try:
-            data = yaml.safe_load(path.read_text(encoding="utf-8"))
-            if isinstance(data, dict) and "name" in data:
-                presets.append(
-                    {
-                        "name": data.get("name", ""),
-                        "dataset_id": data.get("dataset_id"),
-                        "task_text": data.get("task_text", ""),
-                        "expected_outputs": data.get("expected_outputs"),
-                    }
-                )
-        except Exception:  # noqa: S112
-            continue
+        data = _load_preset_dict(path)
+        out.append(
+            ScenarioSummary(
+                id=path.stem.replace("_", "-"),
+                name=str(data.get("name", path.stem)),
+                description=str(data.get("description", "")),
+            )
+        )
+    return out
 
-    return presets
+
+# ── GET /playground/scenarios/{id} ───────────────────────────────────────────
+
+
+@router.get("/scenarios/{scenario_id}", response_model=ScenarioDetail)
+async def get_scenario(scenario_id: str) -> ScenarioDetail:
+    """Return the full body of a preset scenario."""
+    path = _preset_path(scenario_id)
+    if path is None:
+        raise HTTPException(status_code=404, detail=f"No scenario with id {scenario_id!r}")
+    data = _load_preset_dict(path)
+
+    # Resolve the data source: inline `data`, else `dataset_id` lookup via
+    # DatasetLoader (existing helper), else raise 500 if none.
+    body: Any = data.get("data")
+    dataset_id = data.get("dataset_id")
+    if body is None and dataset_id:
+        from bricks.playground.web.datasets import DatasetLoader
+
+        loader = DatasetLoader()
+        matching = next((ds for ds in loader.list_datasets() if ds.get("id") == dataset_id), None)
+        if matching is None:
+            raise HTTPException(status_code=500, detail=f"Dataset {dataset_id!r} referenced by preset not found")
+        # DatasetLoader gives us a full_data JSON string; parse to a value.
+        full = matching.get("full_data")
+        if isinstance(full, str):
+            try:
+                body = json.loads(full)
+            except json.JSONDecodeError:
+                body = full
+        else:
+            body = full
+
+    return ScenarioDetail(
+        id=scenario_id,
+        name=str(data.get("name", scenario_id)),
+        description=str(data.get("description", "")),
+        task=str(data.get("task_text", "")),
+        data=body,
+        expected_output=data.get("expected_outputs"),
+        required_bricks=data.get("required_bricks"),
+    )
+
+
+# ── POST /playground/upload ──────────────────────────────────────────────────
+
+
+@router.post("/upload", response_model=UploadResponse)
+async def upload(file: UploadFile = File(...)) -> UploadResponse:  # noqa: B008
+    """Accept a CSV or JSON upload; return parsed contents.
+
+    Rejects payloads larger than ``_UPLOAD_MAX_BYTES`` (5 MB).
+    """
+    raw = await file.read()
+    if len(raw) > _UPLOAD_MAX_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File exceeds {_UPLOAD_MAX_BYTES // (1024 * 1024)} MB limit ({len(raw)} bytes)",
+        )
+
+    filename = file.filename or "upload"
+    suffix = Path(filename).suffix.lower()
+
+    data: Any
+    row_count: int | None = None
+
+    if suffix == ".csv" or (file.content_type or "").endswith("csv"):
+        try:
+            text = raw.decode("utf-8-sig")
+        except UnicodeDecodeError as exc:
+            raise HTTPException(status_code=400, detail=f"CSV must be UTF-8: {exc}") from exc
+        reader = csv.DictReader(io.StringIO(text))
+        rows = list(reader)
+        data = rows
+        row_count = len(rows)
+    else:
+        # Default to JSON.
+        try:
+            text = raw.decode("utf-8")
+            data = json.loads(text)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise HTTPException(status_code=400, detail=f"Could not parse JSON: {exc}") from exc
+        if isinstance(data, list):
+            row_count = len(data)
+
+    return UploadResponse(
+        data=data,
+        filename=filename,
+        size_bytes=len(raw),
+        row_count=row_count,
+    )
+
+
+# ── POST /playground/run ─────────────────────────────────────────────────────
+
+
+@router.post("/run", response_model=RunResponse, response_model_exclude_none=True)
+async def run_playground(req: RunRequest) -> RunResponse:
+    """Run BricksEngine on the task and return structured results.
+
+    ``compare`` is wired in #45; this PR always omits ``raw_llm`` from the
+    response.
+    """
+    from bricks.playground.showcase.engine import BricksEngine
+    from bricks.playground.showcase.result_writer import check_correctness
+
+    provider = _build_provider(req.provider, req.model, req.api_key)
+    engine = BricksEngine(provider=provider)
+
+    raw_data = req.data if isinstance(req.data, str) else json.dumps(req.data)
+    fenced = raw_data if raw_data.strip().startswith("```") else f"```json\n{raw_data}\n```"
+
+    t0 = time.monotonic()
+    result = engine.solve(req.task, fenced)
+    duration_ms = int((time.monotonic() - t0) * 1000)
+
+    checks = []
+    if req.expected_output is not None:
+        expected = req.expected_output
+        got = result.outputs or {}
+        for key, exp_val in expected.items():
+            got_val = got.get(key)
+            checks.append({"key": key, "expected": exp_val, "got": got_val, "pass": got_val == exp_val})
+        # Whole-dict correctness is available via check_correctness as a sanity
+        # gate but we already expose per-key results above.
+        check_correctness(got, expected)
+
+    bricks_result = EngineResult(
+        blueprint_yaml=result.raw_response or None,
+        outputs=result.outputs or {},
+        response=None,
+        tokens=TokenBreakdown(
+            **{
+                "in": result.tokens_in,
+                "out": result.tokens_out,
+                "total": result.tokens_in + result.tokens_out,
+            }
+        ),
+        duration_ms=duration_ms,
+        cost_usd=None,
+        checks=[{"key": c["key"], "expected": c["expected"], "got": c["got"], "pass": c["pass"]} for c in checks],
+    )
+
+    metadata = RunMetadata(
+        model=result.model or req.model,
+        provider=req.provider,
+        version=_bricks_version,
+        timestamp=datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+    )
+
+    return RunResponse(bricks=bricks_result, raw_llm=None, run_metadata=metadata)

--- a/src/bricks/playground/web/schemas.py
+++ b/src/bricks/playground/web/schemas.py
@@ -1,18 +1,25 @@
-"""Pydantic v2 schemas for the Bricks Benchmark web API."""
+"""Pydantic v2 schemas for the Bricks Playground web API."""
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+# ── Legacy schemas (used by scenario_loader + retained /api tests) ───────────
+#
+# Kept so the older internal `scenario_to_benchmark_request` helper and the
+# existing unit tests continue to pass during the Playground v0.5.0 rollout.
+# Slated for removal in the #46 polish sweep once scenario_loader moves to
+# the new RunRequest payload shape.
 
 
 class BenchmarkRequest(BaseModel):
-    """Request body for POST /api/run.
+    """Legacy request body (pre-v0.5.0 /api/run).
 
     Attributes:
-        task_text: Natural language description of the computation task.
-        raw_data: JSON string containing the input data.
+        task_text: Natural-language task description.
+        raw_data: JSON string of the input data.
         expected_outputs: Optional ground-truth outputs for correctness checking.
         required_bricks: Optional list of brick names to hint the composer.
         model: LLM model string (default: ``'claudecode'``).
@@ -26,19 +33,7 @@ class BenchmarkRequest(BaseModel):
 
 
 class EngineResultResponse(BaseModel):
-    """Result from one engine for one benchmark run.
-
-    Attributes:
-        engine_name: Class name of the engine (e.g. ``'BricksEngine'``).
-        outputs: Parsed structured outputs from the engine.
-        correct: True/False if expected_outputs were provided, None otherwise.
-        tokens_in: Input token count.
-        tokens_out: Output token count.
-        duration_seconds: Wall-clock time for this run.
-        model: Model identifier string used.
-        raw_response: Full LLM response text (YAML blueprint or JSON).
-        error: Non-empty string if the engine failed.
-    """
+    """Legacy per-engine result for /api/run."""
 
     engine_name: str
     outputs: dict[str, Any]
@@ -52,16 +47,118 @@ class EngineResultResponse(BaseModel):
 
 
 class BenchmarkResponse(BaseModel):
-    """Complete benchmark comparison response.
-
-    Attributes:
-        bricks_result: Result from BricksEngine.
-        llm_result: Result from RawLLMEngine.
-        savings_ratio: llm_total_tokens / bricks_total_tokens (1.0 if bricks used 0 tokens).
-        savings_percent: ``(1 - bricks_tokens / llm_tokens) * 100``.
-    """
+    """Legacy two-engine benchmark comparison response."""
 
     bricks_result: EngineResultResponse
     llm_result: EngineResultResponse
     savings_ratio: float
     savings_percent: float
+
+
+# ── v0.5.0 Playground schemas (design.md §6) ─────────────────────────────────
+
+
+class ScenarioSummary(BaseModel):
+    """Lightweight scenario descriptor returned by ``GET /playground/scenarios``."""
+
+    id: str
+    name: str
+    description: str
+
+
+class ScenarioDetail(BaseModel):
+    """Full scenario body returned by ``GET /playground/scenarios/{id}``."""
+
+    id: str
+    name: str
+    description: str
+    task: str
+    data: Any
+    expected_output: dict[str, Any] | None = None
+    required_bricks: list[str] | None = None
+
+
+class UploadResponse(BaseModel):
+    """Shape returned by ``POST /playground/upload``."""
+
+    data: Any
+    filename: str
+    size_bytes: int
+    row_count: int | None = None
+
+
+class RunRequest(BaseModel):
+    """Request body for ``POST /playground/run`` (design.md §6).
+
+    API keys live only in the request body (BYOK). They are never read from
+    environment variables. Non-``claude_code`` / non-``ollama`` providers
+    require ``api_key``; validation is enforced at dispatch time.
+    """
+
+    provider: Literal["anthropic", "openai", "claude_code", "ollama"]
+    model: str
+    api_key: str | None = None
+    task: str
+    data: Any
+    expected_output: dict[str, Any] | None = None
+    compare: bool = False
+
+
+class TokenBreakdown(BaseModel):
+    """Per-engine token counter."""
+
+    in_: int = Field(alias="in")
+    out: int
+    total: int
+
+    model_config = {"populate_by_name": True}
+
+
+class CheckResult(BaseModel):
+    """One correctness check line item."""
+
+    key: str
+    expected: Any
+    got: Any
+    pass_: bool = Field(alias="pass")
+
+    model_config = {"populate_by_name": True}
+
+
+class BrickUsage(BaseModel):
+    """One brick type and how many times it appeared in the blueprint."""
+
+    name: str
+    category: str
+    count: int
+
+
+class EngineResult(BaseModel):
+    """Per-engine result payload for ``/playground/run`` (design.md §6)."""
+
+    blueprint_yaml: str | None = None
+    bricks_used: list[BrickUsage] | None = None
+    response: str | None = None
+    outputs: dict[str, Any]
+    tokens: TokenBreakdown
+    duration_ms: int
+    cost_usd: float | None = None
+    checks: list[CheckResult] = []
+
+
+class RunMetadata(BaseModel):
+    """Top-level metadata about the run."""
+
+    model: str
+    provider: str
+    seed: int = 42
+    version: str
+    timestamp: str
+
+
+class RunResponse(BaseModel):
+    """Response body for ``POST /playground/run`` (design.md §6)."""
+
+    bricks: EngineResult
+    raw_llm: EngineResult | None = None
+    run_metadata: RunMetadata

--- a/src/bricks/playground/web/static/index.html
+++ b/src/bricks/playground/web/static/index.html
@@ -1052,7 +1052,12 @@ outputs_map:
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') startRun();
   });
 
-  function startRun() {
+  // Live data returned from the most recent /playground/run call.
+  // showResults() uses this when present and falls back to the mock numbers
+  // when the fetch hasn't completed yet.
+  let lastRun = null;
+
+  async function startRun() {
     // configure steps
     const rawStep = document.querySelector('#steps li[data-s="3"]');
     rawStep.style.display = compareOn ? '' : 'none';
@@ -1064,8 +1069,12 @@ outputs_map:
 
     showView('view-running');
 
+    // Kick off the animation and the real fetch in parallel.
     const sequence = compareOn ? [0, 1, 2, 3, 4] : [0, 1, 2, 4];
     let i = 0;
+    let animationDone = false;
+    let runResponse = null;
+    let runError = null;
     const tick = () => {
       if (i > 0) {
         const prev = document.querySelector(`#steps li[data-s="${sequence[i-1]}"]`);
@@ -1077,18 +1086,100 @@ outputs_map:
         i++;
         setTimeout(tick, 520 + Math.random() * 300);
       } else {
-        setTimeout(showResults, 450);
+        animationDone = true;
+        if (runResponse !== null || runError !== null) {
+          lastRun = runResponse;
+          setTimeout(() => showResults(runError), 450);
+        }
       }
     };
     tick();
+
+    // Fire the real /playground/run request using whatever's in the setup view.
+    const taskText = document.getElementById('taskInput').value.trim();
+    const dataBodyEl = document.getElementById('dataBody');
+    let dataValue;
+    try {
+      dataValue = JSON.parse(dataBodyEl.textContent || '{}');
+    } catch (_) {
+      dataValue = dataBodyEl.textContent || '';
+    }
+
+    try {
+      const resp = await fetch('/playground/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          // Only claude_code is wired end-to-end until #44 lands.
+          provider: 'claude_code',
+          model: (document.getElementById('modelSel')?.value || '').toLowerCase().includes('haiku')
+            ? 'haiku' : (document.getElementById('modelSel')?.value || '').toLowerCase().includes('sonnet')
+            ? 'sonnet' : '',
+          task: taskText,
+          data: dataValue,
+          expected_output: window.__expectedOutput || null,
+          compare: compareOn,
+        }),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
+      runResponse = await resp.json();
+    } catch (err) {
+      runError = err;
+    }
+
+    if (animationDone) {
+      lastRun = runResponse;
+      showResults(runError);
+    }
   }
 
   // ---- results ----
-  function showResults() {
+  function showResults(runError) {
     const verdictTitle = document.getElementById('verdictTitle');
     const scoreGrid = document.getElementById('scoreGrid');
     const metrics = document.getElementById('metrics');
     const cmpTable = document.getElementById('cmpTable');
+
+    if (runError) {
+      verdictTitle.innerHTML = 'Run failed';
+      scoreGrid.className = 'score-grid';
+      scoreGrid.innerHTML = `
+        <div class="scol loss">
+          <div class="who"><i></i>Error</div>
+          <div class="meta">${String(runError.message || runError)}</div>
+        </div>`;
+      metrics.className = 'metrics';
+      metrics.innerHTML = '';
+      showView('view-results');
+      return;
+    }
+
+    // If the API returned real data, render it; otherwise fall back to the
+    // demo numbers baked into the mockup so the UI still animates through.
+    if (lastRun && lastRun.bricks) {
+      const b = lastRun.bricks;
+      const tokens = b.tokens?.total ?? ((b.tokens?.in || 0) + (b.tokens?.out || 0));
+      const cost = (b.cost_usd == null) ? '—' : `$${b.cost_usd.toFixed(4)}`;
+      const passed = (b.checks || []).filter(c => c.pass).length;
+      const total = (b.checks || []).length;
+      verdictTitle.innerHTML = 'Bricks ran deterministically.';
+      scoreGrid.className = 'score-grid';
+      scoreGrid.innerHTML = `
+        <div class="scol win">
+          <div class="who"><i></i>Bricks</div>
+          <div class="num">${passed}<span class="of">/${total || '?'}</span></div>
+          <div class="meta">${tokens.toLocaleString()} tokens · ${cost}</div>
+        </div>`;
+      metrics.className = 'metrics';
+      metrics.innerHTML = `
+        <div class="metric"><div class="k">Tokens</div><div class="v">${tokens.toLocaleString()}</div><div class="sub">composed once</div></div>
+        <div class="metric"><div class="k">Cost</div><div class="v">${cost}</div><div class="sub">${lastRun.run_metadata?.model || ''}</div></div>
+        <div class="metric"><div class="k">Duration</div><div class="v">${((b.duration_ms || 0) / 1000).toFixed(1)}s</div><div class="sub">wall clock</div></div>`;
+      if (cmpTable) cmpTable.querySelectorAll('.raw-col').forEach(el => el.style.display = 'none');
+      if (typeof applyTweaks === 'function') applyTweaks();
+      showView('view-results');
+      return;
+    }
 
     if (compareOn) {
       verdictTitle.innerHTML = 'Bricks beat raw LLM';
@@ -1143,6 +1234,56 @@ outputs_map:
   ['dragleave','drop'].forEach(ev => dz.addEventListener(ev, e => {
     e.preventDefault(); dz.classList.remove('drag');
   }));
+  dz.addEventListener('drop', async (e) => {
+    e.preventDefault();
+    const file = e.dataTransfer?.files?.[0];
+    if (!file) return;
+    const fd = new FormData();
+    fd.append('file', file);
+    try {
+      const resp = await fetch('/playground/upload', { method: 'POST', body: fd });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const body = await resp.json();
+      document.getElementById('dataBody').innerHTML = hlJson(body.data);
+    } catch (err) {
+      console.error('upload failed', err);
+    }
+  });
+
+  // ---- scenario fetch (replaces hardcoded customers/options) ----
+  const scenSelect = document.getElementById('scenSelect');
+  const taskInput = document.getElementById('taskInput');
+  async function loadScenarios() {
+    try {
+      const resp = await fetch('/playground/scenarios');
+      if (!resp.ok) return;
+      const list = await resp.json();
+      if (!Array.isArray(list) || list.length === 0) return;
+      scenSelect.innerHTML = list
+        .map(s => `<option value="${esc(s.id)}">${esc(s.name)}</option>`)
+        .join('');
+      await loadScenarioDetail(scenSelect.value);
+    } catch (err) {
+      // Fall back to the hardcoded mock data that's already rendered.
+      console.warn('scenario list fetch failed, keeping mock', err);
+    }
+  }
+  async function loadScenarioDetail(id) {
+    try {
+      const resp = await fetch(`/playground/scenarios/${encodeURIComponent(id)}`);
+      if (!resp.ok) return;
+      const detail = await resp.json();
+      if (detail.data != null) {
+        document.getElementById('dataBody').innerHTML = hlJson(detail.data);
+      }
+      if (detail.task) taskInput.value = detail.task;
+      window.__expectedOutput = detail.expected_output || null;
+    } catch (err) {
+      console.warn('scenario detail fetch failed', err);
+    }
+  }
+  scenSelect.addEventListener('change', () => loadScenarioDetail(scenSelect.value));
+  loadScenarios();
 
   // ---- copy yaml ----
   const copyYamlBtn = document.getElementById('copyYamlBtn');

--- a/tests/playground/test_endpoints.py
+++ b/tests/playground/test_endpoints.py
@@ -1,0 +1,147 @@
+"""Happy-path + failure tests for the ``/playground`` FastAPI routes."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bricks.playground.web.app import app
+
+
+@pytest.fixture(name="client")
+def _client() -> TestClient:
+    return TestClient(app)
+
+
+# ── scenarios ────────────────────────────────────────────────────────────────
+
+
+def test_list_scenarios_returns_presets(client: TestClient) -> None:
+    r = client.get("/playground/scenarios")
+    assert r.status_code == 200
+    payload = r.json()
+    assert isinstance(payload, list)
+    assert len(payload) >= 1
+    ids = {s["id"] for s in payload}
+    assert "crm-pipeline" in ids
+    sample = next(s for s in payload if s["id"] == "crm-pipeline")
+    assert sample["name"]
+    assert sample["description"]
+
+
+def test_get_scenario_happy_path(client: TestClient) -> None:
+    r = client.get("/playground/scenarios/crm-pipeline")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["id"] == "crm-pipeline"
+    assert body.get("task")
+    assert body["expected_output"] is not None
+
+
+def test_get_scenario_accepts_underscore_id(client: TestClient) -> None:
+    """Scenario IDs are normalised — ``crm_pipeline`` also resolves."""
+    r = client.get("/playground/scenarios/crm_pipeline")
+    assert r.status_code == 200
+
+
+def test_get_scenario_unknown_returns_404(client: TestClient) -> None:
+    r = client.get("/playground/scenarios/does-not-exist")
+    assert r.status_code == 404
+
+
+# ── upload ───────────────────────────────────────────────────────────────────
+
+
+def test_upload_csv_parses_to_dicts(client: TestClient) -> None:
+    csv_body = "id,name\n1,Alice\n2,Bob\n"
+    r = client.post("/playground/upload", files={"file": ("t.csv", csv_body, "text/csv")})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["row_count"] == 2
+    assert body["data"] == [{"id": "1", "name": "Alice"}, {"id": "2", "name": "Bob"}]
+    assert body["filename"] == "t.csv"
+
+
+def test_upload_json_list_counts_rows(client: TestClient) -> None:
+    payload = [{"a": 1}, {"a": 2}, {"a": 3}]
+    r = client.post(
+        "/playground/upload",
+        files={"file": ("t.json", json.dumps(payload), "application/json")},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["row_count"] == 3
+    assert body["data"] == payload
+
+
+def test_upload_json_object_has_no_row_count(client: TestClient) -> None:
+    r = client.post(
+        "/playground/upload",
+        files={"file": ("t.json", json.dumps({"a": 1}), "application/json")},
+    )
+    assert r.status_code == 200
+    assert r.json()["row_count"] is None
+
+
+def test_upload_rejects_over_5_mb(client: TestClient) -> None:
+    big = "x" * (6 * 1024 * 1024)
+    r = client.post("/playground/upload", files={"file": ("big.json", big, "application/json")})
+    assert r.status_code == 413
+
+
+def test_upload_rejects_malformed_json(client: TestClient) -> None:
+    r = client.post("/playground/upload", files={"file": ("t.json", "{not-json", "application/json")})
+    assert r.status_code == 400
+
+
+# ── run ──────────────────────────────────────────────────────────────────────
+
+
+def test_run_anthropic_without_key_returns_400(client: TestClient) -> None:
+    """BYOK enforcement: no api_key → 400 Bad Request."""
+    r = client.post(
+        "/playground/run",
+        json={
+            "provider": "anthropic",
+            "model": "claude-haiku-4-5",
+            "task": "count items",
+            "data": [{"a": 1}],
+        },
+    )
+    assert r.status_code == 400
+    assert "api_key" in r.json()["detail"].lower()
+
+
+def test_run_anthropic_with_key_returns_501_until_issue_44(client: TestClient) -> None:
+    """Until #44 lands, Anthropic / OpenAI / Ollama return 501 with a pointer."""
+    r = client.post(
+        "/playground/run",
+        json={
+            "provider": "anthropic",
+            "model": "claude-haiku-4-5",
+            "api_key": "sk-fake",
+            "task": "t",
+            "data": [{}],
+        },
+    )
+    assert r.status_code == 501
+    assert "#44" in r.json()["detail"]
+
+
+def test_run_ollama_returns_501_until_issue_44(client: TestClient) -> None:
+    r = client.post(
+        "/playground/run",
+        json={"provider": "ollama", "model": "llama3", "task": "t", "data": [{}]},
+    )
+    assert r.status_code == 501
+
+
+def test_run_rejects_unknown_provider(client: TestClient) -> None:
+    r = client.post(
+        "/playground/run",
+        json={"provider": "unknown", "model": "x", "task": "t", "data": []},
+    )
+    # Pydantic Literal validation → 422.
+    assert r.status_code == 422


### PR DESCRIPTION
Closes #43. Third PR of the Playground v0.5.0 stack (#41 ✓, #42 ✓).

## What landed
**Backend** (`src/bricks/playground/web/routes.py`)
- Router moves to `/playground` prefix. Old `/api/*` routes are removed — nothing external consumed them.
- `GET /playground/scenarios` — lists preset YAMLs as `{id, name, description}`
- `GET /playground/scenarios/{id}` — full body with `task`, `data`, `expected_output`, `required_bricks`. Accepts both dash- and underscore-separated IDs; resolves inline `data` or looks up `dataset_id` via the existing `DatasetLoader`.
- `POST /playground/upload` — CSV (BOM-tolerant) → `list[dict]`, JSON passes through, 5 MB cap (413 over, 400 malformed)
- `POST /playground/run` — `RunRequest` → `RunResponse` (design.md §6). `claude_code` works end-to-end using the enhanced `ClaudeCodeProvider` from #47. `anthropic`/`openai` return 400 when `api_key` is missing (BYOK enforced). `anthropic`/`openai`/`ollama` return **501** pointing at #44. `compare=true` is accepted but `raw_llm` stays null until #45.

**Schemas** (`schemas.py`) — additive. New design.md §6 models live alongside the legacy `BenchmarkRequest`/`Response` which still back `scenario_loader` + existing tests. #46 polish sweep drops the legacy pair.

**Frontend** (`static/index.html`)
- Page-load fetch of `/playground/scenarios` rebuilds the `<select>` options with real preset IDs.
- On scenario change: fetch `/playground/scenarios/{id}`, refresh task + data + `__expectedOutput`.
- Drop-zone dispatches `/playground/upload` and re-renders the data pane.
- `startRun()` animates while a real `/playground/run` fetch runs in parallel; `showResults()` renders live tokens / cost / duration / checks, falls back to mock numbers if data is missing, shows a red "Run failed" card on error.

**Tests** (`tests/playground/test_endpoints.py`) — 13 new tests: scenarios list, scenario detail (happy + underscore + 404), upload (CSV / JSON list / JSON object / oversize 413 / malformed 400), run (BYOK 400 / 501 for non-claude_code / 422 unknown provider).

## Test plan
- [x] `pytest` — 1184 passed, 18 skipped locally
- [x] `ruff check` + `ruff format --check` + `mypy src` clean
- [x] `cog --check README.md` clean
- [ ] CI matrix 3.10 / 3.11 / 3.12 + lint + links

🤖 Generated with [Claude Code](https://claude.com/claude-code)