### PR TITLE
feat(playground): Anthropic / OpenAI / Claude Code / Ollama providers (#44)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ playground = [
     "uvicorn>=0.20",
     "PyYAML>=6.0",
     "python-multipart>=0.0.6",
+    "anthropic>=0.40",
+    "openai>=1.0",
+    "httpx>=0.27",
 ]
 all = [
     "litellm>=1.0,<1.82.7",
@@ -49,6 +52,9 @@ all = [
     "uvicorn>=0.20",
     "PyYAML>=6.0",
     "python-multipart>=0.0.6",
+    "anthropic>=0.40",
+    "openai>=1.0",
+    "httpx>=0.27",
 ]
 dev = [
     "pytest>=9.0",

--- a/src/bricks/playground/web/routes.py
+++ b/src/bricks/playground/web/routes.py
@@ -38,31 +38,50 @@ _UPLOAD_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
 def _build_provider(provider: str, model: str, api_key: str | None) -> LLMProvider:
     """Return an LLMProvider for the given ``provider`` / ``model`` pair.
 
-    Only ``claude_code`` is fully wired in this PR. Anthropic, OpenAI, and
-    Ollama routes are implemented in #44 and raise 501 here.
+    All four providers from design.md §7 are implemented here. API keys
+    live only in the request body (BYOK) and are never read from the
+    environment.
 
     Args:
         provider: One of ``anthropic`` / ``openai`` / ``claude_code`` / ``ollama``.
         model: Provider-specific model identifier.
-        api_key: BYOK key (required for anthropic / openai, ignored otherwise).
+        api_key: BYOK key (required for anthropic / openai, ignored for
+            ``claude_code`` and ``ollama``).
 
     Returns:
         An ``LLMProvider`` instance.
 
     Raises:
-        HTTPException: 400 if BYOK is required but missing; 501 until #44 lands.
+        HTTPException: 400 if BYOK is required but missing.
     """
     if provider == "claude_code":
         from bricks.providers.claudecode import ClaudeCodeProvider
 
         return ClaudeCodeProvider(model=model or None)
 
+    if provider == "ollama":
+        from bricks.providers.ollama import OllamaProvider
+
+        return OllamaProvider(model=model)
+
     if provider in {"anthropic", "openai"} and not api_key:
         raise HTTPException(status_code=400, detail=f"{provider} requires an api_key in the request body (BYOK)")
 
+    if provider == "anthropic":
+        from bricks.providers.anthropic import AnthropicProvider
+
+        assert api_key is not None  # narrowed by the BYOK check above
+        return AnthropicProvider(model=model, api_key=api_key)
+
+    if provider == "openai":
+        from bricks.providers.openai import OpenAIProvider
+
+        assert api_key is not None
+        return OpenAIProvider(model=model, api_key=api_key)
+
     raise HTTPException(
-        status_code=501,
-        detail=f"Provider {provider!r} is not implemented in this build. See issue #44.",
+        status_code=400,
+        detail=f"Unknown provider {provider!r}",
     )
 
 

--- a/src/bricks/providers/anthropic/__init__.py
+++ b/src/bricks/providers/anthropic/__init__.py
@@ -1,0 +1,7 @@
+"""bricks-provider-anthropic — routes Bricks LLM calls through the Anthropic SDK."""
+
+from __future__ import annotations
+
+from bricks.providers.anthropic.provider import AnthropicProvider
+
+__all__ = ["AnthropicProvider"]

--- a/src/bricks/providers/anthropic/provider.py
+++ b/src/bricks/providers/anthropic/provider.py
@@ -1,0 +1,83 @@
+"""LLMProvider implementation that talks to the Anthropic SDK directly.
+
+BYOK only — the API key is passed in at construction and never read from
+environment variables.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from bricks.llm.base import CompletionResult, LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class AnthropicProvider(LLMProvider):
+    """LLMProvider that routes completions through the Anthropic Python SDK.
+
+    The API key is required and is passed only via the constructor. This
+    provider never inspects ``os.environ`` — BYOK flow for the Playground.
+
+    Example::
+
+        provider = AnthropicProvider(model="claude-haiku-4-5", api_key=key)
+        response = provider.complete("Say hello.")
+    """
+
+    def __init__(
+        self,
+        model: str,
+        api_key: str,
+        *,
+        max_tokens: int = 4096,
+        timeout: float = 120.0,
+    ) -> None:
+        """Initialise the provider.
+
+        Args:
+            model: Anthropic model identifier (e.g. ``claude-haiku-4-5``).
+            api_key: BYOK key passed to the SDK client. Required.
+            max_tokens: Max output tokens per completion.
+            timeout: Per-request timeout in seconds.
+        """
+        if not api_key:
+            raise ValueError("AnthropicProvider requires an api_key (BYOK only, never read from env).")
+        self.model = model
+        self.api_key = api_key
+        self.max_tokens = max_tokens
+        self.timeout = timeout
+
+    def complete(self, prompt: str, system: str = "") -> CompletionResult:
+        """Send a prompt through the Anthropic Messages API."""
+        try:
+            import anthropic  # noqa: PLC0415
+        except ImportError as exc:
+            raise RuntimeError("anthropic SDK not installed. Install with: pip install bricks[playground]") from exc
+
+        client = anthropic.Anthropic(api_key=self.api_key, timeout=self.timeout)
+
+        t0 = time.monotonic()
+        msg = client.messages.create(
+            model=self.model,
+            max_tokens=self.max_tokens,
+            system=system or anthropic.NOT_GIVEN,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        elapsed = time.monotonic() - t0
+
+        text_parts = [block.text for block in msg.content if getattr(block, "type", None) == "text"]
+        text = "".join(text_parts)
+
+        usage = msg.usage
+        return CompletionResult(
+            text=text,
+            input_tokens=getattr(usage, "input_tokens", 0) or 0,
+            output_tokens=getattr(usage, "output_tokens", 0) or 0,
+            model=msg.model or self.model,
+            duration_seconds=elapsed,
+            estimated=False,
+            cached_input_tokens=getattr(usage, "cache_read_input_tokens", 0) or 0,
+            cache_creation_input_tokens=getattr(usage, "cache_creation_input_tokens", 0) or 0,
+        )

--- a/src/bricks/providers/ollama/__init__.py
+++ b/src/bricks/providers/ollama/__init__.py
@@ -1,0 +1,7 @@
+"""bricks-provider-ollama — routes Bricks LLM calls through a local Ollama server."""
+
+from __future__ import annotations
+
+from bricks.providers.ollama.provider import OllamaProvider
+
+__all__ = ["OllamaProvider"]

--- a/src/bricks/providers/ollama/provider.py
+++ b/src/bricks/providers/ollama/provider.py
@@ -1,0 +1,73 @@
+"""LLMProvider implementation that talks to a local Ollama server over HTTP."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from bricks.llm.base import CompletionResult, LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaProvider(LLMProvider):
+    """LLMProvider that calls a local Ollama server (default ``localhost:11434``).
+
+    Ollama handles auth locally — no key required. Fails with a clear error
+    message if the server isn't running.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        host: str = "http://localhost:11434",
+        timeout: float = 300.0,
+    ) -> None:
+        """Initialise the provider.
+
+        Args:
+            model: Ollama model name (e.g. ``llama3``, ``mistral``).
+            host: Base URL of the Ollama server.
+            timeout: Per-request timeout in seconds.
+        """
+        self.model = model
+        self.host = host.rstrip("/")
+        self.timeout = timeout
+
+    def complete(self, prompt: str, system: str = "") -> CompletionResult:
+        """POST ``/api/generate`` with ``stream=false`` and return the response."""
+        try:
+            import httpx  # noqa: PLC0415
+        except ImportError as exc:
+            raise RuntimeError("httpx not installed. Install with: pip install bricks[playground]") from exc
+
+        payload: dict[str, object] = {
+            "model": self.model,
+            "prompt": prompt,
+            "stream": False,
+        }
+        if system:
+            payload["system"] = system
+
+        t0 = time.monotonic()
+        try:
+            response = httpx.post(f"{self.host}/api/generate", json=payload, timeout=self.timeout)
+            response.raise_for_status()
+        except httpx.ConnectError as exc:
+            raise RuntimeError(
+                f"Could not reach Ollama at {self.host}. Is the server running? Start it with: `ollama serve`"
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            raise RuntimeError(f"Ollama returned HTTP {exc.response.status_code}: {exc.response.text}") from exc
+        elapsed = time.monotonic() - t0
+
+        data = response.json()
+        return CompletionResult(
+            text=str(data.get("response", "")),
+            input_tokens=int(data.get("prompt_eval_count", 0) or 0),
+            output_tokens=int(data.get("eval_count", 0) or 0),
+            model=str(data.get("model", self.model)),
+            duration_seconds=elapsed,
+            estimated=False,
+        )

--- a/src/bricks/providers/openai/__init__.py
+++ b/src/bricks/providers/openai/__init__.py
@@ -1,0 +1,7 @@
+"""bricks-provider-openai — routes Bricks LLM calls through the OpenAI SDK."""
+
+from __future__ import annotations
+
+from bricks.providers.openai.provider import OpenAIProvider
+
+__all__ = ["OpenAIProvider"]

--- a/src/bricks/providers/openai/provider.py
+++ b/src/bricks/providers/openai/provider.py
@@ -1,0 +1,85 @@
+"""LLMProvider implementation that talks to the OpenAI SDK directly.
+
+BYOK only — API key is constructor-only and never read from environment.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from bricks.llm.base import CompletionResult, LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIProvider(LLMProvider):
+    """LLMProvider that routes completions through the OpenAI Python SDK.
+
+    Uses the Chat Completions API with ``messages=[{role: user, content: prompt}]``
+    (plus an optional system message). The API key is required and never
+    read from environment variables.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        api_key: str,
+        *,
+        max_tokens: int = 4096,
+        timeout: float = 120.0,
+    ) -> None:
+        """Initialise the provider.
+
+        Args:
+            model: OpenAI model identifier (e.g. ``gpt-4o-mini``).
+            api_key: BYOK key passed to the SDK client. Required.
+            max_tokens: Max output tokens per completion.
+            timeout: Per-request timeout in seconds.
+        """
+        if not api_key:
+            raise ValueError("OpenAIProvider requires an api_key (BYOK only, never read from env).")
+        self.model = model
+        self.api_key = api_key
+        self.max_tokens = max_tokens
+        self.timeout = timeout
+
+    def complete(self, prompt: str, system: str = "") -> CompletionResult:
+        """Send a prompt through the OpenAI Chat Completions API."""
+        try:
+            import openai  # noqa: PLC0415
+        except ImportError as exc:
+            raise RuntimeError("openai SDK not installed. Install with: pip install bricks[playground]") from exc
+
+        client = openai.OpenAI(api_key=self.api_key, timeout=self.timeout)
+
+        messages = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+
+        t0 = time.monotonic()
+        resp = client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            max_tokens=self.max_tokens,
+        )
+        elapsed = time.monotonic() - t0
+
+        text = resp.choices[0].message.content or ""
+        usage = resp.usage
+
+        cached = 0
+        details = getattr(usage, "prompt_tokens_details", None)
+        if details is not None:
+            cached = getattr(details, "cached_tokens", 0) or 0
+
+        return CompletionResult(
+            text=text,
+            input_tokens=getattr(usage, "prompt_tokens", 0) or 0,
+            output_tokens=getattr(usage, "completion_tokens", 0) or 0,
+            model=resp.model or self.model,
+            duration_seconds=elapsed,
+            estimated=False,
+            cached_input_tokens=cached,
+        )

--- a/tests/playground/test_endpoints.py
+++ b/tests/playground/test_endpoints.py
@@ -114,30 +114,6 @@ def test_run_anthropic_without_key_returns_400(client: TestClient) -> None:
     assert "api_key" in r.json()["detail"].lower()
 
 
-def test_run_anthropic_with_key_returns_501_until_issue_44(client: TestClient) -> None:
-    """Until #44 lands, Anthropic / OpenAI / Ollama return 501 with a pointer."""
-    r = client.post(
-        "/playground/run",
-        json={
-            "provider": "anthropic",
-            "model": "claude-haiku-4-5",
-            "api_key": "sk-fake",
-            "task": "t",
-            "data": [{}],
-        },
-    )
-    assert r.status_code == 501
-    assert "#44" in r.json()["detail"]
-
-
-def test_run_ollama_returns_501_until_issue_44(client: TestClient) -> None:
-    r = client.post(
-        "/playground/run",
-        json={"provider": "ollama", "model": "llama3", "task": "t", "data": [{}]},
-    )
-    assert r.status_code == 501
-
-
 def test_run_rejects_unknown_provider(client: TestClient) -> None:
     r = client.post(
         "/playground/run",

--- a/tests/playground/test_providers.py
+++ b/tests/playground/test_providers.py
@@ -1,0 +1,261 @@
+"""Unit tests for the Playground provider adapters.
+
+All tests mock the underlying SDK / subprocess / HTTP call — no network.
+A BYOK test for each keyed provider asserts the API key is carried only
+via the constructor, never read from the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from bricks.providers.anthropic import AnthropicProvider
+from bricks.providers.ollama import OllamaProvider
+from bricks.providers.openai import OpenAIProvider
+
+# ── Anthropic ────────────────────────────────────────────────────────────────
+
+
+def _fake_anthropic_message(text: str = "hi", model: str = "claude-haiku-4-5") -> Any:
+    """Build a stand-in for anthropic.types.Message."""
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="text", text=text)],
+        model=model,
+        usage=SimpleNamespace(
+            input_tokens=10,
+            output_tokens=5,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+        ),
+    )
+
+
+def test_anthropic_requires_api_key() -> None:
+    with pytest.raises(ValueError, match="BYOK"):
+        AnthropicProvider(model="claude-haiku-4-5", api_key="")
+
+
+def test_anthropic_complete_maps_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeMessages:
+        def create(self, **kwargs: Any) -> Any:
+            captured["messages_kwargs"] = kwargs
+            return _fake_anthropic_message("hello there")
+
+    class FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["client_kwargs"] = kwargs
+            self.messages = FakeMessages()
+
+    fake_anthropic = SimpleNamespace(Anthropic=FakeClient, NOT_GIVEN=object())
+    monkeypatch.setitem(__import__("sys").modules, "anthropic", fake_anthropic)
+
+    provider = AnthropicProvider(model="claude-haiku-4-5", api_key="sk-test-xxx")
+    result = provider.complete("say hi", system="only say hi")
+
+    assert result.text == "hello there"
+    assert result.input_tokens == 10
+    assert result.output_tokens == 5
+    assert result.model == "claude-haiku-4-5"
+    assert result.estimated is False
+    assert captured["client_kwargs"]["api_key"] == "sk-test-xxx"
+
+
+def test_anthropic_ignores_env_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BYOK: the provider never reads ANTHROPIC_API_KEY from the environment."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "env-leaked-key")
+
+    captured: dict[str, Any] = {}
+
+    class FakeMessages:
+        def create(self, **kwargs: Any) -> Any:
+            return _fake_anthropic_message()
+
+    class FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["client_kwargs"] = kwargs
+            self.messages = FakeMessages()
+
+    fake_anthropic = SimpleNamespace(Anthropic=FakeClient, NOT_GIVEN=object())
+    monkeypatch.setitem(__import__("sys").modules, "anthropic", fake_anthropic)
+
+    provider = AnthropicProvider(model="claude-haiku-4-5", api_key="sk-byok-xxx")
+    provider.complete("hi")
+
+    assert captured["client_kwargs"]["api_key"] == "sk-byok-xxx"
+    assert captured["client_kwargs"]["api_key"] != os.environ["ANTHROPIC_API_KEY"]
+
+
+# ── OpenAI ───────────────────────────────────────────────────────────────────
+
+
+def _fake_openai_response(text: str = "hi") -> Any:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))],
+        model="gpt-4o-mini",
+        usage=SimpleNamespace(
+            prompt_tokens=8,
+            completion_tokens=4,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=2),
+        ),
+    )
+
+
+def test_openai_requires_api_key() -> None:
+    with pytest.raises(ValueError, match="BYOK"):
+        OpenAIProvider(model="gpt-4o-mini", api_key="")
+
+
+def test_openai_complete_maps_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            captured["kwargs"] = kwargs
+            return _fake_openai_response("openai says hi")
+
+    class FakeChat:
+        def __init__(self) -> None:
+            self.completions = FakeCompletions()
+
+    class FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["client_kwargs"] = kwargs
+            self.chat = FakeChat()
+
+    fake_openai = SimpleNamespace(OpenAI=FakeClient)
+    monkeypatch.setitem(__import__("sys").modules, "openai", fake_openai)
+
+    provider = OpenAIProvider(model="gpt-4o-mini", api_key="sk-open-xxx")
+    result = provider.complete("hi", system="terse")
+
+    assert result.text == "openai says hi"
+    assert result.input_tokens == 8
+    assert result.output_tokens == 4
+    assert result.cached_input_tokens == 2
+    assert result.model == "gpt-4o-mini"
+    assert captured["client_kwargs"]["api_key"] == "sk-open-xxx"
+    assert captured["kwargs"]["messages"][0] == {"role": "system", "content": "terse"}
+    assert captured["kwargs"]["messages"][1] == {"role": "user", "content": "hi"}
+
+
+def test_openai_ignores_env_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BYOK: the provider never reads OPENAI_API_KEY from the environment."""
+    monkeypatch.setenv("OPENAI_API_KEY", "env-leaked-key")
+
+    captured: dict[str, Any] = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs: Any) -> Any:
+            return _fake_openai_response()
+
+    class FakeChat:
+        def __init__(self) -> None:
+            self.completions = FakeCompletions()
+
+    class FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["client_kwargs"] = kwargs
+            self.chat = FakeChat()
+
+    fake_openai = SimpleNamespace(OpenAI=FakeClient)
+    monkeypatch.setitem(__import__("sys").modules, "openai", fake_openai)
+
+    provider = OpenAIProvider(model="gpt-4o-mini", api_key="sk-byok-xxx")
+    provider.complete("hi")
+
+    assert captured["client_kwargs"]["api_key"] == "sk-byok-xxx"
+    assert captured["client_kwargs"]["api_key"] != os.environ["OPENAI_API_KEY"]
+
+
+# ── Ollama ───────────────────────────────────────────────────────────────────
+
+
+def test_ollama_complete_parses_response() -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(url: str, **kwargs: Any) -> Any:
+        captured["url"] = url
+        captured["json"] = kwargs.get("json")
+        return SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: {
+                "response": "ollama says hi",
+                "model": "llama3",
+                "prompt_eval_count": 12,
+                "eval_count": 3,
+            },
+        )
+
+    with patch("httpx.post", fake_post):
+        provider = OllamaProvider(model="llama3")
+        result = provider.complete("hi", system="terse")
+
+    assert result.text == "ollama says hi"
+    assert result.input_tokens == 12
+    assert result.output_tokens == 3
+    assert result.model == "llama3"
+    assert captured["url"] == "http://localhost:11434/api/generate"
+    assert captured["json"]["model"] == "llama3"
+    assert captured["json"]["prompt"] == "hi"
+    assert captured["json"]["system"] == "terse"
+    assert captured["json"]["stream"] is False
+
+
+def test_ollama_connect_error_is_helpful() -> None:
+    import httpx
+
+    def fake_post(*_args: Any, **_kwargs: Any) -> Any:
+        raise httpx.ConnectError("cannot connect")
+
+    with patch("httpx.post", fake_post):
+        provider = OllamaProvider(model="llama3")
+        with pytest.raises(RuntimeError, match="ollama serve"):
+            provider.complete("hi")
+
+
+# ── Claude Code adapter (reuses bricks.providers.claudecode from #47) ────────
+
+
+def test_claudecode_via_build_provider() -> None:
+    """routes._build_provider('claude_code', ...) returns the existing provider."""
+    from bricks.playground.web.routes import _build_provider
+    from bricks.providers.claudecode import ClaudeCodeProvider
+
+    p = _build_provider("claude_code", "haiku", None)
+    assert isinstance(p, ClaudeCodeProvider)
+    assert p.model == "haiku"
+
+
+def test_claudecode_subprocess_mocked() -> None:
+    """Smoke: the underlying #47 provider still parses JSON output via subprocess."""
+    import json as jsonlib
+
+    from bricks.providers.claudecode import ClaudeCodeProvider
+
+    sample = {
+        "is_error": False,
+        "result": "hello",
+        "total_cost_usd": 0.01,
+        "usage": {
+            "input_tokens": 5,
+            "output_tokens": 2,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+        },
+        "modelUsage": {"claude-haiku-4-5": {}},
+    }
+    fake = subprocess.CompletedProcess(args=["claude"], returncode=0, stdout=jsonlib.dumps(sample), stderr="")
+    with patch("bricks.providers.claudecode.provider.subprocess.run", return_value=fake):
+        provider = ClaudeCodeProvider()
+        result = provider.complete("hi")
+    assert result.text == "hello"
+    assert result.cost_usd == 0.01
+    assert result.model == "claude-haiku-4-5"


### PR DESCRIPTION
Closes #44. Fourth PR of the Playground v0.5.0 stack (#41 ✓, #42 ✓, #43 ✓).

## Summary
- Adds three new `LLMProvider` adapters:
  - `bricks.providers.anthropic.AnthropicProvider` — Anthropic SDK Messages API; captures input/output/cache tokens; constructor-only `api_key`
  - `bricks.providers.openai.OpenAIProvider` — OpenAI SDK Chat Completions; captures `cached_tokens` from `prompt_tokens_details`; constructor-only `api_key`
  - `bricks.providers.ollama.OllamaProvider` — `httpx` POST to `localhost:11434/api/generate` with `stream=false`; friendly error pointing at `ollama serve` when `ConnectError` fires
- Claude Code continues to use the enhanced `bricks.providers.claudecode` from #47 (real cost + JSON + cache) — this PR **wraps, not re-implements**.
- `routes._build_provider` now dispatches all four. BYOK still enforced (400 without key for anthropic/openai).
- Deps: `anthropic>=0.40`, `openai>=1.0`, `httpx>=0.27` added under the `playground` / `all` extras (SDK-direct, not routed through the compromised-latest-litellm path).

## BYOK hardening
Two explicit env-leak tests: each monkeypatches `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` to a sentinel, calls the provider, and asserts the SDK client was constructed with the BYOK key — **not** the environment value.

## Test plan
- [x] `pytest tests/playground -v` — 24/24 passing (11 new provider tests + existing endpoint/static)
- [x] Full suite: 1192 passed, 18 skipped
- [x] `ruff check` + `ruff format --check` + `mypy src` clean
- [x] `cog --check README.md` clean
- [ ] CI 3.10 / 3.11 / 3.12 + lint + links green

🤖 Generated with [Claude Code](https://claude.com/claude-code)