### PR TITLE
docs(playground): README + AGENTS + CHANGELOG polish for v0.5.0 (#46)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,13 +17,13 @@ Test one:        pytest tests/path/to/test_x.py::test_name
 Lint:            ruff check . && ruff format --check .
 Typecheck:       mypy src/bricks
 Run CLI:         bricks --help
-Run benchmark:   bricks-bench
+Run Playground:  bricks playground  (local web UI at http://localhost:8080)
 
 ## Architecture
 - `src/bricks/core/` — engine, context, DSL pipeline
 - `src/bricks/stdlib/` — standard bricks (text, data, logic)
-- `src/bricks/benchmark/` — benchmark suite + web GUI
-- `src/bricks/providers/` — LLM provider adapters
+- `src/bricks/playground/` — web GUI, benchmark runner, FastAPI backend
+- `src/bricks/providers/` — LLM provider adapters (claudecode, anthropic, openai, ollama)
 See docs/architecture.md for detail.
 
 ## Conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased] — Playground v0.5.0 (2026-04-21)
+
+### Added
+- **`bricks playground` CLI** — one-liner local web UI at `http://localhost:8080` with free-port probe, `--host`, `--no-browser`, `--force-port`. Ctrl+C shuts down cleanly.
+- **Playground web UI** — v2 mockup shipped into `src/bricks/playground/web/static/index.html`. Scenario picker, task + data panes, drag-drop CSV/JSON upload, compare-to-raw-LLM toggle.
+- **FastAPI endpoints** under `/playground` (design.md §6):
+  - `GET  /playground/scenarios`          — preset list
+  - `GET  /playground/scenarios/{id}`     — full scenario body
+  - `POST /playground/upload`             — CSV / JSON (5 MB cap)
+  - `POST /playground/run`                — RunRequest → RunResponse, compare toggle honoured
+- **Four provider adapters** (all BYOK — keys live in the request body, never env):
+  - `bricks.providers.anthropic.AnthropicProvider`  — Anthropic SDK
+  - `bricks.providers.openai.OpenAIProvider`        — OpenAI SDK
+  - `bricks.providers.ollama.OllamaProvider`        — `httpx` → localhost:11434
+  - `bricks.providers.claudecode.ClaudeCodeProvider` — enhanced in #47 (real cost + JSON + cache counters)
+- **`cost_usd`** on `CompletionResult` — real dollar cost when the provider reports it (currently Claude Code; others landing in follow-ups).
+- `python-multipart`, `anthropic>=0.40`, `openai>=1.0`, `httpx>=0.27` deps under the `playground` / `all` extras.
+
+### Changed
+- **`src/bricks/benchmark/` → `src/bricks/playground/`** (`git mv`, preserves history). 120 `bricks.benchmark.*` imports rewritten across 40 files.
+- `[project.optional-dependencies].benchmark` → `playground`. `testpaths` and ruff per-file-ignore updated accordingly.
+- CI matrix installs the renamed extra on 3.10 / 3.11 / 3.12.
+
+### Removed
+- Legacy `/api/{run,datasets,bricks,presets}` routes. The v2 UI talks exclusively to `/playground/*`.
+
+---
+
 ## [0.5.9] — 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,14 +10,25 @@ Bricks is a deterministic execution engine for AI agents. Your LLM writes a YAML
 
 ---
 
-## Prove It — 30 Seconds
+## Try it in 30 seconds — `bricks playground`
+
+```bash
+pip install -e ".[playground]"
+bricks playground
+# ✓ Bricks Playground running → http://localhost:8080
+#   (browser opened · Ctrl+C to stop)
+```
+
+The Playground is a local web UI that runs your task through Bricks against embedded scenarios (CRM, tickets, orders) or your own CSV/JSON upload. BYOK for Anthropic / OpenAI; local Claude Code and Ollama need no key.
+
+## Prove It — 30 Seconds (CLI)
 
 ```bash
 git clone https://github.com/hemipaska-maker/bricks-ai.git
 cd bricks
 pip install -e ".[stdlib,ai]"
 export ANTHROPIC_API_KEY=sk-ant-...       # or any supported LLM — see below
-python -m bricks_benchmark.showcase.run --live --scenario CRM-pipeline
+python -m bricks.playground.showcase.run --live --scenario CRM-pipeline
 ```
 
 Here's what you'll see — real results tested across three Claude models:
@@ -41,21 +52,21 @@ Bricks works with any model. Blueprints are model-agnostic — compose with one 
 ```bash
 # Anthropic (default)
 export ANTHROPIC_API_KEY=sk-ant-...
-python -m bricks_benchmark.showcase.run --live --scenario CRM-pipeline
+python -m bricks.playground.showcase.run --live --scenario CRM-pipeline
 
 # OpenAI
 export OPENAI_API_KEY=sk-...
-python -m bricks_benchmark.showcase.run --live --scenario CRM-pipeline --model gpt-4o-mini
+python -m bricks.playground.showcase.run --live --scenario CRM-pipeline --model gpt-4o-mini
 
 # Google Gemini
 export GOOGLE_API_KEY=AIza...
-python -m bricks_benchmark.showcase.run --live --scenario CRM-pipeline --model gemini/gemini-2.0-flash
+python -m bricks.playground.showcase.run --live --scenario CRM-pipeline --model gemini/gemini-2.0-flash
 
 # Local with Ollama (free, no API key)
-python -m bricks_benchmark.showcase.run --live --scenario CRM-pipeline --model ollama/llama3
+python -m bricks.playground.showcase.run --live --scenario CRM-pipeline --model ollama/llama3
 
 # Claude Code Max plan ($0)
-python -m bricks_benchmark.showcase.run --live --scenario CRM-pipeline --model claudecode
+python -m bricks.playground.showcase.run --live --scenario CRM-pipeline --model claudecode
 ```
 
 ---
@@ -407,9 +418,9 @@ Three acts: compose a blueprint, execute it on CRM data, compare Bricks vs raw L
 Run the full benchmark suite:
 
 ```bash
-python -m bricks_benchmark.showcase.run --live                         # all scenarios
-python -m bricks_benchmark.showcase.run --live --scenario CRM-pipeline # single scenario
-python -m bricks_benchmark.showcase.run --live --scenario TICKET-pipeline  # support tickets
+python -m bricks.playground.showcase.run --live                         # all scenarios
+python -m bricks.playground.showcase.run --live --scenario CRM-pipeline # single scenario
+python -m bricks.playground.showcase.run --live --scenario TICKET-pipeline  # support tickets
 ```
 
 | Scenario | What it proves | Bricks | Raw LLM |

--- a/src/bricks/playground/run_benchmark.py
+++ b/src/bricks/playground/run_benchmark.py
@@ -1,10 +1,10 @@
 """Main entry point: run the Bricks vs Python benchmark.
 
 Usage:
-    python -m benchmark.run_benchmark              # demo mode
-    python -m benchmark.run_benchmark --live       # live mode (real API)
-    python -m benchmark.run_benchmark --verbose    # show YAML/Python code
-    python -m benchmark.run_benchmark --scenario 3 # one scenario only
+    python -m bricks.playground.run_benchmark              # demo mode
+    python -m bricks.playground.run_benchmark --live       # live mode (real API)
+    python -m bricks.playground.run_benchmark --verbose    # show YAML/Python code
+    python -m bricks.playground.run_benchmark --scenario 3 # one scenario only
 """
 
 from __future__ import annotations

--- a/src/bricks/playground/web/__init__.py
+++ b/src/bricks/playground/web/__init__.py
@@ -1,4 +1,4 @@
-"""Bricks Benchmark web module — FastAPI backend for the interactive benchmark GUI."""
+"""Bricks Playground web module — FastAPI backend for the interactive benchmark GUI."""
 
 from __future__ import annotations
 

--- a/src/bricks/playground/web/__main__.py
+++ b/src/bricks/playground/web/__main__.py
@@ -1,4 +1,4 @@
-"""Entry point for the Bricks Benchmark web server.
+"""Entry point for the Bricks Playground web server.
 
 Run with:
     python -m bricks.playground.web

--- a/src/bricks/playground/web/app.py
+++ b/src/bricks/playground/web/app.py
@@ -1,4 +1,4 @@
-"""FastAPI application for the Bricks Benchmark web server."""
+"""FastAPI application for the Bricks Playground web server."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from bricks.playground.web.routes import router
 _STATIC_DIR = Path(__file__).parent / "static"
 _INDEX_HTML = _STATIC_DIR / "index.html"
 
-app = FastAPI(title="Bricks Benchmark", version="0.1.0")
+app = FastAPI(title="Bricks Playground", version="0.1.0")
 app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
 app.include_router(router)
 

--- a/src/bricks/playground/web/datasets.py
+++ b/src/bricks/playground/web/datasets.py
@@ -1,4 +1,4 @@
-"""Dataset loader for the Bricks Benchmark web API.
+"""Dataset loader for the Bricks Playground web API.
 
 Loads built-in datasets from the ``web/datasets/`` directory and serves them
 via the ``/api/datasets`` endpoint.

--- a/src/bricks/playground/web/scenario_format.py
+++ b/src/bricks/playground/web/scenario_format.py
@@ -1,4 +1,4 @@
-"""Portable YAML scenario format for Bricks Benchmark.
+"""Portable YAML scenario format for Bricks Playground.
 
 A ScenarioDefinition describes a complete benchmark task in a single file:
 what data to use, what to compute, and optionally what to expect.


### PR DESCRIPTION
Closes #46. **Final** PR of the Playground v0.5.0 stack (#41 ✓ #42 ✓ #43 ✓ #44 ✓ #45 ✓).

## What landed
- **README.md** — new top section "Try it in 30 seconds — `bricks playground`" makes the one-liner the primary onboarding flow. Kept the showcase CLI section as "Prove It — 30 Seconds (CLI)". Fixed stale `bricks_benchmark.showcase.run` paths → `bricks.playground.showcase.run`. cog regen of the CLI help block.
- **AGENTS.md** — "Run Playground: `bricks playground`" replaces the retired `bricks-bench` stub. Architecture bullet updated to `src/bricks/playground/` with providers listed out.
- **CHANGELOG.md** — new Unreleased entry covering all six PRs: CLI, UI drop-in, endpoints, provider adapters, compare toggle, rename.
- Stale-ref sweep: `run_benchmark.py` usage block fixed to `python -m bricks.playground.run_benchmark`; web docstrings say "Bricks Playground web server" (not "Benchmark").

## Out of scope (deliberate)
The words `benchmark` / `benchmarking` remain in `showcase/` — those describe the *methodology* (MLPerf / HELM style) and are not stale module references. The acceptance criterion in design.md §11 is "no stale references", not "zero occurrences".

## Test plan
- [x] `pytest` — 1205 passed, 18 skipped
- [x] `ruff check` / `ruff format --check` / `mypy src` clean
- [x] `cog --check README.md` clean (regenerated)
- [ ] CI matrix 3.10 / 3.11 / 3.12 + lint + links
- [ ] Manual provider smoke (user-side, requires real keys / local Ollama): Anthropic key in `bricks playground`, Claude Code, Ollama server, OpenAI key — each clicks "Run" and sees real results in the comparison table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)