### PR TITLE
fix(core): attribute for_each/branch inner failures to the real brick (#34)

### DIFF
--- a/src/bricks/core/builtins.py
+++ b/src/bricks/core/builtins.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+from bricks.core.exceptions import BrickExecutionError
 from bricks.core.models import BrickMeta
 from bricks.core.registry import BrickRegistry
 
@@ -45,12 +46,27 @@ def _for_each_impl(
     for i, item in enumerate(items):
         try:
             result = callable_(item=item)
-            results.append(result)
-        except Exception as exc:
+        except BrickExecutionError:
+            # Already attributed (e.g. nested for_each). Preserve it.
             if on_error != "collect":
                 raise
-            errors.append({"index": i, "error": str(exc), "item": item})
+            errors.append({"index": i, "error": f"{do_brick}: propagated", "item": item})
             results.append(None)
+            continue
+        except Exception as exc:
+            # Attribute the failure to the real inner brick so healers,
+            # logs, and traceback consumers see ``do_brick`` — not the
+            # ``__for_each__`` wrapper. See issue #34.
+            if on_error != "collect":
+                raise BrickExecutionError(
+                    brick_name=do_brick,
+                    step_name=f"{do_brick}[item_{i}]",
+                    cause=exc,
+                ) from exc
+            errors.append({"index": i, "error": f"{do_brick}: {exc}", "item": item})
+            results.append(None)
+            continue
+        results.append(result)
 
     output: dict[str, Any] = {"results": results}
     if on_error == "collect":
@@ -83,17 +99,28 @@ def _branch_impl(
     if registry is None:
         raise ValueError("__branch__ requires a registry parameter.")
 
-    condition_fn, _ = registry.get(condition_brick)
-    raw = condition_fn(input=condition_input)
+    def _invoke(brick: str, position: str) -> Any:
+        """Invoke ``brick`` and attribute any failure to it (issue #34)."""
+        fn, _ = registry.get(brick)
+        try:
+            return fn(input=condition_input)
+        except BrickExecutionError:
+            raise  # already attributed
+        except Exception as exc:
+            raise BrickExecutionError(
+                brick_name=brick,
+                step_name=f"{brick}[{position}]",
+                cause=exc,
+            ) from exc
+
+    raw = _invoke(condition_brick, "condition")
     is_true = bool(raw.get("result", False) if isinstance(raw, dict) else raw)
 
     if is_true and if_true_brick:
-        target_fn, _ = registry.get(if_true_brick)
-        branch_result = target_fn(input=condition_input)
+        branch_result = _invoke(if_true_brick, "if_true")
         branch_taken = "true"
     elif if_false_brick:
-        target_fn, _ = registry.get(if_false_brick)
-        branch_result = target_fn(input=condition_input)
+        branch_result = _invoke(if_false_brick, "if_false")
         branch_taken = "false"
     else:
         branch_result = {}

--- a/src/bricks/core/engine.py
+++ b/src/bricks/core/engine.py
@@ -220,6 +220,14 @@ class BlueprintEngine:
         t0 = time.perf_counter()
         try:
             result = callable_(**resolved_params)
+        except BrickExecutionError as exc:
+            # Already attributed by an inner primitive (for_each / branch /
+            # sub-blueprint). Run teardown, then propagate unchanged so the
+            # real failing brick's name survives. See issue #34.
+            _call_teardown(callable_, resolved_params, meta, exc)
+            for prev_callable, prev_params, prev_meta in reversed(completed):
+                _call_teardown(prev_callable, prev_params, prev_meta, exc)
+            raise
         except Exception as exc:
             _call_teardown(callable_, resolved_params, meta, exc)
             for prev_callable, prev_params, prev_meta in reversed(completed):

--- a/tests/ai/test_healing.py
+++ b/tests/ai/test_healing.py
@@ -589,6 +589,43 @@ class TestParamNameHealer:
         result = healer.heal(ctx)
         assert result.produced_something is False
 
+    def test_heal_rewrites_for_each_inner_kwarg_post_issue_34_fix(self) -> None:
+        """Regression guard for issue #34.
+
+        Before the fix, ``BrickExecutionError.brick_name`` was ``"__for_each__"``,
+        so the healer looked up the wrapper's params (``items`` / ``do_brick``
+        / ``on_error``) instead of the real inner brick's and could not
+        propose a sane fix. After the fix the attribution points at the real
+        inner brick (``count_dict_list``), whose close-match swap
+        ``item`` → ``items`` is the correct repair.
+        """
+        dsl = (
+            "@flow\n"
+            "def count_batches(batches):\n"
+            "    return for_each(items=batches, do=lambda b: step.count_dict_list(item=b))\n"
+        )
+        ctx = HealContext(
+            task="count each batch",
+            failed_flow=_StubFlow(label="orig"),  # type: ignore[arg-type]
+            failed_dsl=dsl,
+            # brick_name is the real inner brick, as produced by the fixed
+            # __for_each__ builtin (not "__for_each__").
+            error=BrickExecutionError(
+                "count_dict_list",
+                "count_dict_list[item_0]",
+                TypeError("count_dict_list() got an unexpected keyword argument 'item'"),
+            ),
+            attempt=0,
+            prior_attempts=[],
+            registry=self._registry_with_count(),
+        )
+
+        result = ParamNameHealer().heal(ctx)
+
+        assert result.produced_something is True, "healer should propose a fix now that attribution is correct"
+        assert "items=b" in result.new_dsl
+        assert "item=b" not in result.new_dsl
+
 
 # --- DictUnwrapHealer (tier 15) ---------------------------------------------
 

--- a/tests/core/test_builtin_error_attribution.py
+++ b/tests/core/test_builtin_error_attribution.py
@@ -1,0 +1,229 @@
+"""Regression tests for issue #34 — ``BrickExecutionError.brick_name`` must
+point at the real failing inner brick when a `for_each`/`branch` primitive
+invokes it, not at the ``__for_each__`` / ``__branch__`` wrapper.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from bricks.core.builtins import register_builtins
+from bricks.core.engine import BlueprintEngine
+from bricks.core.exceptions import BrickExecutionError
+from bricks.core.models import BlueprintDefinition, BrickMeta, StepDefinition
+from bricks.core.registry import BrickRegistry
+
+# ── shared fixtures ──────────────────────────────────────────────────────────
+
+
+def _make_registry() -> BrickRegistry:
+    """Registry with builtins + a family of real/failing stdlib-style bricks."""
+    reg = BrickRegistry()
+    register_builtins(reg)
+
+    def is_email_valid(email: str) -> dict[str, Any]:
+        """Valid iff the string contains '@'. The signature deliberately takes
+        ``email`` (not ``item``) so a for_each with the wrong kwarg name will
+        fail with the exact repro TypeError from issue #34."""
+        return {"result": "@" in email}
+
+    reg.register("is_email_valid", is_email_valid, BrickMeta(name="is_email_valid", description="validate email"))
+
+    def boom_at_runtime(item: Any) -> dict[str, Any]:
+        """Accepts ``item`` but always raises at runtime."""
+        raise RuntimeError(f"boom: {item!r}")
+
+    reg.register("boom_at_runtime", boom_at_runtime, BrickMeta(name="boom_at_runtime", description="always fails"))
+
+    def always_true(input: Any) -> dict[str, Any]:
+        return {"result": True}
+
+    reg.register("always_true", always_true, BrickMeta(name="always_true", description="condition=True"))
+
+    def boom_condition(input: Any) -> dict[str, Any]:
+        raise RuntimeError("condition exploded")
+
+    reg.register("boom_condition", boom_condition, BrickMeta(name="boom_condition", description="failing condition"))
+
+    def boom_true_branch(input: Any) -> dict[str, Any]:
+        raise RuntimeError("if_true exploded")
+
+    reg.register("boom_true_branch", boom_true_branch, BrickMeta(name="boom_true_branch", description="failing true"))
+
+    def boom_false_branch(input: Any) -> dict[str, Any]:
+        raise RuntimeError("if_false exploded")
+
+    reg.register(
+        "boom_false_branch",
+        boom_false_branch,
+        BrickMeta(name="boom_false_branch", description="failing false"),
+    )
+
+    def plain_fail(x: int) -> dict[str, Any]:
+        raise ValueError("top-level brick failure")
+
+    reg.register("plain_fail", plain_fail, BrickMeta(name="plain_fail", description="regression guard"))
+
+    return reg
+
+
+@pytest.fixture(name="registry")
+def _registry_fixture() -> BrickRegistry:
+    return _make_registry()
+
+
+def _run_for_each(
+    engine: BlueprintEngine,
+    items: list[Any],
+    do_brick: str,
+    on_error: str = "fail",
+) -> dict[str, Any]:
+    bp = BlueprintDefinition(
+        name="for_each_test",
+        steps=[
+            StepDefinition(
+                name="loop",
+                brick="__for_each__",
+                params={"items": items, "do_brick": do_brick, "on_error": on_error},
+                save_as="loop_result",
+            )
+        ],
+        outputs_map={"result": "${loop_result}"},
+    )
+    return engine.run(bp).outputs
+
+
+def _run_branch(
+    engine: BlueprintEngine,
+    condition_brick: str,
+    if_true_brick: str = "",
+    if_false_brick: str = "",
+    condition_input: Any = 1,
+) -> dict[str, Any]:
+    bp = BlueprintDefinition(
+        name="branch_test",
+        steps=[
+            StepDefinition(
+                name="routing",
+                brick="__branch__",
+                params={
+                    "condition_brick": condition_brick,
+                    "condition_input": condition_input,
+                    "if_true_brick": if_true_brick,
+                    "if_false_brick": if_false_brick,
+                },
+                save_as="branch_result",
+            )
+        ],
+        outputs_map={"result": "${branch_result}"},
+    )
+    return engine.run(bp).outputs
+
+
+# ── for_each attribution ─────────────────────────────────────────────────────
+
+
+def test_for_each_wrong_kwarg_reports_real_inner_brick(registry: BrickRegistry) -> None:
+    """The repro from issue #34: inner brick expects ``email``, for_each
+    passes ``item=``. The engine surfaces ``brick_name="is_email_valid"``."""
+    engine = BlueprintEngine(registry=registry)
+    with pytest.raises(BrickExecutionError) as exc_info:
+        _run_for_each(engine, items=["a@b.com", "not-an-email"], do_brick="is_email_valid")
+
+    assert exc_info.value.brick_name == "is_email_valid"
+    assert exc_info.value.brick_name != "__for_each__"
+    # step_name carries the per-item suffix from the builtin, plus the engine
+    # keeps whichever step it raised in; the key invariant is brick_name.
+    assert "is_email_valid" in exc_info.value.step_name
+
+
+def test_for_each_inner_runtime_error_reports_real_inner_brick(registry: BrickRegistry) -> None:
+    engine = BlueprintEngine(registry=registry)
+    with pytest.raises(BrickExecutionError) as exc_info:
+        _run_for_each(engine, items=[1, 2], do_brick="boom_at_runtime")
+
+    assert exc_info.value.brick_name == "boom_at_runtime"
+
+
+def test_for_each_collect_mode_tags_errors_with_inner_name(registry: BrickRegistry) -> None:
+    """In ``on_error='collect'`` mode no exception propagates, but each
+    collected error string names the real inner brick so traces remain
+    attributable."""
+    engine = BlueprintEngine(registry=registry)
+    out = _run_for_each(engine, items=[1, 2], do_brick="boom_at_runtime", on_error="collect")
+
+    loop = out["result"]
+    assert len(loop["errors"]) == 2
+    for err in loop["errors"]:
+        assert err["error"].startswith("boom_at_runtime:"), err
+
+
+# ── branch attribution ──────────────────────────────────────────────────────
+
+
+def test_branch_failing_condition_reports_condition_brick(registry: BrickRegistry) -> None:
+    engine = BlueprintEngine(registry=registry)
+    with pytest.raises(BrickExecutionError) as exc_info:
+        _run_branch(engine, condition_brick="boom_condition", if_true_brick="always_true")
+
+    assert exc_info.value.brick_name == "boom_condition"
+
+
+def test_branch_failing_if_true_arm_reports_if_true_brick(registry: BrickRegistry) -> None:
+    engine = BlueprintEngine(registry=registry)
+    with pytest.raises(BrickExecutionError) as exc_info:
+        _run_branch(engine, condition_brick="always_true", if_true_brick="boom_true_branch")
+
+    assert exc_info.value.brick_name == "boom_true_branch"
+
+
+def test_branch_failing_if_false_arm_reports_if_false_brick(registry: BrickRegistry) -> None:
+    """condition_brick returns True only when input>0; passing 0 routes false."""
+
+    def always_false(input: Any) -> dict[str, Any]:
+        return {"result": False}
+
+    registry.register("always_false", always_false, BrickMeta(name="always_false", description="False"))
+    engine = BlueprintEngine(registry=registry)
+
+    with pytest.raises(BrickExecutionError) as exc_info:
+        _run_branch(engine, condition_brick="always_false", if_false_brick="boom_false_branch")
+
+    assert exc_info.value.brick_name == "boom_false_branch"
+
+
+# ── regression guards ──────────────────────────────────────────────────────
+
+
+def test_plain_brick_failure_still_attributes_correctly(registry: BrickRegistry) -> None:
+    """Top-level `step.X()` failures must still surface as ``brick_name="X"``
+    — the fix must not regress the non-for_each / non-branch path."""
+    engine = BlueprintEngine(registry=registry)
+    bp = BlueprintDefinition(
+        name="plain",
+        steps=[StepDefinition(name="s1", brick="plain_fail", params={"x": 1})],
+    )
+    with pytest.raises(BrickExecutionError) as exc_info:
+        engine.run(bp)
+
+    assert exc_info.value.brick_name == "plain_fail"
+    assert isinstance(exc_info.value.cause, ValueError)
+
+
+def test_no_double_wrapping_on_for_each_failure(registry: BrickRegistry) -> None:
+    """Exactly one ``BrickExecutionError`` in the cause chain — the outer
+    engine wrapper must not re-wrap the inner-wrapped exception."""
+    engine = BlueprintEngine(registry=registry)
+    with pytest.raises(BrickExecutionError) as exc_info:
+        _run_for_each(engine, items=[1], do_brick="boom_at_runtime")
+
+    # Walk the __cause__ chain and count BEEs.
+    count = 0
+    cur: BaseException | None = exc_info.value
+    while cur is not None:
+        if isinstance(cur, BrickExecutionError):
+            count += 1
+        cur = cur.__cause__
+    assert count == 1, f"expected exactly one BrickExecutionError in cause chain, got {count}"

--- a/tests/core/test_builtins.py
+++ b/tests/core/test_builtins.py
@@ -108,11 +108,17 @@ def test_for_each_executes_over_list() -> None:
 
 
 def test_for_each_fail_mode_stops_on_error() -> None:
-    """__for_each__ in fail mode raises on first error."""
+    """__for_each__ in fail mode raises on first error, attributed to the
+    real inner brick (issue #34) rather than to ``__for_each__``."""
+    from bricks.core.exceptions import BrickExecutionError
+
     reg = _make_registry()
     callable_, _ = reg.get("__for_each__")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(BrickExecutionError) as exc_info:
         callable_(items=[1, 2, 3], do_brick="fail_always", on_error="fail")
+
+    assert exc_info.value.brick_name == "fail_always"
+    assert isinstance(exc_info.value.cause, RuntimeError)
 
 
 def test_for_each_collect_mode_gathers_errors() -> None:


### PR DESCRIPTION
Closes #34.

## Problem
`BrickExecutionError.brick_name` from a failure inside a `for_each` loop body or a `branch` arm pointed at the `__for_each__` / `__branch__` wrapper primitive, not at the brick that actually blew up. Every downstream consumer that trusts `ctx.error.brick_name` — `ParamNameHealer`, `LLMRetryHealer`, `ShapeAwareLLMHealer`, developer logs — was misled. The live TICKET-pipeline repro after #27 burned four healer attempts on the wrong brick purely because of misattribution.

## Fix — two small, independent parts

**1.** [src/bricks/core/builtins.py](src/bricks/core/builtins.py) — `__for_each__` and `__branch__` now wrap each inner `callable_(...)`. Raw exceptions become `BrickExecutionError(brick_name=<inner>, step_name="<inner>[item_N]" / "[condition|if_true|if_false]")`. Already-attributed BEEs (nested for_each) pass through. `on_error="collect"` still does not raise, but each collected error string is prefixed with the inner brick name.

**2.** [src/bricks/core/engine.py](src/bricks/core/engine.py#L221-L231) — `_execute_brick_step` grows an `except BrickExecutionError: raise` arm before the catch-all. Mirrors `_execute_sub_blueprint_step`. Teardown still runs. Result: exactly one BEE in the cause chain, `brick_name` is always the real offender.

## Tests
- `tests/core/test_builtin_error_attribution.py` — 8 new: wrong-kwarg repro, runtime failures in both primitives, all three branch arms, collect-mode prefix assertion, plain-brick-failure regression guard, `__cause__` chain walk that asserts exactly one BEE.
- `tests/ai/test_healing.py` — 1 new: integration test showing `ParamNameHealer` now rewrites the inner kwarg (`item=` → `items=`) because the attribution is correct. The healer gives up before the fix.
- `tests/core/test_builtins.py` — updated `test_for_each_fail_mode_stops_on_error` to match the new `BrickExecutionError(brick_name="fail_always")` shape (was the raw `RuntimeError` that the wrapper used to let escape).

## Acceptance criteria (from the issue)
- [x] for_each reproducer asserts `brick_name` is the inner brick
- [x] branch reproducer for condition / if_true / if_false
- [x] existing `ParamNameHealer` tests still pass; new integration test proposes a fix
- [x] No double-wrapping — walk of `__cause__` shows exactly one BEE
- [x] No regression on top-level brick failures (plain `step.X()` still reports `brick_name="X"`)

## Test plan
- [x] `pytest` — 1214 passed, 18 skipped locally
- [x] `ruff check` / `ruff format --check` / `mypy src` clean
- [x] `cog --check README.md` clean
- [ ] CI matrix 3.10 / 3.11 / 3.12 + lint + links green

🤖 Generated with [Claude Code](https://claude.com/claude-code)