### PR TITLE
fix(playground): real-time wiring via pluggy hooks + SSE (#56)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ playground = [
     "anthropic>=0.40",
     "openai>=1.0",
     "httpx>=0.27",
+    "pluggy>=1.3",
 ]
 all = [
     "litellm>=1.0,<1.82.7",
@@ -55,6 +56,7 @@ all = [
     "anthropic>=0.40",
     "openai>=1.0",
     "httpx>=0.27",
+    "pluggy>=1.3",
 ]
 dev = [
     "pytest>=9.0",

--- a/src/bricks/ai/composer.py
+++ b/src/bricks/ai/composer.py
@@ -253,6 +253,7 @@ class BlueprintComposer:
         selector: BrickSelector | None = None,
         store: BlueprintStore | None = None,
         healers: list[Any] | None = None,
+        plugin_manager: Any | None = None,
     ) -> None:
         """Initialise the composer.
 
@@ -268,11 +269,15 @@ class BlueprintComposer:
                 to construct the LLM-backed tiers, so the default chain is
                 built lazily inside ``compose``. Pass ``[]`` to disable
                 healing entirely while still accepting an executor.
+            plugin_manager: Optional ``pluggy.PluginManager`` for lifecycle
+                hooks. Passed through to the HealerChain so tier attempts
+                are observable. When ``None`` no hooks fire.
         """
         self._provider = provider
         self._selector = selector or AllBricksSelector()
         self._store = store
         self._explicit_healers = healers
+        self._pm = plugin_manager
 
     def compose(
         self,
@@ -345,6 +350,9 @@ class BlueprintComposer:
             keys_str = ", ".join(input_keys)
             user_message = f"{task}\nThe function receives these parameters: {keys_str}."
 
+        if self._pm is not None:
+            self._pm.hook.compose_start(task=task)
+
         # First call
         detail = self._compose_call(1, system, user_message)
         calls.append(detail)
@@ -371,12 +379,20 @@ class BlueprintComposer:
             flow_def = self._parse_dsl_response(last.yaml_text)
             blueprint_yaml = flow_def.to_yaml()
             dsl_code = self._strip_fences(last.yaml_text)
+            if self._pm is not None:
+                self._pm.hook.compose_done(
+                    dsl=dsl_code,
+                    tokens_in=total_input,
+                    tokens_out=total_output,
+                )
 
         exec_outputs: dict[str, Any] | None = None
         exec_error = ""
         heal_attempts: list[Any] = []
 
         if executor is not None and last.is_valid and flow_def is not None:
+            if self._pm is not None:
+                self._pm.hook.execute_start(blueprint_yaml=blueprint_yaml)
             try:
                 exec_outputs = executor(flow_def)
             except BrickExecutionError as exc:
@@ -402,6 +418,8 @@ class BlueprintComposer:
                         dsl_code = chain_result.final_dsl
                 else:
                     exec_error = chain_result.final_error
+                    if self._pm is not None:
+                        self._pm.hook.run_failed(error=exec_error or "unknown runtime error")
 
         result = ComposeResult(
             task=task,
@@ -481,7 +499,7 @@ class BlueprintComposer:
             # Caller opted out of healing.
             return _EmptyChainResult(final_error=str(error))
 
-        chain = HealerChain(healers=healers, max_attempts=4)
+        chain = HealerChain(healers=healers, max_attempts=4, plugin_manager=self._pm)
         ctx = HealContext(
             task=task,
             failed_flow=flow_def,

--- a/src/bricks/ai/healing.py
+++ b/src/bricks/ai/healing.py
@@ -400,10 +400,21 @@ class HealerChain:
             cost predictable. Set higher for aggressive recovery.
     """
 
-    def __init__(self, healers: list[Healer], max_attempts: int = 2) -> None:
-        """Initialise the chain with a pool of healers."""
+    def __init__(
+        self,
+        healers: list[Healer],
+        max_attempts: int = 2,
+        plugin_manager: Any | None = None,
+    ) -> None:
+        """Initialise the chain with a pool of healers.
+
+        ``plugin_manager`` — optional ``pluggy.PluginManager``; when set the
+        chain fires ``heal_attempt`` for every tier that produces a flow
+        (succeeded or not). See :mod:`bricks.core.hooks`.
+        """
         self._healers: list[Healer] = sorted(healers, key=lambda h: h.tier)
         self._max_attempts = max_attempts
+        self._pm = plugin_manager
 
     @property
     def healers(self) -> list[Healer]:
@@ -477,6 +488,8 @@ class HealerChain:
                         tokens_out=result.tokens_out,
                     )
                 )
+                if self._pm is not None:
+                    self._pm.hook.heal_attempt(tier=healer.tier, healer_name=healer.name, succeeded=False)
                 # Swap in the new failure context for the next iteration.
                 ctx = HealContext(
                     task=ctx.task,
@@ -499,6 +512,8 @@ class HealerChain:
                     tokens_out=result.tokens_out,
                 )
             )
+            if self._pm is not None:
+                self._pm.hook.heal_attempt(tier=healer.tier, healer_name=healer.name, succeeded=True)
             return ChainResult(
                 success=True,
                 outputs=outputs,

--- a/src/bricks/core/engine.py
+++ b/src/bricks/core/engine.py
@@ -66,18 +66,27 @@ class BlueprintEngine:
 
     _MAX_DEPTH: int = 10
 
-    def __init__(self, registry: BrickRegistry, loader: Any | None = None) -> None:
+    def __init__(
+        self,
+        registry: BrickRegistry,
+        loader: Any | None = None,
+        plugin_manager: Any | None = None,
+    ) -> None:
         """Initialise the engine.
 
         Args:
             registry: The brick registry to use for step execution.
             loader: Optional BlueprintLoader. Defaults to a new BlueprintLoader instance.
+            plugin_manager: Optional ``pluggy.PluginManager`` for lifecycle
+                hooks (see :mod:`bricks.core.hooks`). When ``None`` no
+                hooks fire — production paths incur zero cost.
         """
         from bricks.core.loader import BlueprintLoader  # noqa: PLC0415 — avoid circular at module level
 
         self._registry = registry
         self._loader: BlueprintLoader = loader if loader is not None else BlueprintLoader()
         self._resolver = ReferenceResolver()
+        self._pm = plugin_manager
 
     def run(
         self,
@@ -217,6 +226,12 @@ class BlueprintEngine:
         brick_name: str = step.brick  # type: ignore[assignment]  # guaranteed non-None by caller
         callable_, meta = self._registry.get(brick_name)
 
+        # Fire step_start for top-level user bricks only. Internal wrapper
+        # primitives would flood the UI with per-iteration events; the outer
+        # wrapper step still emits its own start/done.
+        if self._pm is not None:
+            self._pm.hook.step_start(step_name=step.name, brick_name=brick_name)
+
         t0 = time.perf_counter()
         try:
             result = callable_(**resolved_params)
@@ -240,6 +255,13 @@ class BlueprintEngine:
 
         duration_ms = (time.perf_counter() - t0) * 1000
         completed.append((callable_, resolved_params, meta))
+
+        if self._pm is not None:
+            self._pm.hook.step_done(
+                step_name=step.name,
+                brick_name=brick_name,
+                duration_ms=int(duration_ms),
+            )
 
         step_result: StepResult | None = None
         if verbosity in (Verbosity.STANDARD, Verbosity.FULL):

--- a/src/bricks/core/hooks.py
+++ b/src/bricks/core/hooks.py
@@ -1,0 +1,80 @@
+"""Pluggy hook spec for Bricks execution lifecycle events.
+
+Callers (composer, healer chain, engine, showcase engines) fire hooks
+through a ``pluggy.PluginManager``. When no plugins are registered the
+calls are no-ops — production paths pay no runtime cost.
+
+Consumers that want live progress (e.g. the Playground SSE endpoint)
+register a plugin that implements any subset of these hooks. The
+PluginManager dispatches each call to every registered implementation.
+
+Namespace is ``"bricks"``; hooks are grouped into two logical families:
+
+- **compose/execute lifecycle**: ``compose_start``, ``compose_done``,
+  ``execute_start``, ``step_start``, ``step_done``, ``run_failed``.
+- **healing + checking**: ``heal_attempt``, ``raw_llm_start``,
+  ``raw_llm_done``, ``check_done``.
+
+All hook method signatures use keyword arguments per pluggy convention.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pluggy
+
+_NAMESPACE = "bricks"
+hookspec = pluggy.HookspecMarker(_NAMESPACE)
+hookimpl = pluggy.HookimplMarker(_NAMESPACE)
+
+
+class BricksHookSpec:
+    """Declared hooks for Bricks runtime events."""
+
+    @hookspec
+    def compose_start(self, task: str) -> None:
+        """Fires before the composer dispatches its first LLM call."""
+
+    @hookspec
+    def compose_done(self, dsl: str, tokens_in: int, tokens_out: int) -> None:
+        """Fires after the composer has a validated DSL response."""
+
+    @hookspec
+    def execute_start(self, blueprint_yaml: str) -> None:
+        """Fires after compose succeeds, before the engine runs the first step."""
+
+    @hookspec
+    def step_start(self, step_name: str, brick_name: str) -> None:
+        """Fires immediately before a brick step is invoked by the engine."""
+
+    @hookspec
+    def step_done(self, step_name: str, brick_name: str, duration_ms: int) -> None:
+        """Fires immediately after a brick step returns successfully."""
+
+    @hookspec
+    def heal_attempt(self, tier: int, healer_name: str, succeeded: bool) -> None:
+        """Fires once per tier the HealerChain attempts."""
+
+    @hookspec
+    def raw_llm_start(self) -> None:
+        """Fires before the Raw-LLM engine invokes the provider."""
+
+    @hookspec
+    def raw_llm_done(self, response: str, tokens_in: int, tokens_out: int) -> None:
+        """Fires after the Raw-LLM engine returns."""
+
+    @hookspec
+    def check_done(self, key: str, expected: Any, got: Any, passed: bool) -> None:
+        """Fires once per correctness-check key when comparing outputs."""
+
+    @hookspec
+    def run_failed(self, error: str) -> None:
+        """Fires when the full compose→execute→heal path exhausts without success."""
+
+
+def get_plugin_manager() -> pluggy.PluginManager:
+    """Return a fresh PluginManager with the BricksHookSpec registered."""
+    pm = pluggy.PluginManager(_NAMESPACE)
+    pm.add_hookspecs(BricksHookSpec)
+    return pm

--- a/src/bricks/playground/showcase/engine.py
+++ b/src/bricks/playground/showcase/engine.py
@@ -113,11 +113,14 @@ class BricksEngine(Engine):
     The LLM only sees brick signatures during compose, not the raw data.
     """
 
-    def __init__(self, provider: Any) -> None:
+    def __init__(self, provider: Any, plugin_manager: Any | None = None) -> None:
         """Initialise with an LLMProvider.
 
         Args:
             provider: Any LLMProvider instance (LiteLLMProvider or ClaudeCodeProvider).
+            plugin_manager: Optional ``pluggy.PluginManager`` threaded into
+                composer + engine for lifecycle hooks. See
+                :mod:`bricks.core.hooks`. When ``None`` no hooks fire.
         """
         from bricks.ai.composer import BlueprintComposer
         from bricks.core.builtins import register_builtins
@@ -126,13 +129,14 @@ class BricksEngine(Engine):
         from bricks.core.registry import BrickRegistry
         from bricks.stdlib import register as _register_stdlib
 
-        self._composer = BlueprintComposer(provider=provider)
+        self._pm = plugin_manager
+        self._composer = BlueprintComposer(provider=provider, plugin_manager=plugin_manager)
         self._loader = BlueprintLoader()
         registry = BrickRegistry()
         _register_stdlib(registry)
         register_builtins(registry)
         self._registry = registry
-        self._engine = BlueprintEngine(registry=registry)
+        self._engine = BlueprintEngine(registry=registry, plugin_manager=plugin_manager)
 
     def solve(self, task_text: str, raw_data: str) -> EngineResult:
         """Compose blueprint from task_text, execute it with raw_data.
@@ -280,13 +284,16 @@ class RawLLMEngine(Engine):
         "No code, no explanation, no markdown fences — just raw JSON."
     )
 
-    def __init__(self, provider: Any) -> None:
+    def __init__(self, provider: Any, plugin_manager: Any | None = None) -> None:
         """Initialise with an LLMProvider.
 
         Args:
             provider: Any LLMProvider instance.
+            plugin_manager: Optional ``pluggy.PluginManager`` for the
+                ``raw_llm_start`` / ``raw_llm_done`` hooks.
         """
         self._provider = provider
+        self._pm = plugin_manager
 
     def solve(self, task_text: str, raw_data: str) -> EngineResult:
         """Send task + raw_data to LLM, parse JSON response.
@@ -305,9 +312,19 @@ class RawLLMEngine(Engine):
             "Compute the exact values. Return ONLY a JSON object."
         )
 
+        if self._pm is not None:
+            self._pm.hook.raw_llm_start()
+
         t0 = time.monotonic()
         completion = self._provider.complete(prompt, system=self._SYSTEM)
         duration = time.monotonic() - t0
+
+        if self._pm is not None:
+            self._pm.hook.raw_llm_done(
+                response=completion.text,
+                tokens_in=completion.input_tokens,
+                tokens_out=completion.output_tokens,
+            )
 
         raw_text = completion.text.strip()
         logger.debug("[RawLLMEngine] Raw response: %s", raw_text)

--- a/src/bricks/playground/web/routes.py
+++ b/src/bricks/playground/web/routes.py
@@ -5,6 +5,8 @@ All routes live under the ``/playground`` prefix per design.md §6.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import csv
 import io
 import json
@@ -15,8 +17,10 @@ from typing import Any
 
 import yaml  # type: ignore[import-untyped]
 from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi.responses import StreamingResponse
 
 from bricks import __version__ as _bricks_version
+from bricks.core.hooks import hookimpl as _hookimpl
 from bricks.llm.base import LLMProvider
 from bricks.playground.web.schemas import (
     EngineResult,
@@ -292,3 +296,172 @@ async def run_playground(req: RunRequest) -> RunResponse:
         raw_llm=raw_llm_result,
         run_metadata=metadata,
     )
+
+
+# ── POST /playground/run-stream (SSE) ────────────────────────────────────────
+
+
+class _HookStreamer:
+    """Pluggy plugin that pushes each hook call onto an ``asyncio.Queue``.
+
+    One plugin instance is registered per ``/playground/run-stream`` request.
+    Hooks fire on the worker thread running ``BricksEngine.solve``; the
+    plugin uses ``loop.call_soon_threadsafe`` to enqueue frames onto the
+    event loop's queue so the SSE generator can pick them up without
+    blocking the worker.
+    """
+
+    def __init__(self, queue: asyncio.Queue[Any], loop: asyncio.AbstractEventLoop) -> None:
+        self._queue = queue
+        self._loop = loop
+
+    def _push(self, phase: str, **payload: Any) -> None:
+        frame = {"phase": phase, **payload}
+        self._loop.call_soon_threadsafe(self._queue.put_nowait, frame)
+
+    # Each hookimpl mirrors a BricksHookSpec method.
+
+    @_hookimpl
+    def compose_start(self, task: str) -> None:
+        # Trim the task to keep the frame light.
+        self._push("compose_start", task=task[:200])
+
+    @_hookimpl
+    def compose_done(self, dsl: str, tokens_in: int, tokens_out: int) -> None:
+        self._push("compose_done", tokens_in=tokens_in, tokens_out=tokens_out)
+
+    @_hookimpl
+    def execute_start(self, blueprint_yaml: str) -> None:
+        self._push("execute_start")
+
+    @_hookimpl
+    def step_start(self, step_name: str, brick_name: str) -> None:
+        self._push("step_start", step_name=step_name, brick_name=brick_name)
+
+    @_hookimpl
+    def step_done(self, step_name: str, brick_name: str, duration_ms: int) -> None:
+        self._push("step_done", step_name=step_name, brick_name=brick_name, duration_ms=duration_ms)
+
+    @_hookimpl
+    def heal_attempt(self, tier: int, healer_name: str, succeeded: bool) -> None:
+        self._push("heal_attempt", tier=tier, healer_name=healer_name, succeeded=succeeded)
+
+    @_hookimpl
+    def raw_llm_start(self) -> None:
+        self._push("raw_llm_start")
+
+    @_hookimpl
+    def raw_llm_done(self, response: str, tokens_in: int, tokens_out: int) -> None:
+        self._push("raw_llm_done", tokens_in=tokens_in, tokens_out=tokens_out)
+
+    @_hookimpl
+    def check_done(self, key: str, expected: Any, got: Any, passed: bool) -> None:
+        self._push("check_done", key=key, expected=expected, got=got, passed=passed)
+
+    @_hookimpl
+    def run_failed(self, error: str) -> None:
+        self._push("run_failed", error=error)
+
+
+def _sse_frame(event: str | None, data: Any) -> str:
+    """Format ``data`` as an SSE frame, optionally with an ``event:`` line."""
+    payload = json.dumps(data, default=str)
+    if event:
+        return f"event: {event}\ndata: {payload}\n\n"
+    return f"data: {payload}\n\n"
+
+
+@router.post("/run-stream")
+async def run_playground_stream(req: RunRequest) -> StreamingResponse:
+    """SSE variant of ``/playground/run`` — streams lifecycle events.
+
+    Frames:
+
+    - ``data: {"phase": "<name>", ...}\\n\\n`` — one per hook call.
+    - ``event: done\\ndata: {...RunResponse...}\\n\\n`` — final result.
+    - ``event: error\\ndata: {"message": "..."}\\n\\n`` — on failure.
+
+    The existing non-streaming ``/playground/run`` endpoint is untouched
+    and still the right choice for programmatic callers.
+    """
+    from bricks.core.hooks import get_plugin_manager
+    from bricks.playground.showcase.engine import BricksEngine, RawLLMEngine
+
+    provider = _build_provider(req.provider, req.model, req.api_key)
+    raw_data = req.data if isinstance(req.data, str) else json.dumps(req.data)
+    fenced = raw_data if raw_data.strip().startswith("```") else f"```json\n{raw_data}\n```"
+
+    loop = asyncio.get_running_loop()
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+    pm = get_plugin_manager()
+    pm.register(_HookStreamer(queue, loop))
+
+    sentinel_done = object()
+    sentinel_err = object()
+    err_holder: list[BaseException] = []
+    result_holder: dict[str, Any] = {}
+
+    def _run_in_thread() -> None:
+        try:
+            t0 = time.monotonic()
+            bricks_raw = BricksEngine(provider=provider, plugin_manager=pm).solve(req.task, fenced)
+            bricks_ms = int((time.monotonic() - t0) * 1000)
+
+            raw_llm_result: EngineResult | None = None
+            if req.compare:
+                t_raw = time.monotonic()
+                raw_raw = RawLLMEngine(provider=provider, plugin_manager=pm).solve(req.task, fenced)
+                raw_ms = int((time.monotonic() - t_raw) * 1000)
+                raw_llm_result = _engine_result(raw_raw, raw_ms, req.expected_output, is_raw=True)
+
+            bricks_result = _engine_result(bricks_raw, bricks_ms, req.expected_output, is_raw=False)
+
+            # Fire check_done for each key so the SSE stream carries per-check
+            # events even though checks are computed after execute returns.
+            for check in bricks_result.checks:
+                pm.hook.check_done(
+                    key=check.key,
+                    expected=check.expected,
+                    got=check.got,
+                    passed=check.pass_,
+                )
+
+            metadata = RunMetadata(
+                model=bricks_raw.model or req.model,
+                provider=req.provider,
+                version=_bricks_version,
+                timestamp=datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+            )
+            response = RunResponse(
+                bricks=bricks_result,
+                raw_llm=raw_llm_result,
+                run_metadata=metadata,
+            )
+            result_holder["response"] = response.model_dump(exclude_none=True, by_alias=True)
+            loop.call_soon_threadsafe(queue.put_nowait, sentinel_done)
+        except Exception as exc:
+            err_holder.append(exc)
+            loop.call_soon_threadsafe(queue.put_nowait, sentinel_err)
+
+    worker = asyncio.create_task(asyncio.to_thread(_run_in_thread))
+
+    async def _generator() -> Any:
+        try:
+            while True:
+                item = await queue.get()
+                if item is sentinel_done:
+                    yield _sse_frame("done", result_holder["response"])
+                    return
+                if item is sentinel_err:
+                    msg = str(err_holder[0]) if err_holder else "unknown error"
+                    yield _sse_frame("error", {"message": msg})
+                    return
+                yield _sse_frame(None, item)
+        finally:
+            if not worker.done():
+                worker.cancel()
+            with contextlib.suppress(BaseException):
+                await worker
+
+    headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+    return StreamingResponse(_generator(), media_type="text/event-stream", headers=headers)

--- a/src/bricks/playground/web/static/index.html
+++ b/src/bricks/playground/web/static/index.html
@@ -381,6 +381,53 @@
   .steps li.done .mark { background: var(--ok); border-color: var(--ok); color: #fff; }
   .steps li.done .mark::before { content: "✓"; }
 
+  /* ===== fan-out progress graphic (issue #56) ===== */
+  .fanout {
+    width: 100%;
+    max-width: 620px;
+    margin: 16px auto 0;
+    display: block;
+  }
+  .fanout .edge {
+    fill: none;
+    stroke: var(--rule-2);
+    stroke-width: 1.5;
+    color: var(--rule-2); /* arrow head inherits */
+    transition: stroke 220ms ease, color 220ms ease;
+  }
+  .fanout .fnode rect {
+    fill: var(--paper);
+    stroke: var(--rule-2);
+    stroke-width: 1.5;
+    transition: fill 220ms ease, stroke 220ms ease;
+  }
+  .fanout .fnode text {
+    fill: var(--faint);
+    font-family: var(--mono);
+    font-size: 11px;
+    text-anchor: middle;
+    dominant-baseline: middle;
+    transition: fill 220ms ease;
+  }
+  .fanout .fnode.on rect {
+    fill: var(--paper-2);
+    stroke: var(--accent);
+    stroke-width: 2;
+    animation: pulse 1.2s ease-in-out infinite;
+  }
+  .fanout .fnode.on text { fill: var(--ink); }
+  .fanout .fnode.done rect {
+    fill: var(--ok);
+    stroke: var(--ok);
+  }
+  .fanout .fnode.done text { fill: #fff; }
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.55; }
+  }
+  .fanout.solo [data-compare-only="true"],
+  .fanout.solo .hide-if-solo { display: none; }
+
   /* ===== results view ===== */
   .results {
     max-width: 960px;
@@ -681,19 +728,21 @@
   <div class="spacer"></div>
   <div class="byok" title="Model">
     <select id="modelSel" style="padding-right: 24px;">
-      <option>Haiku 4.5</option>
-      <option>Sonnet 4.5</option>
-      <option>GPT-4o Mini</option>
-      <option>Llama3 local</option>
+      <option value="claude-haiku-4-5">Haiku 4.5</option>
+      <option value="claude-sonnet-4-5">Sonnet 4.5</option>
+      <option value="gpt-4o-mini">GPT-4o Mini</option>
+      <option value="gpt-4o">GPT-4o</option>
+      <option value="llama3">Llama3 local</option>
     </select>
   </div>
   <div class="byok" title="Bring your own key">
-    <select>
-      <option>Anthropic</option>
-      <option>OpenAI</option>
+    <select id="providerSel">
+      <option value="claude_code">Claude Code</option>
+      <option value="anthropic">Anthropic</option>
+      <option value="openai">OpenAI</option>
+      <option value="ollama">Ollama</option>
     </select>
-    <input type="password" placeholder="sk-ant-•••••••••" value="sk-ant-api03-xXxXxXx" />
-    <div class="byok-dot"><i></i>connected</div>
+    <input type="password" id="apiKeyInput" placeholder="sk-ant-••••••••• (optional for Claude Code / Ollama)" />
   </div>
 </nav>
 
@@ -794,13 +843,42 @@
     <div class="spinner"></div>
     <h2 id="runHeadline">Running your pipeline…</h2>
     <p id="runSub">Bricks composing a blueprint, then executing deterministically.</p>
-    <ol class="steps" id="steps">
-      <li data-s="0"><span class="mark">1</span>Parsing input data</li>
-      <li data-s="1"><span class="mark">2</span>Bricks — composing blueprint</li>
-      <li data-s="2"><span class="mark">3</span>Bricks — executing pipeline</li>
-      <li data-s="3" class="hide-if-solo"><span class="mark">4</span>Raw LLM — sending full prompt</li>
-      <li data-s="4"><span class="mark">5</span>Checking outputs</li>
-    </ol>
+    <svg class="fanout" id="fanout" viewBox="0 0 620 220" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Pipeline progress">
+      <defs>
+        <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+          <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+        </marker>
+      </defs>
+      <!-- edges -->
+      <path class="edge" d="M 80 110 L 200 60"  marker-end="url(#arr)"/>
+      <path class="edge" d="M 80 110 L 200 160" marker-end="url(#arr)" data-compare-only="true"/>
+      <path class="edge" d="M 280 60  L 400 60"  marker-end="url(#arr)"/>
+      <path class="edge" d="M 280 160 L 400 160" marker-end="url(#arr)" data-compare-only="true"/>
+      <path class="edge" d="M 480 60  L 540 110" marker-end="url(#arr)"/>
+      <path class="edge" d="M 480 160 L 540 110" marker-end="url(#arr)" data-compare-only="true"/>
+      <!-- nodes -->
+      <g class="fnode" data-node="input" transform="translate(30 95)">
+        <rect width="80" height="30" rx="6"/>
+        <text x="40" y="20">Input</text>
+      </g>
+      <g class="fnode" data-node="compose" transform="translate(200 45)">
+        <rect width="90" height="30" rx="6"/>
+        <text x="45" y="20">Compose</text>
+      </g>
+      <g class="fnode" data-node="execute" transform="translate(400 45)">
+        <rect width="90" height="30" rx="6"/>
+        <text x="45" y="20">Execute</text>
+      </g>
+      <g class="fnode hide-if-solo" data-node="raw_llm" transform="translate(280 145)">
+        <rect width="130" height="30" rx="6"/>
+        <text x="65" y="20">Raw LLM call</text>
+      </g>
+      <g class="fnode" data-node="check" transform="translate(540 95)">
+        <rect width="80" height="30" rx="6"/>
+        <text x="40" y="20">Check</text>
+      </g>
+    </svg>
+    <p class="heal-note" id="healNote" style="display:none; margin-top:14px; font-size:13px; color:var(--muted); font-style:italic;"></p>
   </div>
 </main>
 
@@ -928,10 +1006,64 @@
       <button class="ghost">Share results</button>
     </div>
 
+    <details class="checks-drilldown" id="checksDrilldown" style="margin-top:24px;">
+      <summary style="cursor:pointer; font-family:var(--mono); font-size:12px; color:var(--muted); padding:6px 0;">
+        Per-check details
+      </summary>
+      <div id="checksTableHost" style="margin-top:12px; font-family:var(--mono); font-size:12px;"></div>
+    </details>
+
   </div>
 </main>
 
 <script>
+  function renderChecksTable(bricksChecks, rawChecks) {
+    const host = document.getElementById('checksTableHost');
+    if (!host) return;
+    const parent = document.getElementById('checksDrilldown');
+    if (!bricksChecks || bricksChecks.length === 0) {
+      host.innerHTML = '<em style="color:var(--faint)">No expected_output set — no checks computed.</em>';
+      if (parent) parent.style.display = '';
+      return;
+    }
+    if (parent) parent.style.display = '';
+    const fmt = (v) => {
+      if (v === null || v === undefined) return '<em style="color:var(--faint)">(missing)</em>';
+      if (typeof v === 'object') return `<code>${escapeHtml(JSON.stringify(v))}</code>`;
+      return `<code>${escapeHtml(String(v))}</code>`;
+    };
+    const icon = (ok) => ok ? '<span style="color:var(--ok)">✓</span>' : '<span style="color:#c53030">✗</span>';
+    const rawByKey = {};
+    if (rawChecks) rawChecks.forEach(c => { rawByKey[c.key] = c; });
+    const rows = bricksChecks.map(c => {
+      const r = rawChecks ? rawByKey[c.key] : null;
+      return `
+        <tr>
+          <td style="padding:6px 12px; border-bottom:1px solid var(--rule);">${escapeHtml(c.key)}</td>
+          <td style="padding:6px 12px; border-bottom:1px solid var(--rule);">${fmt(c.expected)}</td>
+          <td style="padding:6px 12px; border-bottom:1px solid var(--rule);">${fmt(c.got)} ${icon(c.pass)}</td>
+          ${rawChecks ? `<td style="padding:6px 12px; border-bottom:1px solid var(--rule);">${r ? fmt(r.got) + ' ' + icon(r.pass) : '<em style="color:var(--faint)">—</em>'}</td>` : ''}
+        </tr>`;
+    }).join('');
+    host.innerHTML = `
+      <table style="width:100%; border-collapse:collapse;">
+        <thead>
+          <tr style="text-align:left; color:var(--faint); border-bottom:1px solid var(--rule-2);">
+            <th style="padding:6px 12px;">Key</th>
+            <th style="padding:6px 12px;">Expected</th>
+            <th style="padding:6px 12px;">Bricks got</th>
+            ${rawChecks ? '<th style="padding:6px 12px;">Raw LLM got</th>' : ''}
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>`;
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, ch => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[ch]));
+  }
   // ---- sample customers (hardcoded) ----
   const customers = {
     customers: [
@@ -1043,7 +1175,6 @@ outputs_map:
 
   // ---- run flow ----
   const runBtn = document.getElementById('runBtn');
-  const steps = document.querySelectorAll('#steps li');
   const runHeadline = document.getElementById('runHeadline');
   const runSub = document.getElementById('runSub');
 
@@ -1052,50 +1183,57 @@ outputs_map:
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') startRun();
   });
 
-  // Live data returned from the most recent /playground/run call.
-  // showResults() uses this when present and falls back to the mock numbers
-  // when the fetch hasn't completed yet.
+  // Result payload from the most recent /playground/run-stream call.
   let lastRun = null;
 
-  async function startRun() {
-    // configure steps
-    const rawStep = document.querySelector('#steps li[data-s="3"]');
-    rawStep.style.display = compareOn ? '' : 'none';
-    steps.forEach(s => s.classList.remove('active', 'done'));
-    runHeadline.textContent = compareOn ? 'Running both pipelines…' : 'Running your pipeline…';
-    runSub.textContent = compareOn
-      ? 'Bricks composing + executing, raw LLM doing it in one shot.'
-      : 'Bricks composing a blueprint, then executing deterministically.';
+  // Map an SSE phase → the SVG node that should light up / finish.
+  // `compose_start` turns "compose" on; `step_start` keeps "execute" on; etc.
+  const PHASE_MAP = {
+    compose_start: { on: 'compose' },
+    compose_done:  { done: 'compose' },
+    execute_start: { on: 'execute' },
+    step_done:     { on: 'execute' },           // keep pulsing as each step clears
+    raw_llm_start: { on: 'raw_llm' },
+    raw_llm_done:  { done: 'raw_llm' },
+    check_done:    { on: 'check' },
+  };
 
-    showView('view-running');
+  function resetFanout() {
+    const fanout = document.getElementById('fanout');
+    fanout.classList.toggle('solo', !compareOn);
+    fanout.querySelectorAll('.fnode').forEach(n => n.classList.remove('on', 'done'));
+    document.querySelector('.fnode[data-node="input"]').classList.add('done');
+    document.getElementById('healNote').style.display = 'none';
+  }
 
-    // Kick off the animation and the real fetch in parallel.
-    const sequence = compareOn ? [0, 1, 2, 3, 4] : [0, 1, 2, 4];
-    let i = 0;
-    let animationDone = false;
-    let runResponse = null;
-    let runError = null;
-    const tick = () => {
-      if (i > 0) {
-        const prev = document.querySelector(`#steps li[data-s="${sequence[i-1]}"]`);
-        prev.classList.remove('active'); prev.classList.add('done');
+  function applyPhase(phase, payload) {
+    const cfg = PHASE_MAP[phase];
+    if (!cfg) return;
+    if (cfg.on) {
+      const el = document.querySelector(`.fnode[data-node="${cfg.on}"]`);
+      if (el) el.classList.add('on');
+    }
+    if (cfg.done) {
+      const el = document.querySelector(`.fnode[data-node="${cfg.done}"]`);
+      if (el) { el.classList.remove('on'); el.classList.add('done'); }
+    }
+    if (phase === 'heal_attempt') {
+      const note = document.getElementById('healNote');
+      note.textContent = `Healer tier ${payload.tier} (${payload.healer_name}) ${payload.succeeded ? 'recovered' : 'attempted'}`;
+      note.style.display = '';
+    }
+  }
+
+  function finalizeFanout() {
+    document.querySelectorAll('.fnode').forEach(n => {
+      if (n.classList.contains('on')) {
+        n.classList.remove('on');
+        n.classList.add('done');
       }
-      if (i < sequence.length) {
-        const cur = document.querySelector(`#steps li[data-s="${sequence[i]}"]`);
-        cur.classList.add('active');
-        i++;
-        setTimeout(tick, 520 + Math.random() * 300);
-      } else {
-        animationDone = true;
-        if (runResponse !== null || runError !== null) {
-          lastRun = runResponse;
-          setTimeout(() => showResults(runError), 450);
-        }
-      }
-    };
-    tick();
+    });
+  }
 
-    // Fire the real /playground/run request using whatever's in the setup view.
+  function collectRequestBody() {
     const taskText = document.getElementById('taskInput').value.trim();
     const dataBodyEl = document.getElementById('dataBody');
     let dataValue;
@@ -1104,33 +1242,88 @@ outputs_map:
     } catch (_) {
       dataValue = dataBodyEl.textContent || '';
     }
+    const provider = document.getElementById('providerSel')?.value || 'claude_code';
+    const model = document.getElementById('modelSel')?.value || '';
+    const apiKey = document.getElementById('apiKeyInput')?.value || '';
+    const body = {
+      provider,
+      model,
+      task: taskText,
+      data: dataValue,
+      expected_output: window.__expectedOutput || null,
+      compare: compareOn,
+    };
+    // BYOK: only include api_key for providers that require it.
+    if (provider === 'anthropic' || provider === 'openai') {
+      if (apiKey) body.api_key = apiKey;
+    }
+    return body;
+  }
 
+  async function startRun() {
+    runHeadline.textContent = compareOn ? 'Running both pipelines…' : 'Running your pipeline…';
+    runSub.textContent = compareOn
+      ? 'Bricks composing + executing, raw LLM doing it in one shot.'
+      : 'Bricks composing a blueprint, then executing deterministically.';
+
+    resetFanout();
+    showView('view-running');
+
+    let resp;
     try {
-      const resp = await fetch('/playground/run', {
+      resp = await fetch('/playground/run-stream', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          // Only claude_code is wired end-to-end until #44 lands.
-          provider: 'claude_code',
-          model: (document.getElementById('modelSel')?.value || '').toLowerCase().includes('haiku')
-            ? 'haiku' : (document.getElementById('modelSel')?.value || '').toLowerCase().includes('sonnet')
-            ? 'sonnet' : '',
-          task: taskText,
-          data: dataValue,
-          expected_output: window.__expectedOutput || null,
-          compare: compareOn,
-        }),
+        body: JSON.stringify(collectRequestBody()),
       });
-      if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${await resp.text()}`);
-      runResponse = await resp.json();
     } catch (err) {
-      runError = err;
+      lastRun = null;
+      showResults(err);
+      return;
+    }
+    if (!resp.ok) {
+      const errText = await resp.text();
+      lastRun = null;
+      showResults(new Error(`HTTP ${resp.status}: ${errText}`));
+      return;
     }
 
-    if (animationDone) {
-      lastRun = runResponse;
-      showResults(runError);
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    let finalResponse = null;
+    let finalError = null;
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      const frames = buf.split('\n\n');
+      buf = frames.pop();
+      for (const frame of frames) {
+        const lines = frame.split('\n');
+        let eventName = null;
+        let dataLine = '';
+        for (const l of lines) {
+          if (l.startsWith('event:')) eventName = l.slice(6).trim();
+          else if (l.startsWith('data:')) dataLine = l.slice(5).trim();
+        }
+        if (!dataLine) continue;
+        let payload;
+        try { payload = JSON.parse(dataLine); } catch { continue; }
+        if (eventName === 'done') {
+          finalResponse = payload;
+        } else if (eventName === 'error') {
+          finalError = new Error(payload.message || 'stream error');
+        } else if (payload.phase) {
+          applyPhase(payload.phase, payload);
+        }
+      }
     }
+
+    finalizeFanout();
+    lastRun = finalResponse;
+    setTimeout(() => showResults(finalError), 250);
   }
 
   // ---- results ----
@@ -1158,24 +1351,40 @@ outputs_map:
     // demo numbers baked into the mockup so the UI still animates through.
     if (lastRun && lastRun.bricks) {
       const b = lastRun.bricks;
+      const r = lastRun.raw_llm;
       const tokens = b.tokens?.total ?? ((b.tokens?.in || 0) + (b.tokens?.out || 0));
       const cost = (b.cost_usd == null) ? '—' : `$${b.cost_usd.toFixed(4)}`;
       const passed = (b.checks || []).filter(c => c.pass).length;
       const total = (b.checks || []).length;
-      verdictTitle.innerHTML = 'Bricks ran deterministically.';
-      scoreGrid.className = 'score-grid';
+      const hasRaw = r && r.tokens;
+      const rTokens = hasRaw ? (r.tokens?.total ?? ((r.tokens?.in || 0) + (r.tokens?.out || 0))) : 0;
+      const rPassed = hasRaw ? (r.checks || []).filter(c => c.pass).length : 0;
+
+      verdictTitle.innerHTML = hasRaw
+        ? (passed > rPassed ? 'Bricks beat raw LLM' : 'Side-by-side results')
+        : 'Bricks ran deterministically.';
+
+      scoreGrid.className = hasRaw ? 'score-grid dual' : 'score-grid';
       scoreGrid.innerHTML = `
         <div class="scol win">
           <div class="who"><i></i>Bricks</div>
           <div class="num">${passed}<span class="of">/${total || '?'}</span></div>
           <div class="meta">${tokens.toLocaleString()} tokens · ${cost}</div>
-        </div>`;
+        </div>` + (hasRaw ? `
+        <div class="scol ${rPassed >= passed ? 'win' : 'loss'}">
+          <div class="who"><i></i>Raw LLM</div>
+          <div class="num">${rPassed}<span class="of">/${total || '?'}</span></div>
+          <div class="meta">${rTokens.toLocaleString()} tokens</div>
+        </div>` : '');
+
       metrics.className = 'metrics';
       metrics.innerHTML = `
         <div class="metric"><div class="k">Tokens</div><div class="v">${tokens.toLocaleString()}</div><div class="sub">composed once</div></div>
         <div class="metric"><div class="k">Cost</div><div class="v">${cost}</div><div class="sub">${lastRun.run_metadata?.model || ''}</div></div>
         <div class="metric"><div class="k">Duration</div><div class="v">${((b.duration_ms || 0) / 1000).toFixed(1)}s</div><div class="sub">wall clock</div></div>`;
-      if (cmpTable) cmpTable.querySelectorAll('.raw-col').forEach(el => el.style.display = 'none');
+      if (cmpTable) cmpTable.querySelectorAll('.raw-col').forEach(el => el.style.display = hasRaw ? '' : 'none');
+
+      renderChecksTable(b.checks || [], hasRaw ? (r.checks || []) : null);
       if (typeof applyTweaks === 'function') applyTweaks();
       showView('view-results');
       return;

--- a/tests/ai/test_composer.py
+++ b/tests/ai/test_composer.py
@@ -45,6 +45,8 @@ def _make_composer(registry: BrickRegistry) -> BlueprintComposer:
 
     composer._selector = AllBricksSelector()
     composer._store = None
+    composer._explicit_healers = None
+    composer._pm = None
     return composer
 
 

--- a/tests/ai/test_composer_dsl.py
+++ b/tests/ai/test_composer_dsl.py
@@ -81,6 +81,8 @@ def _make_composer(registry: BrickRegistry, response: str = _SIMPLE_DSL) -> Blue
 
     composer._selector = AllBricksSelector()
     composer._store = None
+    composer._explicit_healers = None
+    composer._pm = None
     return composer
 
 

--- a/tests/core/test_hooks.py
+++ b/tests/core/test_hooks.py
@@ -1,0 +1,157 @@
+"""Tests for the pluggy hook spec in :mod:`bricks.core.hooks`.
+
+Registers a recording plugin, runs a minimal blueprint through the
+engine, and asserts the expected lifecycle events fire in the expected
+order with the right payload shapes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bricks.core.builtins import register_builtins
+from bricks.core.engine import BlueprintEngine
+from bricks.core.hooks import get_plugin_manager, hookimpl
+from bricks.core.models import BlueprintDefinition, BrickMeta, StepDefinition
+from bricks.core.registry import BrickRegistry
+
+
+class _RecordingPlugin:
+    """Plugin that records every hook call as ``(phase, payload)`` tuples."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    @hookimpl
+    def compose_start(self, task: str) -> None:
+        self.events.append(("compose_start", {"task": task}))
+
+    @hookimpl
+    def compose_done(self, dsl: str, tokens_in: int, tokens_out: int) -> None:
+        self.events.append(("compose_done", {"dsl": dsl, "tokens_in": tokens_in, "tokens_out": tokens_out}))
+
+    @hookimpl
+    def execute_start(self, blueprint_yaml: str) -> None:
+        self.events.append(("execute_start", {"blueprint_yaml": blueprint_yaml}))
+
+    @hookimpl
+    def step_start(self, step_name: str, brick_name: str) -> None:
+        self.events.append(("step_start", {"step_name": step_name, "brick_name": brick_name}))
+
+    @hookimpl
+    def step_done(self, step_name: str, brick_name: str, duration_ms: int) -> None:
+        self.events.append(
+            ("step_done", {"step_name": step_name, "brick_name": brick_name, "duration_ms": duration_ms})
+        )
+
+    @hookimpl
+    def heal_attempt(self, tier: int, healer_name: str, succeeded: bool) -> None:
+        self.events.append(("heal_attempt", {"tier": tier, "healer_name": healer_name, "succeeded": succeeded}))
+
+    @hookimpl
+    def raw_llm_start(self) -> None:
+        self.events.append(("raw_llm_start", {}))
+
+    @hookimpl
+    def raw_llm_done(self, response: str, tokens_in: int, tokens_out: int) -> None:
+        self.events.append(("raw_llm_done", {"response": response, "tokens_in": tokens_in, "tokens_out": tokens_out}))
+
+    @hookimpl
+    def check_done(self, key: str, expected: Any, got: Any, passed: bool) -> None:
+        self.events.append(("check_done", {"key": key, "expected": expected, "got": got, "passed": passed}))
+
+    @hookimpl
+    def run_failed(self, error: str) -> None:
+        self.events.append(("run_failed", {"error": error}))
+
+
+def test_engine_fires_step_start_and_step_done_in_order() -> None:
+    """BlueprintEngine with a plugin_manager emits step_start → step_done
+    for each top-level brick step, in the order the steps run."""
+    reg = BrickRegistry()
+    register_builtins(reg)
+
+    def add(a: int, b: int) -> dict[str, int]:
+        return {"result": a + b}
+
+    def double(x: int) -> dict[str, int]:
+        return {"result": x * 2}
+
+    reg.register("add", add, BrickMeta(name="add", description="sum"))
+    reg.register("double", double, BrickMeta(name="double", description="x2"))
+
+    pm = get_plugin_manager()
+    recorder = _RecordingPlugin()
+    pm.register(recorder)
+
+    engine = BlueprintEngine(registry=reg, plugin_manager=pm)
+    bp = BlueprintDefinition(
+        name="test",
+        steps=[
+            StepDefinition(name="s1", brick="add", params={"a": 3, "b": 4}, save_as="sum"),
+            StepDefinition(name="s2", brick="double", params={"x": "${sum.result}"}),
+        ],
+    )
+    engine.run(bp)
+
+    phases = [e[0] for e in recorder.events]
+    assert phases == ["step_start", "step_done", "step_start", "step_done"], phases
+    # Names arrive in order.
+    assert recorder.events[0][1]["brick_name"] == "add"
+    assert recorder.events[1][1]["step_name"] == "s1"
+    assert recorder.events[2][1]["brick_name"] == "double"
+    # duration_ms is an int, non-negative.
+    assert isinstance(recorder.events[1][1]["duration_ms"], int)
+    assert recorder.events[1][1]["duration_ms"] >= 0
+
+
+def test_engine_without_plugin_manager_is_silent() -> None:
+    """A default ``BlueprintEngine(registry=...)`` does not require pluggy
+    and must not raise when no PluginManager is provided."""
+    reg = BrickRegistry()
+
+    def nop(x: int) -> dict[str, int]:
+        return {"result": x}
+
+    reg.register("nop", nop, BrickMeta(name="nop", description="nop"))
+    engine = BlueprintEngine(registry=reg)  # no plugin_manager kwarg
+    out = engine.run(
+        BlueprintDefinition(
+            name="silent",
+            steps=[StepDefinition(name="s1", brick="nop", params={"x": 1})],
+        )
+    )
+    assert out is not None
+
+
+def test_plugin_with_missing_hook_methods_is_ok() -> None:
+    """Pluggy must tolerate a plugin that implements only a subset of
+    hooks. Only the implemented ones fire; the rest are silently skipped."""
+
+    class PartialPlugin:
+        def __init__(self) -> None:
+            self.only_starts: list[str] = []
+
+        @hookimpl
+        def step_start(self, step_name: str, brick_name: str) -> None:
+            self.only_starts.append(step_name)
+
+    reg = BrickRegistry()
+
+    def nop(x: int) -> dict[str, int]:
+        return {"result": x}
+
+    reg.register("nop", nop, BrickMeta(name="nop", description="nop"))
+
+    pm = get_plugin_manager()
+    plugin = PartialPlugin()
+    pm.register(plugin)
+
+    engine = BlueprintEngine(registry=reg, plugin_manager=pm)
+    engine.run(
+        BlueprintDefinition(
+            name="partial",
+            steps=[StepDefinition(name="only_one", brick="nop", params={"x": 1})],
+        )
+    )
+    assert plugin.only_starts == ["only_one"]

--- a/tests/integration/test_dsl_integration.py
+++ b/tests/integration/test_dsl_integration.py
@@ -61,6 +61,8 @@ def _make_composer(registry: BrickRegistry, response: str = _SIMPLE_DSL) -> Blue
 
     composer._selector = AllBricksSelector()
     composer._store = None
+    composer._explicit_healers = None
+    composer._pm = None
     return composer
 
 

--- a/tests/playground/test_run_stream.py
+++ b/tests/playground/test_run_stream.py
@@ -1,0 +1,212 @@
+"""Tests for ``POST /playground/run-stream`` — the SSE variant that drives
+the real-time UI in issue #56.
+
+Reuses the happy-path fixture from :mod:`tests.integration.test_showcase_cached`
+to avoid needing a live LLM. Asserts phase ordering, the final ``done``
+event carries the expected outputs, and compare=True adds raw-LLM frames.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import bricks.playground.web.routes as routes_module
+from bricks.llm.base import CompletionResult, LLMProvider
+from bricks.playground.web.app import app
+
+_FIXTURE_DIR = Path(__file__).parent.parent / "integration" / "fixtures"
+_CRM_RAW = json.dumps(
+    {
+        "customers": [
+            {"id": 1, "status": "active", "monthly_revenue": 100.0},
+            {"id": 2, "status": "inactive", "monthly_revenue": 0.0},
+            {"id": 3, "status": "active", "monthly_revenue": 50.0},
+        ]
+    }
+)
+
+
+class _ScriptedProvider(LLMProvider):
+    """Minimal fixture-replay provider for this SSE suite."""
+
+    def __init__(self, responses: list[CompletionResult]) -> None:
+        self._queue = list(responses)
+
+    def complete(self, prompt: str, system: str = "") -> CompletionResult:
+        if not self._queue:
+            raise IndexError("scripted provider exhausted")
+        return self._queue.pop(0)
+
+
+def _provider_from_fixture(name: str, extra: int = 0) -> _ScriptedProvider:
+    fx = json.loads((_FIXTURE_DIR / name).read_text(encoding="utf-8"))
+    responses = [
+        CompletionResult(
+            text=r["dsl"],
+            input_tokens=r["input_tokens"],
+            output_tokens=r["output_tokens"],
+            model=r.get("model", ""),
+            estimated=False,
+        )
+        for r in fx["responses"]
+    ]
+    # Raw-LLM path needs an extra response (a JSON outputs blob).
+    for _ in range(extra):
+        responses.append(
+            CompletionResult(
+                text='{"result": 2}',
+                input_tokens=10,
+                output_tokens=5,
+                model=fx["responses"][0].get("model", ""),
+                estimated=False,
+            )
+        )
+    return _ScriptedProvider(responses)
+
+
+def _parse_sse(raw: str) -> tuple[list[dict[str, Any]], dict[str, Any] | None, str | None]:
+    """Return (phase_events, done_payload, error_message) from an SSE body."""
+    phases: list[dict[str, Any]] = []
+    done: dict[str, Any] | None = None
+    err: str | None = None
+    for frame in raw.split("\n\n"):
+        frame = frame.strip()
+        if not frame:
+            continue
+        event_name: str | None = None
+        data_line = ""
+        for line in frame.split("\n"):
+            if line.startswith("event:"):
+                event_name = line[6:].strip()
+            elif line.startswith("data:"):
+                data_line = line[5:].strip()
+        if not data_line:
+            continue
+        payload = json.loads(data_line)
+        if event_name == "done":
+            done = payload
+        elif event_name == "error":
+            err = payload.get("message")
+        elif "phase" in payload:
+            phases.append(payload)
+    return phases, done, err
+
+
+@pytest.fixture(name="client")
+def _client() -> TestClient:
+    return TestClient(app)
+
+
+def test_run_stream_emits_phases_in_order_and_done(client: TestClient) -> None:
+    """Happy path: compose_start → compose_done → execute_start → step_*
+    pairs → check_done (once per expected key) → ``event: done`` with the
+    full RunResponse payload."""
+    provider = _provider_from_fixture("crm_pipeline_happy.json")
+
+    with (
+        patch.object(routes_module, "_build_provider", return_value=provider),
+        client.stream(
+            "POST",
+            "/playground/run-stream",
+            json={
+                "provider": "claude_code",
+                "model": "haiku",
+                "task": "Count active customers",
+                "data": json.loads(_CRM_RAW),
+                "expected_output": {"result": 2},
+            },
+        ) as resp,
+    ):
+        assert resp.status_code == 200
+        body = "".join(chunk.decode() for chunk in resp.iter_bytes())
+
+    phases, done, err = _parse_sse(body)
+    assert err is None, err
+    assert done is not None
+    assert done["bricks"]["outputs"] == {"result": 2}
+
+    phase_names = [p["phase"] for p in phases]
+    # Phase ordering: compose events come before execute, steps come after
+    # execute, and check_done lands last — we assert index relationships
+    # rather than exact equality because the count of step_* depends on the
+    # shape of the DSL in the fixture.
+    assert phase_names[0] == "compose_start"
+    assert "compose_done" in phase_names
+    assert "execute_start" in phase_names
+    assert phase_names.index("compose_start") < phase_names.index("compose_done")
+    assert phase_names.index("compose_done") < phase_names.index("execute_start")
+    assert any(p == "step_start" for p in phase_names)
+    assert any(p == "check_done" for p in phase_names)
+
+
+def test_run_stream_compare_true_emits_raw_llm_frames(client: TestClient) -> None:
+    """compare=True triggers RawLLMEngine; its start/done phases must
+    appear in the stream and the final payload must include ``raw_llm``."""
+    # compare=True needs one extra provider response (the raw-LLM JSON).
+    provider = _provider_from_fixture("crm_pipeline_happy.json", extra=1)
+
+    with (
+        patch.object(routes_module, "_build_provider", return_value=provider),
+        client.stream(
+            "POST",
+            "/playground/run-stream",
+            json={
+                "provider": "claude_code",
+                "model": "haiku",
+                "task": "Count active customers",
+                "data": json.loads(_CRM_RAW),
+                "expected_output": {"result": 2},
+                "compare": True,
+            },
+        ) as resp,
+    ):
+        assert resp.status_code == 200
+        body = "".join(chunk.decode() for chunk in resp.iter_bytes())
+
+    phases, done, err = _parse_sse(body)
+    assert err is None
+    assert done is not None
+    assert done.get("raw_llm") is not None
+    names = [p["phase"] for p in phases]
+    assert "raw_llm_start" in names
+    assert "raw_llm_done" in names
+
+
+def test_run_stream_provider_failure_still_closes_with_done(client: TestClient) -> None:
+    """A provider that raises is caught inside ``BricksEngine.solve`` and
+    surfaces as a clean ``done`` event with empty outputs — the stream
+    closes normally so the frontend can render a failure state without
+    seeing a hung connection.
+    """
+
+    class _BoomProvider(LLMProvider):
+        def complete(self, prompt: str, system: str = "") -> CompletionResult:
+            raise RuntimeError("provider is down")
+
+    with (
+        patch.object(routes_module, "_build_provider", return_value=_BoomProvider()),
+        client.stream(
+            "POST",
+            "/playground/run-stream",
+            json={
+                "provider": "claude_code",
+                "model": "haiku",
+                "task": "whatever",
+                "data": {},
+            },
+        ) as resp,
+    ):
+        assert resp.status_code == 200
+        body = "".join(chunk.decode() for chunk in resp.iter_bytes())
+
+    _, done, err = _parse_sse(body)
+    assert err is None, f"unexpected SSE error frame: {err}"
+    assert done is not None, "stream should close with a done event even on provider failure"
+    # Empty outputs signal the failure to the frontend.
+    assert done["bricks"]["outputs"] == {}


### PR DESCRIPTION
Closes #56.

The Playground UI was decoupled from the backend — selectors didn't reach `/playground/run`, progress was a `setTimeout` animation, Compare was inert, the verdict card was opaque, and the CONNECTED pill lied. This PR wires it all end-to-end via pluggy hooks + an SSE endpoint.

## A · Pluggy hook spec
New `src/bricks/core/hooks.py` defines `BricksHookSpec` with `compose_*`, `execute_start`, `step_*`, `heal_attempt`, `raw_llm_*`, `check_done`, `run_failed`. Callers accept an **optional** `plugin_manager` — production paths stay zero-cost when it's `None`. Wired into:
- [composer.py](src/bricks/ai/composer.py) → compose_start/done, execute_start, run_failed
- [engine.py](src/bricks/core/engine.py) → step_start/done per top-level brick
- [healing.py:HealerChain](src/bricks/ai/healing.py) → heal_attempt for every tier that produced a flow
- [showcase/engine.py:RawLLMEngine](src/bricks/playground/showcase/engine.py) → raw_llm_start/done

## B · SSE endpoint
`POST /playground/run-stream` returns `StreamingResponse(media_type="text/event-stream")`. In-process `_HookStreamer` plugin pushes each hook call onto an `asyncio.Queue`; generator yields SSE frames. Worker runs on `asyncio.to_thread` so the event loop keeps draining. Existing `POST /playground/run` untouched — non-browser callers and #37's fixture tests keep working.

## C · Frontend
- Fan-out SVG replaces the vertical step list: **Input → {Compose → Execute} ∪ {Raw LLM} → Check**. `.solo` class collapses to single-column when `compare=false`; active nodes pulse, done nodes turn green.
- `startRun()` uses `fetch` + `body.getReader()` to parse SSE frames; each phase advances the matching SVG node; `event: done` triggers `renderResults(payload)`.
- Selectors now land in the request body: `provider`, `model` (real IDs), `api_key` (BYOK for Anthropic/OpenAI only), `compare`. Claude Code + Ollama added to the provider dropdown.
- `CONNECTED` pill DOM element removed.
- `<details>` drill-down below the verdict card — per-check table (key / expected / Bricks got / Raw LLM got when compare=true) with pass/fail icons, populated from `checks[]`.

## D · Tests
- `tests/core/test_hooks.py` — recording plugin asserts `step_start/done` order + payload; default engine (no PM) stays silent; partial plugin works.
- `tests/playground/test_run_stream.py` — reuses the #37 fixture provider; asserts phase order, compare=true raw-LLM frames, failing-provider still closes with `done`.
- Updated the three `BlueprintComposer.__new__` test fixtures to set `_pm` + `_explicit_healers` to match the constructor.

## Dependency
`pluggy>=1.3` added to `[playground]` and `[all]` extras.

## Test plan
- [x] `pytest` — 1234 passed, 18 skipped
- [x] `ruff check` / `ruff format --check` / `mypy src` / `cog --check README.md` clean
- [x] End-to-end SSE smoke via `TestClient`: phases arrive in order (`compose_start` → `compose_done` → `execute_start` → `step_*` pairs → `check_done` → `done`)
- [ ] CI matrix green on 3.10 / 3.11 / 3.12 + lint + links
- [ ] Post-merge manual smoke: `bricks playground` + CRM preset + Claude Code → live SVG animation; Compare on → both tracks; TICKET-pipeline end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)