### PR TITLE
fix(composer): surface raw LLM DSL on failure + widen for_each error (#60)

### DIFF
--- a/src/bricks/ai/composer.py
+++ b/src/bricks/ai/composer.py
@@ -31,17 +31,36 @@ logger = logging.getLogger(__name__)
 
 
 class ComposerError(BrickError):
-    """Raised when AI composition fails."""
+    """Raised when AI composition fails.
 
-    def __init__(self, message: str, cause: Exception | None = None) -> None:
+    ``dsl_code`` / ``blueprint_yaml`` are structured attributes set by the
+    composer on failure paths so callers can render the offending LLM
+    output without re-paying for another compose (see issue #60). When a
+    composer error lands without access to the raw output, both stay ``""``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        cause: Exception | None = None,
+        *,
+        dsl_code: str = "",
+        blueprint_yaml: str = "",
+    ) -> None:
         """Initialise the error.
 
         Args:
             message: Human-readable error description.
             cause: The underlying exception, if any.
+            dsl_code: The raw LLM-generated Python DSL text that triggered
+                the failure, if available.
+            blueprint_yaml: The rendered blueprint YAML, if a
+                :class:`FlowDefinition` was produced before the failure.
         """
         super().__init__(message)
         self.cause = cause
+        self.dsl_code = dsl_code
+        self.blueprint_yaml = blueprint_yaml
 
 
 class CompositionError(ComposerError):
@@ -378,19 +397,34 @@ class BlueprintComposer:
         total_output = sum(c.output_tokens for c in calls)
         total_cached_in = sum(c.cached_input_tokens for c in calls)
 
+        # Always capture the raw LLM output — even on failure paths, so
+        # downstream callers can render the offending DSL without paying
+        # for another compose (issue #60).
+        dsl_code = self._strip_fences(last.yaml_text) if last.yaml_text else ""
         blueprint_yaml = ""
-        dsl_code = ""
         flow_def: FlowDefinition | None = None
+        validation_errors = list(last.validation_errors)
+        is_valid = last.is_valid
         if last.is_valid:
-            flow_def = self._parse_dsl_response(last.yaml_text)
-            blueprint_yaml = flow_def.to_yaml()
-            dsl_code = self._strip_fences(last.yaml_text)
-            if self._pm is not None:
-                self._pm.hook.compose_done(
-                    dsl=dsl_code,
-                    tokens_in=total_input,
-                    tokens_out=total_output,
-                )
+            try:
+                flow_def = self._parse_dsl_response(last.yaml_text)
+                blueprint_yaml = flow_def.to_yaml()
+            except CompositionError as exc:
+                # Post-AST-validation failure — the DSL validated but
+                # ``exec()`` or the FlowDefinition extraction raised.
+                # Return a structured is_valid=False ComposeResult instead
+                # of letting the exception escape compose().
+                is_valid = False
+                validation_errors.append(str(exc))
+                dsl_code = exc.dsl_code or dsl_code
+                flow_def = None
+            else:
+                if self._pm is not None:
+                    self._pm.hook.compose_done(
+                        dsl=dsl_code,
+                        tokens_in=total_input,
+                        tokens_out=total_output,
+                    )
 
         exec_outputs: dict[str, Any] | None = None
         exec_error = ""
@@ -432,8 +466,8 @@ class BlueprintComposer:
             blueprint_yaml=blueprint_yaml,
             dsl_code=dsl_code,
             flow_def=flow_def,
-            is_valid=last.is_valid,
-            validation_errors=last.validation_errors,
+            is_valid=is_valid,
+            validation_errors=validation_errors,
             calls=calls,
             api_calls=len(calls),
             total_input_tokens=total_input,
@@ -674,7 +708,10 @@ class BlueprintComposer:
 
         validation = validate_dsl(code)
         if not validation.valid:
-            raise CompositionError(f"LLM generated invalid DSL code. Errors: {validation.errors}\nCode:\n{code}")
+            raise CompositionError(
+                f"LLM generated invalid DSL code. Errors: {validation.errors}\nCode:\n{code}",
+                dsl_code=code,
+            )
 
         namespace: dict[str, Any] = {
             "step": step,
@@ -689,7 +726,10 @@ class BlueprintComposer:
             None,
         )
         if flow_def is None:
-            raise CompositionError(f"LLM code did not produce a FlowDefinition.\nCode:\n{code}")
+            raise CompositionError(
+                f"LLM code did not produce a FlowDefinition.\nCode:\n{code}",
+                dsl_code=code,
+            )
 
         return flow_def
 

--- a/src/bricks/core/dsl.py
+++ b/src/bricks/core/dsl.py
@@ -269,19 +269,32 @@ def for_each(
     _dsl_module._tracer = inner_tracer
     inner_tracer.start()
     mock = Node(type="brick", brick_name="__mock__", params={})
+    trace_error: Exception | None = None
     try:
         do(mock)
-    except Exception:  # noqa: S110
-        pass
+    except Exception as exc:
+        # Capture rather than silence — the exception is usually the single
+        # most-useful hint when the trace records no nodes. See issue #60.
+        trace_error = exc
     finally:
         inner_tracer.stop()
         _dsl_module._tracer = outer_tracer
 
     inner_nodes = inner_tracer.get_nodes()
     if not inner_nodes:
+        hint_parts: list[str] = []
+        try:
+            source = inspect.getsource(do).strip()
+        except (OSError, TypeError):
+            source = ""
+        if source:
+            hint_parts.append(f"Lambda source: {source}")
+        if trace_error is not None:
+            hint_parts.append(f"Inner lambda raised: {type(trace_error).__name__}: {trace_error}")
+        extra = ("\n  " + "\n  ".join(hint_parts)) if hint_parts else ""
         raise ValueError(
             "for_each: could not extract brick name from do= callable. "
-            "Ensure the lambda calls exactly one step.brick_name(...)."
+            "Ensure the lambda calls exactly one step.brick_name(...)." + extra
         )
     first = inner_nodes[0]
     do_brick: str = first.brick_name or f"__{first.type}__"

--- a/src/bricks/playground/showcase/engine.py
+++ b/src/bricks/playground/showcase/engine.py
@@ -171,15 +171,21 @@ class BricksEngine(Engine):
             )
         except Exception as exc:
             # Framework errors from compose itself (not BrickExecutionError —
-            # those are caught inside compose). Surface them as a failed result.
+            # those are caught inside compose). Surface them as a failed
+            # result. Any raw DSL the LLM emitted before the failure is
+            # attached to ComposerError as a structured attr (issue #60),
+            # so callers can render it in the Playground UI / results JSON.
             logger.error("[BricksEngine] Compose raised: %s", exc)
+            dsl_code_attr = getattr(exc, "dsl_code", "") or ""
+            blueprint_yaml_attr = getattr(exc, "blueprint_yaml", "") or ""
             return EngineResult(
                 outputs={},
                 tokens_in=0,
                 tokens_out=0,
                 duration_seconds=time.monotonic() - t0,
                 model="",
-                raw_response="",
+                raw_response=blueprint_yaml_attr,
+                dsl_code=dsl_code_attr,
                 error=str(exc),
             )
 
@@ -192,6 +198,7 @@ class BricksEngine(Engine):
                 duration_seconds=time.monotonic() - t0,
                 model=compose_result.model,
                 raw_response=compose_result.blueprint_yaml,
+                dsl_code=compose_result.dsl_code or "",
                 error="; ".join(compose_result.validation_errors),
             )
 

--- a/tests/ai/test_composer_error_surfaces_code.py
+++ b/tests/ai/test_composer_error_surfaces_code.py
@@ -1,0 +1,133 @@
+"""Tests for issue #60 — composer must persist the raw LLM output on failure paths.
+
+When the LLM emits DSL that fails AST validation or can't be parsed into a
+``FlowDefinition``, callers need the offending text to triage without
+paying for another compose (~$1.25 per live failure in the tracked
+repro). This suite asserts the structured ``dsl_code`` / ``blueprint_yaml``
+attributes flow through both paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from bricks.ai.composer import (
+    BlueprintComposer,
+    CallDetail,
+    ComposeResult,
+    CompositionError,
+)
+from bricks.core.selector import AllBricksSelector
+from bricks.llm.base import CompletionResult, LLMProvider
+
+
+def _make_composer(response_text: str) -> BlueprintComposer:
+    """Build a composer whose provider always returns ``response_text``."""
+    composer = BlueprintComposer.__new__(BlueprintComposer)
+    mock_provider = MagicMock(spec=LLMProvider)
+    mock_provider.complete.return_value = CompletionResult(text=response_text, input_tokens=5, output_tokens=10)
+    composer._provider = mock_provider
+    composer._selector = AllBricksSelector()
+    composer._store = None
+    composer._explicit_healers = None
+    composer._pm = None
+    return composer
+
+
+def test_composition_error_carries_dsl_code_attr() -> None:
+    """``CompositionError.dsl_code`` exposes the offending LLM output
+    as a structured attr so callers don't have to string-parse the
+    message."""
+    composer = _make_composer("unused")
+    raw_bad_dsl = "@flow\ndef bad():\n    import os  # forbidden by validator\n"
+    try:
+        composer._parse_dsl_response(raw_bad_dsl)
+    except CompositionError as exc:
+        # dsl_code carries the post-fence-strip body. We don't care about
+        # trailing whitespace — what matters is the identifying text is
+        # present as a structured attr, not buried in the message.
+        assert "import os" in exc.dsl_code, f"dsl_code not populated: {exc.dsl_code!r}"
+        assert exc.dsl_code.strip() == raw_bad_dsl.strip()
+        assert "LLM generated invalid DSL code" in str(exc)
+        return
+    raise AssertionError("expected CompositionError")
+
+
+def test_composition_error_constructor_stores_both_structured_attrs() -> None:
+    """The ``ComposerError`` / ``CompositionError`` public constructor
+    exposes both attrs so a caller that catches one can always read them
+    without hasattr guards."""
+    err = CompositionError("no flow", dsl_code="x = 1", blueprint_yaml="name: x\n")
+    assert err.dsl_code == "x = 1"
+    assert err.blueprint_yaml == "name: x\n"
+    # Default is empty string when not provided — not None — so downstream
+    # branches like ``raw_response = exc.blueprint_yaml`` don't need a
+    # None-guard.
+    err2 = CompositionError("no flow")
+    assert err2.dsl_code == ""
+    assert err2.blueprint_yaml == ""
+
+
+def test_compose_returns_is_valid_false_when_parse_raises(monkeypatch: Any) -> None:
+    """Even when ``_parse_dsl_response`` throws, ``compose()`` must NOT
+    propagate the exception — it should return a structured
+    ``ComposeResult(is_valid=False)`` with ``dsl_code`` set. This is the
+    key unblocker from issue #60: callers never lose the raw LLM text."""
+    composer = _make_composer("unused")
+
+    raw_dsl = "@flow\ndef some_flow():\n    return None\n"
+
+    # Simulate the wire shape: the provider returns valid-looking DSL,
+    # validate_dsl reports OK (so CallDetail.is_valid=True), but
+    # _parse_dsl_response raises post-validation (e.g. exec failure).
+    fake_call = CallDetail(
+        call_number=1,
+        input_tokens=10,
+        output_tokens=20,
+        yaml_text=raw_dsl,
+        is_valid=True,
+    )
+    monkeypatch.setattr(composer, "_compose_call", lambda *a, **kw: fake_call)
+    monkeypatch.setattr(
+        composer,
+        "_parse_dsl_response",
+        MagicMock(side_effect=CompositionError("parse failed post-validation", dsl_code=raw_dsl)),
+    )
+
+    from bricks.core.registry import BrickRegistry
+
+    result = composer.compose(task="whatever", registry=BrickRegistry())
+
+    assert isinstance(result, ComposeResult)
+    assert result.is_valid is False, "compose must not raise — return is_valid=False instead"
+    assert result.dsl_code == raw_dsl, f"dsl_code must round-trip the raw text, got {result.dsl_code!r}"
+    assert result.validation_errors, "post-validation failures must be recorded as validation_errors"
+    assert any("parse failed post-validation" in e for e in result.validation_errors)
+
+
+def test_compose_persists_dsl_code_on_ast_validation_failure(monkeypatch: Any) -> None:
+    """When the LLM emits syntactically invalid DSL, ``CallDetail.is_valid``
+    is False and ``_parse_dsl_response`` never runs. The raw text should
+    still land in ``ComposeResult.dsl_code`` so it's visible downstream."""
+    composer = _make_composer("unused")
+
+    raw_dsl = "not-valid-python-code-at-all ((("
+    fake_call = CallDetail(
+        call_number=1,
+        input_tokens=10,
+        output_tokens=20,
+        yaml_text=raw_dsl,
+        is_valid=False,
+        validation_errors=["SyntaxError: unexpected token"],
+    )
+    monkeypatch.setattr(composer, "_compose_call", lambda *a, **kw: fake_call)
+
+    from bricks.core.registry import BrickRegistry
+
+    result = composer.compose(task="whatever", registry=BrickRegistry())
+
+    assert result.is_valid is False
+    # dsl_code is stripped of fences; the raw body survives.
+    assert result.dsl_code == raw_dsl
+    assert result.validation_errors == ["SyntaxError: unexpected token"]

--- a/tests/core/test_for_each_extractor_error_message.py
+++ b/tests/core/test_for_each_extractor_error_message.py
@@ -1,0 +1,48 @@
+"""Tests for issue #60 part 2 — `for_each` extraction failures must self-report.
+
+When the ``for_each`` lambda doesn't record a step node through the
+tracer, the resulting ``ValueError`` is the only breadcrumb the caller
+has to diagnose. Pre-fix, it said only ``"could not extract brick name
+from do= callable"`` — no source, no original exception, forcing an
+expensive re-run with a debugger attached. This suite guards the
+widened error message.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bricks.core.dsl import for_each, step
+
+
+def test_empty_lambda_reports_lambda_source() -> None:
+    """A lambda that simply doesn't call ``step.X(...)`` must trigger the
+    extraction error with the lambda's source included — so the reader
+    can see the shape immediately."""
+    with pytest.raises(ValueError) as exc_info:
+        for_each(items=[1, 2, 3], do=lambda _x: None)  # doesn't record anything
+
+    msg = str(exc_info.value)
+    assert "could not extract brick name" in msg
+    # `inspect.getsource` on a lambda typically returns the whole enclosing
+    # line; any fragment uniquely identifying this lambda is good enough.
+    assert "lambda _x: None" in msg, f"lambda source not surfaced: {msg!r}"
+
+
+def test_lambda_raising_before_step_call_reports_inner_exception() -> None:
+    """A lambda that raises *before* recording a step call must surface
+    the inner exception type + message — pre-fix we silently swallowed it."""
+
+    def blow_up_first(_x: object) -> object:
+        raise RuntimeError("synthetic failure inside lambda")
+
+    with pytest.raises(ValueError) as exc_info:
+        # The ``do`` lambda raises before the ``step.X(...)`` call, so
+        # the tracer never records a node. The error must mention the
+        # RuntimeError so the reader knows *why* the trace was empty.
+        for_each(items=[1, 2], do=lambda x: blow_up_first(x) or step.nothing(item=x))
+
+    msg = str(exc_info.value)
+    assert "could not extract brick name" in msg
+    assert "RuntimeError" in msg
+    assert "synthetic failure inside lambda" in msg


### PR DESCRIPTION
Closes #60.

(Closed #61 separately via gh CLI — duplicate of #63, already fixed by PR #64.)

## Summary
Composer failures were untriageable without paying ~$1.25 per re-run to recover the offending LLM output. This PR makes the raw DSL text a structured attr on every failure path, and makes the `for_each` extraction error self-report the lambda source + silenced inner exception.

## 1. `CompositionError` carries `dsl_code` / `blueprint_yaml`
- `ComposerError` / `CompositionError` constructors grow both fields (default `""` — no None-guards needed downstream).
- Both `raise CompositionError(...)` sites in `_parse_dsl_response` pass `dsl_code=code`.
- Message format unchanged — existing `match=` assertions still pass.

## 2. `compose()` always returns a structured `ComposeResult`
- Always strips fences from the last `CallDetail.yaml_text` into `dsl_code` — even on AST-validation failure.
- `_parse_dsl_response` is now wrapped in `try/except CompositionError`; on failure we build `ComposeResult(is_valid=False, validation_errors=[...], dsl_code=...)` instead of letting the exception escape.
- `showcase/engine.py` reads `dsl_code` / `blueprint_yaml` from the `ComposerError` on the framework-error path and carries them into the `EngineResult` → they now reach `/playground/run-stream` and the Blueprint drawer on every failure.

## 3. `for_each` extraction error self-reports
- The silent `except Exception: pass` at the inner-tracer site now captures the exception on a local.
- When `inner_nodes` is empty, the ValueError message appends:
  - `Lambda source: <inspect.getsource(do).strip()>` (best-effort)
  - `Inner lambda raised: <Type>: <msg>` when set
- Prefix `"could not extract brick name"` preserved for backwards-compat.

## Tests
- `tests/ai/test_composer_error_surfaces_code.py` — 4 new tests covering the CompositionError attr, the public constructor, the compose() parse-raise path, and the AST-validation-failure persistence.
- `tests/core/test_for_each_extractor_error_message.py` — 2 new tests: empty lambda surfaces its source; raising lambda surfaces inner exception.
- Full suite: **1245 passed**, 18 skipped.

## Test plan
- [x] `pytest` green
- [x] `ruff check` / `ruff format --check` / `mypy src` / `cog --check README.md` clean
- [ ] CI matrix green on 3.10 / 3.11 / 3.12

## Out of scope
Widening the `for_each` extractor to support arbitrary composer-generated lambda shapes needs a concrete failing example. This PR makes the next failure cheap to capture (the traceback now includes the lambda source). Follow-up issue when a new shape shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)