### PR TITLE
fix(core): @flow wires params to ${inputs.X}; default registry ships builtins (#66)

### DIFF
--- a/src/bricks/api.py
+++ b/src/bricks/api.py
@@ -37,17 +37,24 @@ _DEFAULT_MODEL: str = "claude-haiku-4-5-20251001"
 def _build_default_registry() -> BrickRegistry:
     """Build the default registry by discovering installed brick packs.
 
+    Also registers DSL control-flow builtins (``__for_each__`` / ``__branch__``).
+    Without this, any composed blueprint that wraps iteration in ``for_each``
+    fails at execute() with ``BrickNotFoundError: '__for_each__'`` —
+    issue #66 bug B.
+
     Returns:
         A :class:`~bricks.core.registry.BrickRegistry` populated with all
-        bricks from every installed pack.
+        bricks from every installed pack plus DSL builtins.
 
     Raises:
         BricksConfigError: If no packs (e.g. ``bricks-stdlib``) are installed.
     """
+    from bricks.core.builtins import register_builtins  # noqa: PLC0415
     from bricks.packs import discover_and_load  # noqa: PLC0415
 
     reg = BrickRegistry()
     discover_and_load(reg)
+    register_builtins(reg)
     return reg
 
 

--- a/src/bricks/core/dag.py
+++ b/src/bricks/core/dag.py
@@ -10,28 +10,30 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from bricks.core.dsl import Node
+from bricks.core.dsl import InputRef, Node
 
 if TYPE_CHECKING:
     from bricks.core.models import BlueprintDefinition
 
 
 def _resolve_param(value: Any, node_to_step_name: dict[str, str]) -> Any:
-    """Recursively resolve Node references in param values to ``${step.result}`` strings.
+    """Recursively resolve Node / InputRef references to engine-reference strings.
 
-    Handles direct Node values, as well as Nodes nested inside lists and dicts.
-    If a Node's id is not in the mapping (shouldn't happen in normal DAG construction),
-    the raw value is returned unchanged as a defensive fallback.
+    Handles direct Node values, :class:`~bricks.core.dsl.InputRef` sentinels,
+    and both nested inside lists and dicts. Nodes become ``${step.result}``;
+    InputRefs become ``${inputs.<name>}``. Unknown scalars pass through.
 
     Args:
-        value: A param value — may be a Node, list, dict, or scalar.
+        value: A param value — may be a Node, InputRef, list, dict, or scalar.
         node_to_step_name: Mapping of node IDs to step names.
 
     Returns:
-        The value with all resolvable Node references replaced by reference strings.
+        The value with all resolvable references replaced by reference strings.
     """
     if isinstance(value, Node) and value.id in node_to_step_name:
         return f"${{{node_to_step_name[value.id]}.result}}"
+    if isinstance(value, InputRef):
+        return f"${{inputs.{value.name}}}"
     if isinstance(value, list):
         return [_resolve_param(v, node_to_step_name) for v in value]
     if isinstance(value, dict):
@@ -191,6 +193,10 @@ class DAG:
             items_param: Any
             if isinstance(node.items, Node) and node.items.id in node_to_step_name:
                 items_param = f"${{{node_to_step_name[node.items.id]}.result}}"
+            elif isinstance(node.items, InputRef):
+                # ``@flow def f(items): for_each(items=items, ...)`` —
+                # bind the iteration list to the runtime input slot.
+                items_param = f"${{inputs.{node.items.name}}}"
             elif isinstance(node.items, list):
                 # Literal list (e.g. ``for_each(items=my_list, do=...)``) —
                 # pass the values through so the engine iterates over them.
@@ -198,6 +204,9 @@ class DAG:
             else:
                 items_param = []
             do_name = node.do if isinstance(node.do, str) else str(node.do)
+            resolved_statics = {
+                key: _resolve_param(value, node_to_step_name) for key, value in node.static_kwargs.items()
+            }
             return StepDefinition(
                 name=step_name,
                 brick="__for_each__",
@@ -205,7 +214,7 @@ class DAG:
                     "items": items_param,
                     "do_brick": do_name,
                     "item_kwarg": node.item_kwarg,
-                    "static_kwargs": dict(node.static_kwargs),
+                    "static_kwargs": resolved_statics,
                     "on_error": node.on_error,
                 },
                 save_as=step_name,

--- a/src/bricks/core/dsl.py
+++ b/src/bricks/core/dsl.py
@@ -45,6 +45,22 @@ if TYPE_CHECKING:
     from bricks.core.models import BlueprintDefinition
 
 
+@dataclass(frozen=True)
+class InputRef:
+    """Sentinel injected by :func:`flow` for each declared flow parameter.
+
+    The ``@flow`` decorator traces the user's function once at decoration
+    time with one of these per parameter slot. During DAG serialisation,
+    :func:`~bricks.core.dag._resolve_param` converts it to the
+    ``${inputs.<name>}`` reference string the engine resolves at
+    ``execute`` time. Without the sentinel, the old code left literal
+    ``None`` values in step params, so ``step.X(values=values)`` ran with
+    ``values=None`` and crashed inside the brick.
+    """
+
+    name: str
+
+
 @dataclass
 class Node:
     """A single node in the Bricks execution DAG.
@@ -386,6 +402,7 @@ class FlowDefinition:
         dag: DAG,
         fn: Callable[..., Any] | None = None,
         output_nodes: dict[str, Node] | None = None,
+        input_names: list[str] | None = None,
     ) -> None:
         """Initialise with a name, description, and pre-built DAG.
 
@@ -398,12 +415,19 @@ class FlowDefinition:
                 the ``None``-param DAG captured at decoration time.
             output_nodes: Optional mapping of output key → terminal Node for
                 multi-output flows that return ``dict[str, Node]``.
+            input_names: Declared flow parameter names (order preserved).
+                Populated by :func:`flow` so :meth:`to_blueprint` can emit
+                the matching ``blueprint.inputs`` keys — without them the
+                orchestrator's :class:`~bricks.orchestrator.input_mapper.InputMapper`
+                has no slots to bind runtime ``inputs={...}`` values into
+                and step params remain stuck on the trace-time sentinel.
         """
         self.name = name
         self.description = description
         self.dag = dag
         self._fn = fn
         self.output_nodes = output_nodes
+        self.input_names: list[str] = list(input_names or [])
 
     def to_dag(self) -> DAG:
         """Return the raw DAG.
@@ -435,6 +459,8 @@ class FlowDefinition:
                 for key, node in self.output_nodes.items()
                 if node.id in node_id_to_step
             }
+        if self.input_names:
+            bp.inputs = dict.fromkeys(self.input_names, "Any")
         return bp
 
     def to_yaml(self) -> str:
@@ -567,7 +593,11 @@ def flow(
     from bricks.core.dag_builder import DAGBuilder  # noqa: PLC0415
 
     sig = inspect.signature(func)
-    mock_args = dict.fromkeys(sig.parameters)
+    param_names = list(sig.parameters)
+    # Each parameter becomes an InputRef sentinel — the DAG serialiser
+    # turns it into a ``${inputs.<name>}`` reference, which the engine's
+    # InputMapper resolves to the runtime value passed to execute().
+    mock_args: dict[str, Any] = {name: InputRef(name) for name in param_names}
 
     _tracer.start()
     try:
@@ -595,4 +625,5 @@ def flow(
         dag=dag,
         fn=func,
         output_nodes=output_nodes,
+        input_names=param_names,
     )

--- a/tests/core/test_flow_input_binding.py
+++ b/tests/core/test_flow_input_binding.py
@@ -1,0 +1,107 @@
+"""Tests for issue #66 bug A — ``@flow`` must wire parameters to ``${inputs.X}``.
+
+Before the fix, ``@flow`` traced the decorated function with ``None``
+substituted for every parameter, so a pipeline as simple as
+``step.reduce_sum(values=values)`` recorded ``params={"values": None}``
+on the step. The engine then called ``reduce_sum(values=None)`` and
+crashed with ``'NoneType' object is not iterable``.
+
+The fix introduces :class:`~bricks.core.dsl.InputRef` sentinels, threaded
+through the trace so the DAG serialiser emits
+``params={"values": "${inputs.values}"}`` and populates
+``blueprint.inputs`` so the orchestrator's ``InputMapper`` can bind the
+runtime value. This suite guards all three links in that chain plus the
+end-to-end engine run that the issue reporter reproduced.
+"""
+
+from __future__ import annotations
+
+from bricks.core.builtins import register_builtins
+from bricks.core.dsl import flow, for_each, step
+from bricks.core.engine import BlueprintEngine
+from bricks.core.registry import BrickRegistry
+
+
+def _registry_with(name: str, fn: object) -> BrickRegistry:
+    """Build a registry with the given brick plus builtins registered."""
+    from bricks.core.models import BrickMeta
+
+    reg = BrickRegistry()
+    reg.register(name, fn, BrickMeta(name=name, description="test", category="test"))
+    register_builtins(reg)
+    return reg
+
+
+def test_flow_param_rewrites_step_params_to_inputs_reference() -> None:
+    """``@flow def f(values): step.X(values=values)`` must emit
+    ``params={"values": "${inputs.values}"}`` — not a literal None."""
+
+    @flow
+    def my_pipeline(values):  # type: ignore[no-untyped-def]
+        """Sum a list."""
+        return step.reduce_sum(values=values)
+
+    bp = my_pipeline.to_blueprint()
+    assert len(bp.steps) == 1
+    assert bp.steps[0].params == {"values": "${inputs.values}"}
+
+
+def test_flow_populates_blueprint_inputs_schema() -> None:
+    """``blueprint.inputs`` must list every flow parameter so the
+    orchestrator's InputMapper knows which runtime values to bind."""
+
+    @flow
+    def my_pipeline(values):  # type: ignore[no-untyped-def]
+        return step.reduce_sum(values=values)
+
+    bp = my_pipeline.to_blueprint()
+    assert bp.inputs == {"values": "Any"}
+
+
+def test_flow_executes_end_to_end_through_engine() -> None:
+    """Blueprint-layer round-trip: engine.run(bp, inputs={"values": [...]})
+    resolves ``${inputs.values}`` and reaches the brick with the real list.
+    This is the exact scenario the issue reporter's $2.04 repro hit."""
+
+    captured: dict[str, object] = {}
+
+    def reduce_sum(values: list[float]) -> dict[str, float]:
+        captured["values"] = values
+        return {"result": float(sum(values))}
+
+    @flow
+    def sum_pipeline(values):  # type: ignore[no-untyped-def]
+        return step.reduce_sum(values=values)
+
+    bp = sum_pipeline.to_blueprint()
+    reg = _registry_with("reduce_sum", reduce_sum)
+    engine = BlueprintEngine(registry=reg)
+    result = engine.run(bp, inputs={"values": [1.0, 2.0, 3.0]})
+
+    assert captured["values"] == [1.0, 2.0, 3.0], "brick received literal None pre-fix"
+    assert result.outputs == {"result": 6.0}
+
+
+def test_flow_for_each_items_binds_to_input_list() -> None:
+    """Regression for the other shape from issue #66:
+    ``@flow def f(records): for_each(items=records, ...)`` must bind
+    the iteration list to the runtime input, not to an empty ``[]``."""
+
+    def echo(item: int) -> dict[str, int]:
+        return {"result": item * 2}
+
+    @flow
+    def double_each(records):  # type: ignore[no-untyped-def]
+        return for_each(items=records, do=lambda r: step.echo(item=r))
+
+    bp = double_each.to_blueprint()
+    assert bp.inputs == {"records": "Any"}
+    # The for_each step's items slot must reference the runtime input —
+    # not the empty-list fallback that used to be the silent failure mode.
+    for_each_step = next(s for s in bp.steps if s.brick == "__for_each__")
+    assert for_each_step.params["items"] == "${inputs.records}"
+
+    reg = _registry_with("echo", echo)
+    engine = BlueprintEngine(registry=reg)
+    result = engine.run(bp, inputs={"records": [1, 2, 3]})
+    assert result.outputs["result"] == [{"result": 2}, {"result": 4}, {"result": 6}]

--- a/tests/test_default_registry_includes_builtins.py
+++ b/tests/test_default_registry_includes_builtins.py
@@ -1,0 +1,71 @@
+"""Tests for issue #66 bug B — public ``Bricks`` default registry must ship builtins.
+
+``Bricks.default()`` → ``_build_default_registry()`` previously called
+``discover_and_load`` for stdlib packs but never registered the DSL
+control-flow builtins (``__for_each__`` / ``__branch__``). Any composed
+blueprint that wrapped iteration crashed on the first ``registry.get``
+lookup. The showcase path worked only because it registered builtins
+manually; the public API didn't.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from bricks.api import Bricks, _build_default_registry
+from bricks.core.engine import BlueprintEngine
+from bricks.core.models import BlueprintDefinition, StepDefinition
+
+
+def test_build_default_registry_includes_control_flow_builtins() -> None:
+    """The registry backing ``Bricks.default()`` must have both DSL
+    builtins so composed blueprints never crash with
+    ``BrickNotFoundError: '__for_each__'``."""
+    reg = _build_default_registry()
+    assert reg.has("__for_each__"), "__for_each__ missing — for_each blueprints would fail"
+    assert reg.has("__branch__"), "__branch__ missing — conditional blueprints would fail"
+
+
+def test_bricks_default_registry_runs_for_each_blueprint() -> None:
+    """End-to-end: a hand-built ``__for_each__`` blueprint must run
+    through the default registry without ``BrickNotFoundError``."""
+
+    def double(item: int) -> dict[str, int]:
+        return {"result": item * 2}
+
+    # Pass an explicit mock provider so Bricks.default() skips the
+    # real LiteLLMProvider construction (which would need an API key).
+    bricks = Bricks.default(provider=MagicMock())
+
+    # Register a test brick into the live registry so __for_each__ can
+    # look it up mid-iteration.
+    from bricks.core.models import BrickMeta
+
+    bricks.registry.register(
+        "double",
+        double,
+        BrickMeta(name="double", description="Double an int", category="test"),
+    )
+
+    bp = BlueprintDefinition(
+        name="map_double",
+        steps=[
+            StepDefinition(
+                name="map",
+                brick="__for_each__",
+                params={
+                    "items": [1, 2, 3],
+                    "do_brick": "double",
+                    "item_kwarg": "item",
+                    "static_kwargs": {},
+                    "on_error": "fail",
+                },
+                save_as="map",
+            ),
+        ],
+        outputs_map={"result": "${map.result}"},
+    )
+
+    engine = BlueprintEngine(registry=bricks.registry)
+    result = engine.run(bp, inputs={})
+    assert result.outputs == {"result": [{"result": 2}, {"result": 4}, {"result": 6}]}


### PR DESCRIPTION
## Summary

Closes #66. Two P0 bugs were blocking every list-input research task through `Bricks.default().execute(...)` — RA's Track-1 runs burned ~$2.04 reproducing them.

- **Bug A** — `@flow` traced with `dict.fromkeys(sig.parameters)` (all `None`), so `step.reduce_sum(values=values)` recorded `params={"values": None}` and the engine crashed on `'NoneType' object is not iterable`. Introduced a frozen `InputRef(name)` sentinel in [src/bricks/core/dsl.py](src/bricks/core/dsl.py), threaded `input_names` through `FlowDefinition` → `to_blueprint()` so step params become `${inputs.X}` references and `blueprint.inputs` is populated for the orchestrator's `InputMapper`. `for_each`'s `items` slot and closed-over `static_kwargs` resolve `InputRef` too via [src/bricks/core/dag.py](src/bricks/core/dag.py).
- **Bug B** — `_build_default_registry()` in [src/bricks/api.py](src/bricks/api.py) called `discover_and_load` but never `register_builtins`, so every composed `for_each`/`branch` blueprint hit `BrickNotFoundError: '__for_each__'`. One-line fix to register both.
- Added 6 new tests: `tests/core/test_flow_input_binding.py` (4 cases — param rewrite, `blueprint.inputs` schema, end-to-end engine run, `for_each(items=input)` binding) and `tests/test_default_registry_includes_builtins.py` (2 cases — builtins present, end-to-end `__for_each__` blueprint via `Bricks.default().registry`).

## Test plan

- [x] `pytest tests/core/test_flow_input_binding.py tests/test_default_registry_includes_builtins.py -v` — 6/6 pass
- [x] `pytest` — full suite 1251 passed, 18 skipped
- [x] `ruff check src tests` + `ruff format --check` — clean
- [x] `mypy src` — no issues in 123 files
- [x] `cog --check README.md` — clean
- [x] Repro from issue: `@flow def f(values): step.reduce_sum(values=values)` → `engine.run(bp, inputs={"values": [1.0, 2.0, 3.0]})` returns `{"result": 6.0}` (end-to-end test guards this)
- [ ] CI matrix green on 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)