### PR TITLE
fix(core): for_each lambda supports item subscript / attr access (closes #69)

### DIFF
--- a/src/bricks/core/builtins.py
+++ b/src/bricks/core/builtins.py
@@ -14,12 +14,44 @@ from bricks.core.models import BrickMeta
 from bricks.core.registry import BrickRegistry
 
 
+def _apply_path(path: list[Any], item: Any) -> Any:
+    """Replay a recorded subscript / getattr chain on a real item.
+
+    The DSL tracer captures ``pat["pattern"]`` etc. as a sequence of
+    ``(op, key)`` pairs (see :class:`bricks.core.dsl._ItemProxy` —
+    issue #69). At runtime ``__for_each__`` calls this helper to
+    reproduce the same access on the actual iteration item.
+
+    Args:
+        path: Ordered list of ``(op, key)`` pairs where ``op`` is
+            ``"getitem"`` or ``"getattr"``. Tuples may arrive as lists
+            after a YAML round-trip — both shapes are accepted.
+        item: The real iteration value to apply *path* to.
+
+    Returns:
+        The value reached after applying every step.
+
+    Raises:
+        ValueError: If *path* contains an unknown operation.
+    """
+    for entry in path:
+        op, key = entry[0], entry[1]
+        if op == "getitem":
+            item = item[key]
+        elif op == "getattr":
+            item = getattr(item, key)
+        else:
+            raise ValueError(f"__for_each__: unknown access op {op!r} in item_paths")
+    return item
+
+
 def _for_each_impl(
     items: list[Any],
     do_brick: str,
     on_error: Literal["fail", "collect"] = "fail",
     item_kwarg: str = "item",
     static_kwargs: dict[str, Any] | None = None,
+    item_paths: dict[str, list[Any]] | None = None,
     registry: BrickRegistry | None = None,
 ) -> dict[str, Any]:
     """Execute a brick for each item in the list.
@@ -31,12 +63,21 @@ def _for_each_impl(
         item_kwarg: Keyword name to pass each item under. Extracted by the
             DSL tracer from the for_each lambda (e.g. ``"email"`` for
             ``for_each(do=lambda e: step.is_email_valid(email=e))``).
+            Empty string means the lambda never bound the bare item to
+            a kwarg (e.g. ``do=lambda p: step.X(value=p["k"])`` — uses
+            only ``item_paths``); in that case the item is not injected.
             Defaults to ``"item"`` for blueprints written without the DSL.
         static_kwargs: Literal keyword arguments the lambda closed over, to
             be passed on every iteration alongside ``item_kwarg`` — e.g.
             ``{"rename_map": {"id": "customer_id"}}`` for
             ``for_each(do=lambda r: step.rename_dict_keys(input=r, rename_map={...}))``.
             The per-item kwarg wins on name conflict.
+        item_paths: Subscript / attribute access chains the DSL tracer
+            captured for kwargs that derive from the iteration item —
+            e.g. ``{"value": [("getitem", "pattern")]}`` for
+            ``for_each(do=lambda p: step.X(value=p["pattern"]))``.
+            Each chain is applied to the real item per iteration. See
+            issue #69.
         registry: Registry to look up ``do_brick``. Required.
 
     Returns:
@@ -53,15 +94,21 @@ def _for_each_impl(
 
     callable_, _ = registry.get(do_brick)
     static: dict[str, Any] = dict(static_kwargs or {})
+    paths: dict[str, list[Any]] = dict(item_paths or {})
     results: list[Any] = []
     errors: list[dict[str, Any]] = []
 
     for i, item in enumerate(items):
         try:
-            # Merge statics first, then overlay the per-item kwarg so it wins
-            # any name conflict (a lambda that closed over a key matching
-            # ``item_kwarg`` would otherwise shadow the iterator).
-            call_kwargs = {**static, item_kwarg: item}
+            # Order: static < path-derived < whole-item kwarg. The
+            # whole-item kwarg wins on name conflict (matches the
+            # docstring); path-derived overrides statics with the same
+            # key (which would itself be unusual). Empty item_kwarg
+            # means the lambda never bound the bare item — skip it.
+            derived = {name: _apply_path(path, item) for name, path in paths.items()}
+            call_kwargs: dict[str, Any] = {**static, **derived}
+            if item_kwarg:
+                call_kwargs[item_kwarg] = item
             result = callable_(**call_kwargs)
         except BrickExecutionError:
             # Already attributed (e.g. nested for_each). Preserve it.

--- a/src/bricks/core/dag.py
+++ b/src/bricks/core/dag.py
@@ -215,6 +215,7 @@ class DAG:
                     "do_brick": do_name,
                     "item_kwarg": node.item_kwarg,
                     "static_kwargs": resolved_statics,
+                    "item_paths": {key: list(path) for key, path in node.item_paths.items()},
                     "on_error": node.on_error,
                 },
                 save_as=step_name,

--- a/src/bricks/core/dsl.py
+++ b/src/bricks/core/dsl.py
@@ -85,6 +85,14 @@ class Node:
             in ``for_each(do=lambda r: step.rename_dict_keys(input=r, rename_map={...}))``.
             Captured by the DSL tracer and merged per-iteration by the
             ``__for_each__`` builtin. Defaults to an empty dict.
+        item_paths: Keyword arguments derived from subscripting or
+            attribute access on the iteration item — e.g.
+            ``{"value": [("getitem", "pattern")]}`` for
+            ``for_each(do=lambda p: step.X(value=p["pattern"]))``.
+            Each entry maps a kwarg name to a sequence of
+            ``(op, key)`` pairs (``"getitem"`` or ``"getattr"``)
+            applied to the real item per iteration by the
+            ``__for_each__`` builtin. Empty by default.
         on_error: Error policy for ``for_each`` — ``"fail"`` (default, stop on
             first error) or ``"collect"`` (continue, gather all errors).
         condition: Condition for ``branch`` nodes (brick name string in v1).
@@ -104,6 +112,7 @@ class Node:
     do: str | Callable[..., Any] | None = None
     item_kwarg: str = "item"
     static_kwargs: dict[str, Any] = field(default_factory=dict)
+    item_paths: dict[str, list[tuple[str, Any]]] = field(default_factory=dict)
     on_error: str = "fail"
 
     # branch fields
@@ -134,6 +143,64 @@ class Node:
         if self.type == "brick":
             return f"Node(brick={self.brick_name!r}, id={self.id!r})"
         return f"Node(type={self.type!r}, id={self.id!r})"
+
+
+class _ItemProxy(Node):
+    """Trace-time stand-in for the for_each iteration item.
+
+    Subclasses :class:`Node` so the existing ``isinstance(value, Node)``
+    kwarg-detection in :func:`for_each` still finds it. Adds
+    ``__getitem__`` / ``__getattr__`` that return new proxies recording
+    an access path. After tracing, the path is read off each kwarg's
+    proxy and stored on the for_each Node so ``__for_each__`` can apply
+    the same path to the real item per iteration at runtime.
+
+    All proxies in a chain share the root ``id`` so the kwarg-scan
+    identity check (``value.id == mock.id``) finds descendants
+    alongside the bare mock.
+    """
+
+    # Class-level annotation so mypy knows the real type — without it,
+    # `__getattr__` shadows the attribute and reads of `_access_path`
+    # are typed as `_ItemProxy`. The runtime value is set via
+    # ``object.__setattr__`` in ``__init__``.
+    _access_path: list[tuple[str, Any]]
+
+    def __init__(self, root_id: str, access_path: list[tuple[str, Any]] | None = None) -> None:
+        """Build a proxy that pretends to be the iteration item.
+
+        Args:
+            root_id: Shared identifier across the proxy chain — equal to
+                the original mock's id, so existing identity comparisons
+                in :func:`for_each` recognise descendants.
+            access_path: Sequence of ``(op, key)`` pairs recording how
+                this proxy was reached from the root. Empty for the
+                root mock; one entry longer per subscript / getattr.
+        """
+        super().__init__(type="brick", brick_name="__mock__", params={})
+        # Bypass the dataclass __setattr__ contract for the shared id —
+        # we want every descendant to compare equal to the root under
+        # the existing identity check.
+        object.__setattr__(self, "id", root_id)
+        object.__setattr__(self, "_access_path", list(access_path or []))
+
+    def __getitem__(self, key: Any) -> _ItemProxy:
+        """Record a subscript access and return an extended proxy."""
+        return _ItemProxy(self.id, [*self._access_path, ("getitem", key)])
+
+    def __getattr__(self, name: str) -> _ItemProxy:
+        """Record an attribute access and return an extended proxy.
+
+        Only fires when normal attribute lookup fails — Node fields
+        (``id``, ``params``, the ``output`` property, etc.) still
+        resolve via the inherited dataclass machinery. Underscore
+        names are skipped so Python internals (``__class__``,
+        ``__deepcopy__``, ``_access_path`` itself) don't accidentally
+        produce proxies.
+        """
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return _ItemProxy(self.id, [*self._access_path, ("getattr", name)])
 
 
 class ExecutionTracer:
@@ -284,7 +351,10 @@ def for_each(
     outer_tracer = _dsl_module._tracer
     _dsl_module._tracer = inner_tracer
     inner_tracer.start()
-    mock = Node(type="brick", brick_name="__mock__", params={})
+    # _ItemProxy lets the lambda subscript / attr-access the item without
+    # raising at trace time — the access path is recorded and replayed
+    # per iteration at runtime. See issue #69.
+    mock = _ItemProxy(root_id=uuid.uuid4().hex[:8])
     trace_error: Exception | None = None
     try:
         do(mock)
@@ -315,15 +385,22 @@ def for_each(
     first = inner_nodes[0]
     do_brick: str = first.brick_name or f"__{first.type}__"
 
-    # Find the kwarg the lambda binds the iteration item to — the key in
-    # the inner node's params whose value is the mock Node we injected.
-    # Default to "item" for backward compatibility when the lambda doesn't
-    # use the item, uses it positionally, or nests it inside an expression.
-    item_kwarg: str = "item"
+    # Find the kwarg(s) the lambda binds to the iteration item.
+    # _ItemProxy values with no access path → bare-item kwarg (item_kwarg).
+    # _ItemProxy values with an access path → derived kwarg, recorded in
+    # item_paths so __for_each__ can apply the same subscript / getattr
+    # chain to the real item per iteration. See issue #69.
+    # item_kwarg starts empty so a path-only lambda doesn't inject a
+    # stray ``item=`` kwarg into the inner brick call at runtime.
+    item_kwarg: str = ""
     static_kwargs: dict[str, Any] = {}
+    item_paths: dict[str, list[tuple[str, Any]]] = {}
     for key, value in first.params.items():
-        if isinstance(value, Node) and value.id == mock.id:
-            item_kwarg = key
+        if isinstance(value, _ItemProxy):
+            if value._access_path:
+                item_paths[key] = value._access_path
+            else:
+                item_kwarg = key
             continue
         # Lambdas that close over *other* step outputs (Node refs) are not
         # supported: the DAG is built once per compose, so there's no way to
@@ -342,6 +419,7 @@ def for_each(
         item_kwarg=item_kwarg,
         on_error=on_error,
         static_kwargs=static_kwargs,
+        item_paths=item_paths,
     )
     _tracer.record(node)
     return node

--- a/tests/core/test_for_each_item_subscript.py
+++ b/tests/core/test_for_each_item_subscript.py
@@ -1,0 +1,197 @@
+"""Tests for issue #69 — ``for_each`` lambdas may subscript / attr-access the item.
+
+Pre-fix the trace-time mock injected as the iteration item was a plain
+:class:`Node`, so the very common composer pattern
+``do=lambda pat: step.X(value=pat["pattern"])`` raised
+``TypeError: 'Node' object is not subscriptable`` *before* reaching the
+inner ``step.X(...)`` call. The tracer recorded zero inner nodes and
+the extractor failed with "could not extract brick name from do=
+callable" — blocking every list-of-dicts task in RA's Track-1
+benchmarks.
+
+The fix introduces :class:`~bricks.core.dsl._ItemProxy`, threads an
+``item_paths`` access-path map through the for_each Node, and teaches
+the runtime ``__for_each__`` builtin to replay the recorded path on
+each real item. This suite locks down the surface end-to-end plus the
+issue's acceptance criteria.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from bricks.core.builtins import register_builtins
+from bricks.core.dsl import FlowDefinition, _ItemProxy, flow, for_each, step
+from bricks.core.engine import BlueprintEngine
+from bricks.core.models import BrickMeta
+from bricks.core.registry import BrickRegistry
+
+
+def _make_registry() -> BrickRegistry:
+    """Build a registry with a few small bricks + the for_each builtin.
+
+    Mirrors :func:`tests.core.test_for_each_static_kwargs._make_registry`
+    so anyone reading both files sees the same shape — but kept local
+    so the suites don't import each other.
+    """
+    reg = BrickRegistry()
+    register_builtins(reg)
+
+    def identity(value: Any) -> dict[str, Any]:
+        return {"result": value}
+
+    reg.register("identity", identity, BrickMeta(name="identity", description="echo"))
+
+    def add(a: int, b: int) -> dict[str, int]:
+        return {"result": a + b}
+
+    reg.register("add", add, BrickMeta(name="add", description="a+b"))
+
+    def filter_dict_list(items: list[dict[str, Any]], key: str, value: Any) -> dict[str, Any]:
+        return {"result": [r for r in items if r.get(key) == value]}
+
+    reg.register(
+        "filter_dict_list",
+        filter_dict_list,
+        BrickMeta(name="filter_dict_list", description="filter by key=value"),
+    )
+
+    return reg
+
+
+def _flow_to_outputs(fn: Any, **inputs: Any) -> dict[str, Any]:
+    """Compile + run a ``@flow`` decorator'd function through the real engine."""
+    flow_def: FlowDefinition = fn  # type: ignore[assignment]
+    engine = BlueprintEngine(registry=_make_registry())
+    return flow_def.execute(inputs=inputs, engine=engine)
+
+
+def _per_item_results(out: dict[str, Any]) -> list[Any]:
+    """Pull the per-iteration result list out of the flow's output dict.
+
+    Single-output flows surface the for_each output as ``{"result": [...]}``
+    where each entry is the inner brick's ``{"result": value}`` dict.
+    """
+    raw = out["result"]
+    items = raw if isinstance(raw, list) else raw["result"]
+    return [r["result"] if isinstance(r, dict) and "result" in r else r for r in items]
+
+
+# --- acceptance criteria from issue #69 -------------------------------------
+
+
+def test_subscript_extracts_and_runs_end_to_end() -> None:
+    """``lambda r: step.identity(value=r["k"])`` — the issue's minimal repro.
+
+    Pre-fix: ValueError from the extractor before reaching the brick.
+    Post-fix: each iteration calls ``identity(value=row["k"])``.
+    """
+
+    @flow
+    def pluck(rows):  # type: ignore[no-untyped-def]
+        return for_each(items=rows, do=lambda r: step.identity(value=r["k"]))
+
+    out = _flow_to_outputs(pluck, rows=[{"k": 1}, {"k": 2}, {"k": 3}])
+    assert _per_item_results(out) == [1, 2, 3]
+
+
+def test_attr_access_extracts_and_runs_end_to_end() -> None:
+    """Acceptance #2 — attribute-style item access works the same way."""
+
+    @flow
+    def pluck_attr(items):  # type: ignore[no-untyped-def]
+        return for_each(items=items, do=lambda r: step.identity(value=r.field))
+
+    items = [SimpleNamespace(field=10), SimpleNamespace(field=20)]
+    out = _flow_to_outputs(pluck_attr, items=items)
+    assert _per_item_results(out) == [10, 20]
+
+
+def test_chained_subscript_runs_end_to_end() -> None:
+    """``r["a"]["b"]`` — nested dicts. Path replay must compose."""
+
+    @flow
+    def deep(rows):  # type: ignore[no-untyped-def]
+        return for_each(items=rows, do=lambda r: step.identity(value=r["a"]["b"]))
+
+    out = _flow_to_outputs(deep, rows=[{"a": {"b": 7}}, {"a": {"b": 11}}])
+    assert _per_item_results(out) == [7, 11]
+
+
+def test_mixed_path_kwargs_run_independently() -> None:
+    """Two derived kwargs from the same item — both paths apply per iteration.
+
+    No whole-item kwarg here; ``item_kwarg`` stays empty so no stray
+    ``item=`` injection clashes with the inner brick signature.
+    """
+
+    @flow
+    def add_pairs(rows):  # type: ignore[no-untyped-def]
+        return for_each(items=rows, do=lambda r: step.add(a=r["k"], b=r["v"]))
+
+    rows = [{"k": 1, "v": 10}, {"k": 2, "v": 20}, {"k": 3, "v": 30}]
+    out = _flow_to_outputs(add_pairs, rows=rows)
+    assert _per_item_results(out) == [11, 22, 33]
+
+
+def test_composer_emitted_shape_regression_69() -> None:
+    """Regression for the bench-runs composer pattern in the issue body.
+
+    ``for_each(items=patterns, do=lambda pat: step.filter_dict_list(items=rows, key="pattern", value=pat["pattern"]))``
+    Items closed over as a literal list because lambdas-referencing-other-
+    nodes is out of scope (issue's non-goals, same as #61). The shape
+    that mattered — ``value=pat["pattern"]`` — is exercised end-to-end.
+    """
+    rows = [
+        {"pattern": "a", "msg": "alpha-1"},
+        {"pattern": "b", "msg": "bravo-1"},
+        {"pattern": "a", "msg": "alpha-2"},
+    ]
+
+    @flow
+    def filter_per_pattern(patterns):  # type: ignore[no-untyped-def]
+        return for_each(
+            items=patterns,
+            do=lambda pat: step.filter_dict_list(items=rows, key="pattern", value=pat["pattern"]),
+        )
+
+    out = _flow_to_outputs(filter_per_pattern, patterns=[{"pattern": "a"}, {"pattern": "b"}])
+    per_item = _per_item_results(out)
+    assert per_item == [
+        [{"pattern": "a", "msg": "alpha-1"}, {"pattern": "a", "msg": "alpha-2"}],
+        [{"pattern": "b", "msg": "bravo-1"}],
+    ]
+
+
+def test_truly_empty_lambda_still_raises_with_60_hints() -> None:
+    """Acceptance #5 — a lambda that genuinely never calls ``step.X(...)``
+    must still raise the issue-#60 ValueError with the lambda source +
+    inner-exception hints. The proxy fix MUST NOT mask diagnostic
+    information for the real "no inner step" failure mode."""
+    with pytest.raises(ValueError) as exc_info:
+        for_each(items=[1, 2, 3], do=lambda _r: None)
+
+    msg = str(exc_info.value)
+    assert "could not extract brick name" in msg
+    assert "lambda _r: None" in msg
+
+
+# --- _ItemProxy unit --------------------------------------------------------
+
+
+def test_item_proxy_records_access_path() -> None:
+    """Wire-shape contract for the proxy: subscripts + getattrs build
+    a ``[(op, key), ...]`` chain in the order they were applied."""
+    p = _ItemProxy(root_id="abc")
+    descendant = p["a"].b["c"]
+    assert descendant._access_path == [
+        ("getitem", "a"),
+        ("getattr", "b"),
+        ("getitem", "c"),
+    ]
+    # Every descendant shares the root id so the existing identity
+    # check (``value.id == mock.id``) recognises them.
+    assert descendant.id == p.id == "abc"


### PR DESCRIPTION
## Summary

Closes #69 — RA's `log-analysis` benchmark at N=200 was a P1 research-blocker post-#66. Composer now emits idiomatic Python like `do=lambda pat: step.filter_dict_list(items=ROWS, key=\"pattern\", value=pat[\"pattern\"])`, but the trace-time mock injected as the iteration item was a plain `Node` — `pat[\"pattern\"]` raised `TypeError: 'Node' object is not subscriptable` *before* reaching the inner `step.X(...)` call. Tracer recorded zero nodes; extractor failed with \"could not extract brick name\". Every list-of-dicts task blocked.

**Fix shape:**

- New private `_ItemProxy(Node)` in [src/bricks/core/dsl.py](src/bricks/core/dsl.py) with `__getitem__` / `__getattr__` that return new proxies recording an access path. Descendants share the root `id` so the existing kwarg-detection identity check still works.
- New `Node.item_paths: dict[str, list[(op, key)]]` field captures per-kwarg access chains. `item_kwarg` now initialises empty so a path-only lambda doesn't inject a stray `item=` kwarg at runtime.
- [src/bricks/core/dag.py](src/bricks/core/dag.py) serialises `item_paths` into the `__for_each__` StepDefinition.
- [src/bricks/core/builtins.py](src/bricks/core/builtins.py) `_for_each_impl` reads `item_paths` and replays each chain against the real item per iteration, alongside `static_kwargs` and `item_kwarg`.

7 new tests in [tests/core/test_for_each_item_subscript.py](tests/core/test_for_each_item_subscript.py) cover all 5 acceptance criteria from the issue end-to-end (subscript, attr, chained subscript, mixed path kwargs, composer-emitted regression shape, #60 hints preserved on truly-empty lambdas) plus a `_ItemProxy` unit test.

## Test plan

- [x] `pytest tests/core/test_for_each_item_subscript.py -v` — 7/7 pass
- [x] Existing for_each suites pass: `test_for_each_static_kwargs.py`, `test_for_each_extractor_error_message.py`, `test_dsl_primitives.py`, `test_dsl.py` — 60/60
- [x] `pytest` — full suite 1278 passed, 18 skipped
- [x] **Mutation check** — disabling `_apply_path` (return raw item) surfaces 5 named failures across the path-replay tests. Reverted.
- [x] `ruff check src tests` + `ruff format --check` — clean
- [x] `mypy src` — no issues in 123 files
- [x] `cog --check README.md` — clean
- [ ] CI matrix green on 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)