### PR TITLE
fix(cli): playground banner uses ASCII so it renders on Windows cp1252

### DIFF
--- a/src/bricks/cli/main.py
+++ b/src/bricks/cli/main.py
@@ -570,7 +570,11 @@ def playground(
             raise typer.Exit(code=1) from exc
 
     url = f"http://{'localhost' if host == '127.0.0.1' else host}:{bound_port}"
-    typer.echo(f"\u2713 Bricks Playground running \u2192 {url}")
+    # Plain ASCII so the banner renders on every platform \u2014 Python's
+    # default Windows console codepage (cp1252) can't encode the
+    # check-mark / arrow glyphs we used to ship and would crash here
+    # before uvicorn even started.
+    typer.echo(f"OK  Bricks Playground running -> {url}")
 
     if not no_browser:
         threading.Timer(0.3, lambda: webbrowser.open(url)).start()


### PR DESCRIPTION
## Summary

`bricks playground` crashed before uvicorn started on Windows with:

```
UnicodeEncodeError: 'charmap' codec can't encode character '✓'
in position 0: character maps to <undefined>
```

The default Windows console codepage is **cp1252**; the check-mark (U+2713) and right-arrow (U+2192) glyphs in the success banner at [src/bricks/cli/main.py:573](src/bricks/cli/main.py#L573) are outside that codepage, so `typer.echo` went straight to the codec layer and aborted. Reproduced on this machine — `bricks playground --no-browser` exited with the traceback above; `PYTHONIOENCODING=utf-8 bricks playground --no-browser` worked.

Fix: swap to ASCII (`OK  ...  ->`) so the banner is portable. The middle-dot (U+00B7) on the next line is cp1252-safe (`\xb7`), left alone.

## Test plan

- [x] `bricks playground --no-browser --port 8081` on Windows: banner prints, server responds 200 on `/`.
- [x] `pytest tests/cli` — 62 passed
- [x] `pytest` — 1278 passed, 18 skipped
- [x] `ruff check src tests` + `ruff format --check` — clean
- [x] `mypy src` — clean
- [x] `cog --check README.md` — clean
- [ ] CI matrix green on 3.10 / 3.11 / 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)