### PR TITLE
fix(playground): CLI run wires through shared provider factory (claude_code/anthropic/openai/ollama)

### DIFF
--- a/src/bricks/cli/main.py
+++ b/src/bricks/cli/main.py
@@ -606,27 +606,42 @@ def _playground_root(
 @playground_app.command("run")
 def playground_run(
     target: str = typer.Argument(..., help="Preset stem (e.g. 'crm_pipeline') or path to a scenario YAML."),
-    compare_raw: bool = typer.Option(
-        False, "--compare-raw", help="Also run the raw-LLM engine for side-by-side comparison."
+    provider: str = typer.Option(
+        "",
+        "--provider",
+        help="LLM provider: claude_code | anthropic | openai | ollama. "
+        "Inferred from the scenario's model alias when empty.",
+    ),
+    model: str = typer.Option(
+        "",
+        "--model",
+        help="Override the scenario's model (e.g. 'gpt-4o-mini'). Empty = use scenario.model.",
     ),
     api_key: str = typer.Option(
         "",
         "--api-key",
-        help="API key for the LLM provider (BYOK). Reads BRICKS_API_KEY / ANTHROPIC_API_KEY env if empty.",
+        help="BYOK key. Resolution: this flag → BRICKS_API_KEY env → "
+        "ANTHROPIC_API_KEY / OPENAI_API_KEY env. Ignored for claude_code / ollama.",
+    ),
+    compare_raw: bool = typer.Option(
+        False, "--compare-raw", help="Also run the raw-LLM engine for side-by-side comparison."
     ),
 ) -> None:
     """Run a playground scenario headlessly and print input data, blueprint, outputs.
 
     Resolves *target* to a YAML path (preset stem under
-    ``bricks/playground/presets/`` or a literal file path), runs the
-    BricksEngine on the bundled data, and (with ``--compare-raw``) the
-    RawLLMEngine alongside it.
+    ``bricks/playground/presets/`` or a literal file path), constructs an
+    LLM provider via :mod:`bricks.playground.provider_factory` (same
+    factory the web UI uses), runs BricksEngine, and — with
+    ``--compare-raw`` — RawLLMEngine alongside it.
     """
-    import os  # noqa: PLC0415
-
     try:
-        from bricks.llm.litellm_provider import LiteLLMProvider  # noqa: PLC0415
         from bricks.playground.engine import BricksEngine, RawLLMEngine  # noqa: PLC0415
+        from bricks.playground.provider_factory import (  # noqa: PLC0415
+            build_provider,
+            infer_provider,
+            resolve_api_key,
+        )
         from bricks.playground.scenario_loader import load_scenario, resolve_preset  # noqa: PLC0415
     except ImportError as exc:
         typer.echo("Error: Playground features require the 'playground' extra.", err=True)
@@ -646,10 +661,22 @@ def playground_run(
     typer.echo(_pretty_truncate(raw_data, max_chars=2000))
     typer.echo("")
 
-    resolved_key = api_key or os.environ.get("BRICKS_API_KEY", "") or os.environ.get("ANTHROPIC_API_KEY", "")
-    provider = LiteLLMProvider(model=scenario.model, api_key=resolved_key)
+    effective_model = model or scenario.model
+    if not provider:
+        try:
+            provider = infer_provider(effective_model)
+        except ValueError as exc:
+            typer.echo(f"Error: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
 
-    bricks_engine = BricksEngine(provider=provider)
+    resolved_key = resolve_api_key(provider, explicit=api_key)
+    try:
+        llm_provider = build_provider(provider=provider, model=effective_model, api_key=resolved_key)
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    bricks_engine = BricksEngine(provider=llm_provider)
     bricks_result = bricks_engine.solve(scenario.task_text, raw_data)
 
     typer.echo("=== COMPOSED BLUEPRINT (bricks) ===")
@@ -664,7 +691,7 @@ def playground_run(
     typer.echo("")
 
     if compare_raw:
-        raw_engine = RawLLMEngine(provider=provider)
+        raw_engine = RawLLMEngine(provider=llm_provider)
         raw_result = raw_engine.solve(scenario.task_text, raw_data)
         typer.echo("=== OUTPUTS (raw_llm) ===")
         if raw_result.error:

--- a/src/bricks/playground/provider_factory.py
+++ b/src/bricks/playground/provider_factory.py
@@ -1,0 +1,165 @@
+"""Shared LLM-provider factory for the playground (web + CLI).
+
+Both the FastAPI web routes and the ``bricks playground run`` CLI need
+to construct an :class:`~bricks.llm.base.LLMProvider` from a
+``(provider, model, api_key)`` triple. They used to diverge — the web
+had its own helper inline in ``web/routes.py`` while the CLI hardcoded
+``LiteLLMProvider`` and broke on every bundled preset (which all
+declare ``model: claudecode``). This module is the single source of
+truth.
+
+Supported providers (matches what the web UI's dropdown exposes):
+
+- ``claude_code`` — uses the local ``claude`` CLI session, no key
+  needed.
+- ``anthropic`` / ``openai`` — direct provider SDKs, BYOK required.
+- ``ollama`` — local Ollama daemon, no key needed.
+"""
+
+from __future__ import annotations
+
+import os
+
+from bricks.llm.base import LLMProvider
+
+#: The four providers the playground knows how to construct. Keep in
+#: sync with :class:`~bricks.playground.web.schemas.RunRequest`'s
+#: ``provider`` Literal so the wire format and the factory don't drift.
+SUPPORTED_PROVIDERS = ("claude_code", "anthropic", "openai", "ollama")
+
+# Providers that don't require BYOK — claude_code uses the local CLI
+# session, ollama hits a local daemon. Centralised so callers can
+# decide whether to prompt for / require an API key without
+# reimplementing the rule.
+_NO_KEY_PROVIDERS = frozenset({"claude_code", "ollama"})
+
+# Per-provider env-var fallbacks for the API key. Resolution order in
+# :func:`resolve_api_key`: explicit arg → ``BRICKS_API_KEY`` (umbrella)
+# → provider-specific. The umbrella var lets a user keep one key set
+# in their shell and switch providers at the CLI without re-exporting.
+_PROVIDER_ENV_KEYS = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+}
+
+
+def infer_provider(model: str) -> str:
+    """Guess the provider name from a model alias.
+
+    Used by the CLI when the user runs ``bricks playground run`` with
+    only the scenario's ``model`` field to go on. The web UI doesn't
+    need this — its dropdown asks for both provider and model
+    explicitly.
+
+    Heuristics, in order:
+
+    - ``"claudecode"`` / ``"claude-code"`` / ``"claude_code"`` →
+      ``claude_code``
+    - ``"ollama/..."`` → ``ollama``
+    - starts with ``"gpt"`` or ``"o1"`` / ``"o3"`` / ``"o4"`` →
+      ``openai``
+    - starts with ``"claude"`` (e.g. ``claude-haiku-4-5``) →
+      ``anthropic``
+
+    Args:
+        model: Model identifier from the scenario YAML or CLI flag.
+
+    Returns:
+        One of :data:`SUPPORTED_PROVIDERS`.
+
+    Raises:
+        ValueError: If *model* doesn't match any known pattern. Caller
+            should ask the user to pass ``--provider`` explicitly.
+    """
+    normalised = model.lower().replace("-", "").replace("_", "")
+    if normalised == "claudecode":
+        return "claude_code"
+    if model.lower().startswith("ollama/"):
+        return "ollama"
+    if model.lower().startswith(("gpt", "o1", "o3", "o4")):
+        return "openai"
+    if model.lower().startswith("claude"):
+        return "anthropic"
+    raise ValueError(
+        f"Cannot infer provider from model {model!r}. "
+        f"Pass --provider explicitly (one of {', '.join(SUPPORTED_PROVIDERS)})."
+    )
+
+
+def resolve_api_key(provider: str, explicit: str = "") -> str:
+    """Pick an API key for *provider* in the agreed precedence order.
+
+    Order: ``explicit`` (CLI flag or web request body) →
+    ``BRICKS_API_KEY`` env (provider-agnostic umbrella) →
+    provider-specific env (``ANTHROPIC_API_KEY`` /
+    ``OPENAI_API_KEY``).
+
+    Args:
+        provider: One of :data:`SUPPORTED_PROVIDERS`.
+        explicit: User-supplied key. Empty string means "fall through
+            to env vars".
+
+    Returns:
+        The resolved key, or ``""`` for providers that don't need one
+        (claude_code, ollama). Returns ``""`` rather than raising when
+        no key is found; the caller decides whether the empty result
+        is a hard error.
+    """
+    if provider in _NO_KEY_PROVIDERS:
+        return ""
+    if explicit:
+        return explicit
+    umbrella = os.environ.get("BRICKS_API_KEY", "")
+    if umbrella:
+        return umbrella
+    env_var = _PROVIDER_ENV_KEYS.get(provider, "")
+    return os.environ.get(env_var, "") if env_var else ""
+
+
+def build_provider(provider: str, model: str, api_key: str = "") -> LLMProvider:
+    """Construct an :class:`~bricks.llm.base.LLMProvider` from a triple.
+
+    Args:
+        provider: One of :data:`SUPPORTED_PROVIDERS`.
+        model: Provider-specific model identifier (e.g.
+            ``claude-haiku-4-5``, ``gpt-4o-mini``, ``ollama/llama3``).
+            For ``claude_code``, an empty string is allowed — the
+            ``claude`` CLI picks its own default.
+        api_key: BYOK key. Required for ``anthropic`` / ``openai``,
+            ignored for ``claude_code`` and ``ollama``.
+
+    Returns:
+        An :class:`LLMProvider` ready for the engine to call.
+
+    Raises:
+        ValueError: If *provider* is unknown OR if BYOK is required but
+            *api_key* is empty. The web layer wraps this in an
+            ``HTTPException(400)`` at the route boundary; the CLI lets
+            it surface as a non-zero exit with the message printed.
+    """
+    if provider == "claude_code":
+        from bricks.providers.claudecode import ClaudeCodeProvider
+
+        return ClaudeCodeProvider(model=model or None)
+
+    if provider == "ollama":
+        from bricks.providers.ollama import OllamaProvider
+
+        return OllamaProvider(model=model)
+
+    if provider in {"anthropic", "openai"} and not api_key:
+        raise ValueError(
+            f"{provider} requires an api_key (--api-key, BRICKS_API_KEY, or {_PROVIDER_ENV_KEYS[provider]})"
+        )
+
+    if provider == "anthropic":
+        from bricks.providers.anthropic import AnthropicProvider
+
+        return AnthropicProvider(model=model, api_key=api_key)
+
+    if provider == "openai":
+        from bricks.providers.openai import OpenAIProvider
+
+        return OpenAIProvider(model=model, api_key=api_key)
+
+    raise ValueError(f"Unknown provider {provider!r}; expected one of {SUPPORTED_PROVIDERS}")

--- a/src/bricks/playground/web/routes.py
+++ b/src/bricks/playground/web/routes.py
@@ -22,6 +22,7 @@ from fastapi.responses import StreamingResponse
 from bricks import __version__ as _bricks_version
 from bricks.core.hooks import hookimpl as _hookimpl
 from bricks.llm.base import LLMProvider
+from bricks.playground.provider_factory import build_provider
 from bricks.playground.scenario_loader import _PRESETS_DIR, resolve_preset
 from bricks.playground.web.schemas import (
     EngineResult,
@@ -40,53 +41,18 @@ _UPLOAD_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
 
 
 def _build_provider(provider: str, model: str, api_key: str | None) -> LLMProvider:
-    """Return an LLMProvider for the given ``provider`` / ``model`` pair.
+    """Thin web wrapper over :func:`bricks.playground.provider_factory.build_provider`.
 
-    All four providers from design.md §7 are implemented here. API keys
-    live only in the request body (BYOK) and are never read from the
-    environment.
-
-    Args:
-        provider: One of ``anthropic`` / ``openai`` / ``claude_code`` / ``ollama``.
-        model: Provider-specific model identifier.
-        api_key: BYOK key (required for anthropic / openai, ignored for
-            ``claude_code`` and ``ollama``).
-
-    Returns:
-        An ``LLMProvider`` instance.
-
-    Raises:
-        HTTPException: 400 if BYOK is required but missing.
+    Translates the shared factory's ``ValueError`` (unknown provider,
+    missing BYOK) into the ``HTTPException(400)`` the route handlers
+    expect. Lives here so the route's signature stays unchanged for
+    existing callers while the actual construction logic is shared
+    with the ``bricks playground run`` CLI.
     """
-    if provider == "claude_code":
-        from bricks.providers.claudecode import ClaudeCodeProvider
-
-        return ClaudeCodeProvider(model=model or None)
-
-    if provider == "ollama":
-        from bricks.providers.ollama import OllamaProvider
-
-        return OllamaProvider(model=model)
-
-    if provider in {"anthropic", "openai"} and not api_key:
-        raise HTTPException(status_code=400, detail=f"{provider} requires an api_key in the request body (BYOK)")
-
-    if provider == "anthropic":
-        from bricks.providers.anthropic import AnthropicProvider
-
-        assert api_key is not None  # narrowed by the BYOK check above
-        return AnthropicProvider(model=model, api_key=api_key)
-
-    if provider == "openai":
-        from bricks.providers.openai import OpenAIProvider
-
-        assert api_key is not None
-        return OpenAIProvider(model=model, api_key=api_key)
-
-    raise HTTPException(
-        status_code=400,
-        detail=f"Unknown provider {provider!r}",
-    )
+    try:
+        return build_provider(provider=provider, model=model, api_key=api_key or "")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 def _load_preset_dict(path: Path) -> dict[str, Any]:

--- a/tests/playground/test_cli_run.py
+++ b/tests/playground/test_cli_run.py
@@ -110,3 +110,93 @@ def test_run_unknown_preset_exits_1_with_helpful_message() -> None:
     # user sees what's available without re-reading docs.
     assert "no_such_preset_42" in r.output
     assert "crm_pipeline" in r.output
+
+
+def test_run_uses_inferred_provider_for_claudecode_preset() -> None:
+    """All bundled presets declare ``model: claudecode`` — the CLI must
+    infer ``claude_code`` (not LiteLLM) so the run actually works."""
+    captured: dict[str, str] = {}
+
+    def fake_build(*, provider: str, model: str, api_key: str) -> object:
+        captured["provider"] = provider
+        captured["model"] = model
+        captured["api_key"] = api_key
+        return SimpleNamespace()
+
+    with (
+        patch("bricks.playground.provider_factory.build_provider", new=fake_build),
+        patch(
+            "bricks.playground.engine.BricksEngine.solve",
+            return_value=_stub_engine_result({"x": 1}),
+        ),
+    ):
+        r = _runner.invoke(app, ["playground", "run", "crm_pipeline"])
+
+    assert r.exit_code == 0, r.output
+    assert captured["provider"] == "claude_code"
+    # API key resolution skips claude_code (no key needed).
+    assert captured["api_key"] == ""
+
+
+def test_run_explicit_provider_flag_overrides_inference() -> None:
+    """``--provider`` wins over the inference rules."""
+    captured: dict[str, str] = {}
+
+    def fake_build(*, provider: str, model: str, api_key: str) -> object:
+        captured["provider"] = provider
+        captured["model"] = model
+        return SimpleNamespace()
+
+    with (
+        patch("bricks.playground.provider_factory.build_provider", new=fake_build),
+        patch(
+            "bricks.playground.engine.BricksEngine.solve",
+            return_value=_stub_engine_result({"x": 1}),
+        ),
+    ):
+        r = _runner.invoke(
+            app,
+            ["playground", "run", "crm_pipeline", "--provider", "anthropic", "--api-key", "k"],
+        )
+
+    assert r.exit_code == 0, r.output
+    assert captured["provider"] == "anthropic"
+
+
+def test_run_model_flag_overrides_scenario_model() -> None:
+    """``--model`` lets the user swap the model without editing the YAML."""
+    captured: dict[str, str] = {}
+
+    def fake_build(*, provider: str, model: str, api_key: str) -> object:
+        captured["model"] = model
+        return SimpleNamespace()
+
+    with (
+        patch("bricks.playground.provider_factory.build_provider", new=fake_build),
+        patch(
+            "bricks.playground.engine.BricksEngine.solve",
+            return_value=_stub_engine_result({"x": 1}),
+        ),
+    ):
+        r = _runner.invoke(
+            app,
+            ["playground", "run", "crm_pipeline", "--model", "gpt-4o-mini", "--api-key", "k"],
+        )
+
+    assert r.exit_code == 0, r.output
+    assert captured["model"] == "gpt-4o-mini"
+
+
+def test_run_anthropic_without_key_exits_1() -> None:
+    """BYOK rule: anthropic without an API key (flag or env) fails fast."""
+    with patch.dict("os.environ", {"BRICKS_API_KEY": "", "ANTHROPIC_API_KEY": ""}, clear=False):
+        # Make sure no umbrella key bleeds in from the host shell.
+        import os
+
+        os.environ.pop("BRICKS_API_KEY", None)
+        os.environ.pop("ANTHROPIC_API_KEY", None)
+        r = _runner.invoke(app, ["playground", "run", "crm_pipeline", "--provider", "anthropic"])
+
+    assert r.exit_code == 1
+    assert "anthropic" in r.output
+    assert "API_KEY" in r.output

--- a/tests/playground/test_provider_factory.py
+++ b/tests/playground/test_provider_factory.py
@@ -1,0 +1,135 @@
+"""Tests for ``bricks.playground.provider_factory``.
+
+The factory is the single source of truth that both the FastAPI web
+routes and the ``bricks playground run`` CLI use to construct an
+``LLMProvider``. Pre-PR the CLI hardcoded ``LiteLLMProvider`` and
+broke on every bundled preset (which all declare ``model: claudecode``).
+This suite locks down inference, key resolution, and construction
+behaviour so the two surfaces can't drift again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bricks.playground.provider_factory import (
+    SUPPORTED_PROVIDERS,
+    build_provider,
+    infer_provider,
+    resolve_api_key,
+)
+
+# ── infer_provider ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("claudecode", "claude_code"),
+        ("claude-code", "claude_code"),
+        ("claude_code", "claude_code"),
+        ("ClaudeCode", "claude_code"),
+        ("ollama/llama3", "ollama"),
+        ("ollama/mistral:7b", "ollama"),
+        ("gpt-4o-mini", "openai"),
+        ("gpt-4", "openai"),
+        ("o1-preview", "openai"),
+        ("o3-mini", "openai"),
+        ("claude-haiku-4-5", "anthropic"),
+        ("claude-sonnet-4-5", "anthropic"),
+        ("claude-opus-4-7", "anthropic"),
+    ],
+)
+def test_infer_provider_recognises_known_aliases(model: str, expected: str) -> None:
+    """Each model alias maps to the right provider so the CLI can pick a
+    provider when the user only supplied the scenario's ``model`` field."""
+    assert infer_provider(model) == expected
+
+
+def test_infer_provider_rejects_unknown_with_helpful_message() -> None:
+    """Unknown aliases produce a ValueError that names the supported set
+    so the user knows which providers exist without re-reading docs."""
+    with pytest.raises(ValueError) as exc_info:
+        infer_provider("gemini/gemini-2.0-flash")
+    msg = str(exc_info.value)
+    assert "gemini/gemini-2.0-flash" in msg
+    assert "--provider" in msg
+    for p in SUPPORTED_PROVIDERS:
+        assert p in msg
+
+
+# ── resolve_api_key ─────────────────────────────────────────────────────────
+
+
+def test_resolve_api_key_returns_empty_for_no_key_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``claude_code`` and ``ollama`` never need an API key, even if env
+    vars are set — the resolver returns "" so the CLI doesn't accidentally
+    pass a stale key into a provider that doesn't want one."""
+    monkeypatch.setenv("BRICKS_API_KEY", "should-be-ignored")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "should-be-ignored")
+    assert resolve_api_key("claude_code", explicit="explicit-key") == ""
+    assert resolve_api_key("ollama") == ""
+
+
+def test_resolve_api_key_explicit_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit ``--api-key`` flag takes precedence over both env vars."""
+    monkeypatch.setenv("BRICKS_API_KEY", "umbrella")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-specific")
+    assert resolve_api_key("anthropic", explicit="explicit") == "explicit"
+
+
+def test_resolve_api_key_umbrella_wins_over_provider_specific(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``BRICKS_API_KEY`` is the provider-agnostic umbrella — it should
+    win over the provider-specific env var so users can keep one key
+    in their shell and switch providers at the CLI."""
+    monkeypatch.setenv("BRICKS_API_KEY", "umbrella")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-specific")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-specific")
+    assert resolve_api_key("anthropic") == "umbrella"
+    assert resolve_api_key("openai") == "umbrella"
+
+
+def test_resolve_api_key_falls_back_to_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without explicit or umbrella, fall through to the provider's own env."""
+    monkeypatch.delenv("BRICKS_API_KEY", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anth-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "oai-key")
+    assert resolve_api_key("anthropic") == "anth-key"
+    assert resolve_api_key("openai") == "oai-key"
+
+
+def test_resolve_api_key_returns_empty_when_nothing_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Caller decides whether the empty result is fatal — resolver doesn't raise."""
+    monkeypatch.delenv("BRICKS_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    assert resolve_api_key("anthropic") == ""
+
+
+# ── build_provider ──────────────────────────────────────────────────────────
+
+
+def test_build_provider_claude_code_needs_no_key() -> None:
+    """``ClaudeCodeProvider`` uses the local CLI session — empty key is fine."""
+    p = build_provider(provider="claude_code", model="", api_key="")
+    assert type(p).__name__ == "ClaudeCodeProvider"
+
+
+def test_build_provider_anthropic_requires_key() -> None:
+    """Without BYOK the factory raises a ValueError naming the env vars
+    so a CLI caller's error message points the user at the right knob."""
+    with pytest.raises(ValueError) as exc_info:
+        build_provider(provider="anthropic", model="claude-haiku-4-5", api_key="")
+    msg = str(exc_info.value)
+    assert "anthropic" in msg
+    assert "ANTHROPIC_API_KEY" in msg
+    assert "BRICKS_API_KEY" in msg
+
+
+def test_build_provider_unknown_raises() -> None:
+    """An unknown provider name fails fast with the supported-set listing."""
+    with pytest.raises(ValueError) as exc_info:
+        build_provider(provider="nope", model="x")
+    msg = str(exc_info.value)
+    assert "nope" in msg
+    for p in SUPPORTED_PROVIDERS:
+        assert p in msg


### PR DESCRIPTION
## Summary

Follow-up to #76: the new \`bricks playground run\` subcommand from PR #79 hardcoded \`LiteLLMProvider\`. All four bundled presets declare \`model: claudecode\` — so every CLI run blew up with \`litellm.BadRequestError: LLM Provider NOT provided. You passed model=claudecode\`.

Fix: promote the web's inline \`_build_provider\` (4 bespoke providers) into a shared \`bricks.playground.provider_factory\` module. Both web routes and the CLI now construct providers through the same function, so adding a new provider later is one edit, not two.

## What changed

**New** [src/bricks/playground/provider_factory.py](src/bricks/playground/provider_factory.py):

- \`build_provider(provider, model, api_key)\` — the web's logic, lifted unchanged. Raises \`ValueError\` instead of \`HTTPException\` so the CLI can format its own messages.
- \`infer_provider(model)\` — CLI helper. \`claudecode\`/\`claude-code\` → \`claude_code\`; \`gpt-*\`/\`o1-*\`/\`o3-*\`/\`o4-*\` → \`openai\`; \`claude-*\` → \`anthropic\`; \`ollama/*\` → \`ollama\`.
- \`resolve_api_key(provider, explicit)\` — precedence: explicit flag → \`BRICKS_API_KEY\` umbrella → provider-specific env (\`ANTHROPIC_API_KEY\` / \`OPENAI_API_KEY\`). Returns \`\"\"\` for \`claude_code\` / \`ollama\` (no key needed).

**[src/bricks/cli/main.py](src/bricks/cli/main.py)** — \`playground run\` gets three new flags and now routes through the shared factory:

\`\`\`
bricks playground run <preset|path>
                       [--provider claude_code|anthropic|openai|ollama]   # override inference
                       [--model <model>]                                  # override scenario.model
                       [--api-key <key>]                                  # override env vars
                       [--compare-raw]
\`\`\`

**[src/bricks/playground/web/routes.py](src/bricks/playground/web/routes.py)** — \`_build_provider\` becomes a 4-line wrapper that catches \`ValueError\` → \`HTTPException(400)\` at the route boundary. **No wire-format change for any web client.**

## Test plan (per AGENTS.md)

- [x] [tests/playground/test_provider_factory.py](tests/playground/test_provider_factory.py) — 22 cases covering inference, key precedence (explicit > umbrella > provider-specific), BYOK enforcement, unknown-provider error.
- [x] [tests/playground/test_cli_run.py](tests/playground/test_cli_run.py) — 4 new cases plus 5 existing: claudecode preset inference (was the broken path), \`--provider\` override, \`--model\` override, anthropic-without-key fast-fails with all three env knobs named.
- [x] Existing web suites unchanged (24 passing): same factory now backs both surfaces.
- [x] \`pytest\` — 1207 passed, 18 skipped.
- [x] \`ruff check . && ruff format --check .\` — clean.
- [x] \`mypy src/bricks\` — clean (87 files).
- [x] \`cog --check README.md\` — clean.
- [x] **Live smoke** — \`bricks playground run custom_example\` correctly constructs \`ClaudeCodeProvider\` (was \`LiteLLMProvider\`) and dispatches to \`claude -p\`. \`bricks playground run … --provider anthropic\` without a key fails fast with the expected BYOK message.
- [ ] CI matrix green on 3.10 / 3.11 / 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)